### PR TITLE
Check qdisc hasn't been cleared before trying to clear it

### DIFF
--- a/injector/network_latency.go
+++ b/injector/network_latency.go
@@ -261,8 +261,19 @@ func (i networkLatencyInjector) Clean() {
 			i.log.Fatalf("can't retrieve link %s: %w", linkName, err)
 		}
 
-		if err := i.config.TrafficController.ClearQdisc(link.Name()); err != nil {
-			i.log.Fatalf("can't delete the %s link qdisc: %w", link.Name(), err)
+		// ensure qdisc isn't cleared before clearing it to avoid any tc error
+		cleared, err := i.config.TrafficController.IsQdiscCleared(link.Name())
+		if err != nil {
+			i.log.Fatalf("can't ensure the %s link qdisc is cleared or not: %w", link.Name(), err)
+		}
+
+		// clear link qdisc if needed
+		if !cleared {
+			if err := i.config.TrafficController.ClearQdisc(link.Name()); err != nil {
+				i.log.Fatalf("can't delete the %s link qdisc: %w", link.Name(), err)
+			}
+		} else {
+			i.log.Infof("%s link qdisc is already cleared, skipping", link.Name())
 		}
 	}
 

--- a/scripts/exec.sh
+++ b/scripts/exec.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. $(dirname $0)/common
+cmd=${@:2}
+exec_into_pod "$1" "$cmd"


### PR DESCRIPTION
### What does this PR do?

It checks for the qdisc state of the interfaces to clean before cleaning them.

### Motivation

Do not error the cleanup pod if the targeted pod has nothing to be cleaned up.

### Testing Guidelines

* Create a disruption resource with a network latency failure
* Exec into that pod and manually clean the root qdisc
  * `tc qdisc del dev eth0 root`
* Delete the created disruption resource

The cleanup pod shouldn't error and should complete successfully, skipping the targeted pod qdisc cleanup.