### PR TITLE
Improve local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,8 @@ Remember to update the chart with any updates to the CRDs or RBAC rules.
 
 If you want to test the controller locally (without having to redeploy a new image on a staging cluster), please use the [minikube project](https://kubernetes.io/docs/setup/learning-environment/minikube/) as described below:
 
-* start minikube
-* ensure your docker client is configured to use the minikube docker daemon
-  * `eval $(minikube docker-env)`
+* start minikube with containerd engine
+  * `make minikube-start`
 * build the new image of the controller with your local changes
   * `make docker-build`
 * deploy the controller on the minikube cluster

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
 - rbac/rbac_role.yaml
 - rbac/rbac_role_binding.yaml
 - manager/manager.yaml
+- preset/preset.yaml
   # Comment the following 3 lines if you want to disable
   # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
   # which protects your /metrics endpoint.

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -45,7 +45,7 @@ spec:
       - command:
         - /manager
         image: controller:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Never
         name: manager
         env:
           - name: POD_NAMESPACE
@@ -54,10 +54,8 @@ spec:
                 fieldPath: metadata.namespace
           - name: SECRET_NAME
             value: $(WEBHOOK_SECRET_NAME)
-          - name: STATSD_URL
-            value: unix:///dev/null
           - name: CHAOS_FI_IMAGE
-            value: chaos-fi:latest
+            value: docker.io/library/chaos-fi:latest
         resources:
           limits:
             cpu: 100m

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: chaos-fi-controller:latest
+      - image: docker.io/library/chaos-fi-controller:latest
         name: manager

--- a/config/default/manager_image_patch.yaml-e
+++ b/config/default/manager_image_patch.yaml-e
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: chaos-fi-controller:latest
+      - image: docker.io/library/chaos-fi-controller:latest
         name: manager

--- a/config/default/preset/preset.yaml
+++ b/config/default/preset/preset.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: settings.k8s.io/v1alpha1
+kind: PodPreset
+metadata:
+  name: statsd
+spec:
+  env:
+    - name: STATSD_URL
+      value: "unix:///dev/null"

--- a/config/samples/chaos_v1beta1_networkfailureinjection.yaml
+++ b/config/samples/chaos_v1beta1_networkfailureinjection.yaml
@@ -4,13 +4,12 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: networkfailureinjection-sample
-  namespace: sre
 spec:
   failure:
-    host: chaos-fi-demo.sre.svc.barbet.cluster.local
+    host: 10.0.0.0/8
     port: 80
-    probability: 50
+    probability: 100
     protocol: tcp
   selector:
-    app: chaos-fi-demo-curl
-  numPodsToTarget: 2
+    app: demo
+  numPodsToTarget: 1

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+  namespace: default
+  labels:
+    app: demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo
+  template:
+    metadata:
+      labels:
+        app: demo
+    spec:
+      containers:
+      - name: demo
+        image: k8s.gcr.io/pause:3.1

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -34,10 +34,11 @@ func GeneratePod(name string, pod *corev1.Pod, args []string) *corev1.Pod {
 			RestartPolicy: "Never",
 			Containers: []corev1.Container{
 				{
-					Name:    "chaos-fi-inject",
-					Image:   os.Getenv(ChaosFailureInjectionImageVariableName),
-					Command: []string{"chaos-fi"},
-					Args:    args,
+					Name:            "chaos-fi-inject",
+					Image:           os.Getenv(ChaosFailureInjectionImageVariableName),
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"chaos-fi"},
+					Args:            args,
 					VolumeMounts: []corev1.VolumeMount{
 						corev1.VolumeMount{
 							MountPath: "/run/containerd",


### PR DESCRIPTION
By adding a set of commands in the `Makefile` such as:

* `minikube-start` to start the minikube cluster with the right parameters
* `docker-build` to build the docker image in the minikube docker daemon + load them in containerd

It also adds a pod preset for every pod to have the `STATSD_URL` environment variable (as done on our clusters) so the controller and the chaos-fi can run.