### PR TITLE
Makes host optional in CRD definition

### DIFF
--- a/config/crds/chaos_v1beta1_networkfailureinjection.yaml
+++ b/config/crds/chaos_v1beta1_networkfailureinjection.yaml
@@ -43,7 +43,6 @@ spec:
                 protocol:
                   type: string
               required:
-              - host
               - port
               - probability
               - protocol

--- a/pkg/apis/chaos/v1beta1/networkfailureinjection_types.go
+++ b/pkg/apis/chaos/v1beta1/networkfailureinjection_types.go
@@ -36,7 +36,7 @@ type NetworkFailureInjectionSpec struct {
 
 // NetworkFailureInjectionSpecFailure defines the failure spec
 type NetworkFailureInjectionSpecFailure struct {
-	Host        string `json:"host"`
+	Host        string `json:"host,omitempty"`
 	Port        int    `json:"port"`
 	Probability int    `json:"probability"`
 	Protocol    string `json:"protocol"`


### PR DESCRIPTION
In reference to this pull request:
https://github.com/DataDog/chaos-fi/pull/16