### PR TITLE
Have pods use local DNSConfig

### DIFF
--- a/pkg/controller/networkfailureinjection/networkfailureinjection_controller.go
+++ b/pkg/controller/networkfailureinjection/networkfailureinjection_controller.go
@@ -214,14 +214,6 @@ func (r *ReconcileNetworkFailureInjection) Reconcile(request reconcile.Request) 
 
 		nodeName := p.Spec.NodeName
 
-		//If Node Local DNS is configured on this pod, use this instead of specified Host in NFI
-		if p.Spec.DNSConfig != nil && len(p.Spec.DNSConfig.Nameservers) >= 1{
-			//Use the first nameserver
-			//TODO?: Test nameservers to check which one to use?
-			instance.Spec.Failure.Host = p.Spec.DNSConfig.Nameservers[0]
-		}
-
-
 		// Define the desired pod object
 		pod := helpers.GeneratePod(
 			instance.Name+"-inject-"+p.Name+"-pod",


### PR DESCRIPTION
The following changes have two effects:

1. Each `networkfailure` injection pod has been give the `"datadoghq.com/local-dns-cache":"true"` annotation. This will have a controller inject `dnsConfig` information when these pods start up.

2. If the injection pod exists it implies that a `dnsConfig` is attached to it which means we can use the `nameservers` in this `dnsConfig` to resolve the host of the pod we are attacking.

Reference Card: https://datadoghq.atlassian.net/browse/SRE-210