### PR TITLE
Use a public minikube iso file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ templates:
       KUBEBUILDER_VERSION: 1.0.8
       KUBEBUILDER_ARCH: amd64
       GOLANGCI_LINT_VERSION: 1.23.1
-      GIT_LFS_SKIP_SMUDGE: 1
   # runs the standard python image
   python_job_template: &python_job_template
     <<: *working_directory

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.iso filter=lfs diff=lfs merge=lfs -text

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,6 @@
 ---
 variables:
   CURRENT_CI_IMAGE: 0.2.0
-  GIT_LFS_SKIP_SMUDGE: "1"
 
 stages:
   - ci-image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+* Make minikube ISO image public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,6 @@ Install the [required](docs/testing.md#requirements) requirements for this proje
 
 If you want to test the controller locally (without having to redeploy a new image on a staging cluster), please use the [minikube project](https://kubernetes.io/docs/setup/learning-environment/minikube/) as described below:
 
-* get minukube iso stored on git-lfs
-  * `git lfs pull`
 * start minikube with containerd engine
   * `make minikube-start`
 * build the new image of the controller with your local changes

--- a/Makefile
+++ b/Makefile
@@ -115,5 +115,5 @@ minikube-start:
 		--disk-size=50GB \
 		--extra-config=apiserver.runtime-config=settings.k8s.io/v1alpha1=true \
 		--extra-config=apiserver.enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,PodPreset \
-		--iso-url=file://$(shell pwd)/minikube/iso/minikube.iso
+		--iso-url=https://public-chaos-controller.s3.amazonaws.com/minikube/minikube.iso
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,17 +5,14 @@
 To get started, we need to have the following software installed:
 
 * [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/)
-* [git-lfs](https://github.com/git-lfs/git-lfs/wiki/Installation)
 * [golangci-lint](https://github.com/golangci/golangci-lint)
 
 This project is based on kubebuilder, please make sure the [listed](https://book.kubebuilder.io/quick-start.html#prerequisites) requirements for kubebuilder are installed as well.
 
 ## Developing locally (minikube)
 
-For using the chaos-controller on minikube we need our own custom build minikube. For now this is stored in the repo on `lfs`.
+For using the chaos-controller on minikube we need our own custom build ISO image available on s3.
 
-* Pull the minikube iso stored on git-lfs:
-  * `git lfs pull`
 * Start minikube with **containerd** container runtime:
   * `make minikube-start`
 * Build the controller container images locally (_Docker for_) and copy them to minikube:
@@ -24,7 +21,6 @@ For using the chaos-controller on minikube we need our own custom build minikube
   * `make install && make deploy`
 
 ``` sh
-git lfs pull
 make minikube-start
 make docker-build
 make install && make deploy

--- a/minikube/iso/minikube.iso
+++ b/minikube/iso/minikube.iso
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3bddffe3d0d464c70c01c18ed10615a2e931583cd79a4509bf654bbeaf4d07c6
-size 157515776


### PR DESCRIPTION
### What does this PR do?

We pushed the custom minikube ISO to s3 so it is publicly available and we can easily update it if needed.

### Motivation

Avoid to use LFS as it requires data packs.

### Testing Guidelines

`make minikube-start` should succeed with the new iso.
