### PR TITLE
use labels.Selector type instead of just string

### DIFF
--- a/config/crds/chaos_v1beta1_dependencyfailureinjection.yaml
+++ b/config/crds/chaos_v1beta1_dependencyfailureinjection.yaml
@@ -48,11 +48,11 @@ spec:
               - probability
               - protocol
               type: object
-            labelSelector:
-              type: string
+            selector:
+              type: object
           required:
           - failure
-          - labelSelector
+          - selector
           type: object
         status:
           properties:

--- a/config/samples/chaos_v1beta1_dependencyfailureinjection.yaml
+++ b/config/samples/chaos_v1beta1_dependencyfailureinjection.yaml
@@ -11,4 +11,5 @@ spec:
     port: 80
     probability: 50
     protocol: tcp
-  labelSelector: "app=chaos-fi-demo-curl"
+  selector:
+    app: chaos-fi-demo-curl

--- a/pkg/apis/chaos/v1beta1/dependencyfailureinjection_types.go
+++ b/pkg/apis/chaos/v1beta1/dependencyfailureinjection_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -27,8 +28,8 @@ import (
 type DependencyFailureInjectionSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	Failure       DependencyFailureInjectionSpecFailure `json:"failure"`
-	LabelSelector string                                `json:"labelSelector"`
+	Failure  DependencyFailureInjectionSpecFailure `json:"failure"`
+	Selector labels.Set                            `json:"selector"`
 }
 
 // DependencyFailureInjectionSpecFailure defines the failure spec

--- a/pkg/apis/chaos/v1beta1/dependencyfailureinjection_types_test.go
+++ b/pkg/apis/chaos/v1beta1/dependencyfailureinjection_types_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -34,7 +35,13 @@ func TestStorageDependencyFailureInjection(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "default",
-		}}
+		},
+		Spec: DependencyFailureInjectionSpec{
+			Selector: labels.Set{
+				"foo": "bar",
+			},
+		},
+	}
 	g := gomega.NewGomegaWithT(t)
 
 	// Test Create

--- a/pkg/apis/chaos/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/chaos/v1beta1/zz_generated.deepcopy.go
@@ -20,6 +20,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	labels "k8s.io/apimachinery/pkg/labels"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -28,7 +29,7 @@ func (in *DependencyFailureInjection) DeepCopyInto(out *DependencyFailureInjecti
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	out.Status = in.Status
 	return
 }
@@ -88,6 +89,13 @@ func (in *DependencyFailureInjectionList) DeepCopyObject() runtime.Object {
 func (in *DependencyFailureInjectionSpec) DeepCopyInto(out *DependencyFailureInjectionSpec) {
 	*out = *in
 	out.Failure = in.Failure
+	if in.Selector != nil {
+		in, out := &in.Selector, &out.Selector
+		*out = make(labels.Set, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controller/dependencyfailureinjection/dependencyfailureinjection_controller.go
+++ b/pkg/controller/dependencyfailureinjection/dependencyfailureinjection_controller.go
@@ -386,15 +386,11 @@ func (r *ReconcileDependencyFailureInjection) cleanFailures(instance *chaosv1bet
 // getMatchingPods returns a PodList containing all pods matching the DependencyFailureInjection's label selector.
 func (r *ReconcileDependencyFailureInjection) getMatchingPods(instance *chaosv1beta1.DependencyFailureInjection) (*corev1.PodList, error) {
 	// Fetch pods from label selector
-	labelSelector := instance.Spec.LabelSelector
-	listOptions := &client.ListOptions{}
-	err := listOptions.SetLabelSelector(labelSelector)
-	if err != nil {
-		return nil, err
-	}
+	labelSelector := instance.Spec.Selector.AsSelector()
+	listOptions := &client.ListOptions{LabelSelector: labelSelector}
 
 	pods := &corev1.PodList{}
-	err = r.Client.List(context.TODO(), listOptions, pods)
+	err := r.Client.List(context.TODO(), listOptions, pods)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/dependencyfailureinjection/dependencyfailureinjection_controller_test.go
+++ b/pkg/controller/dependencyfailureinjection/dependencyfailureinjection_controller_test.go
@@ -89,7 +89,7 @@ func TestReconcile(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: chaosv1beta1.DependencyFailureInjectionSpec{
-			LabelSelector: "foo=bar",
+			Selector: map[string]string{"foo": "bar"},
 			Failure: chaosv1beta1.DependencyFailureInjectionSpecFailure{
 				Host:        "127.0.0.1",
 				Port:        80,


### PR DESCRIPTION
Currently the CRD accepts a `string` as the `LabelSelector`. We want to use a built-in Kubernetes type instead.