### PR TITLE
add 'out' dir to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .git/
 vendor/
 minikube/
+out/


### PR DESCRIPTION
Add the output dir for exporting container images to the dockerignore file.