### PR TITLE
Allow connection establishment before drop in network failure

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -50,10 +50,11 @@ type DisruptionSpec struct {
 // NetworkFailureSpec represents a network failure injection
 type NetworkFailureSpec struct {
 	// +nullable
-	Hosts       []string `json:"hosts,omitempty"`
-	Port        int      `json:"port"`
-	Probability int      `json:"probability"`
-	Protocol    string   `json:"protocol"`
+	Hosts              []string `json:"hosts,omitempty"`
+	Port               int      `json:"port"`
+	Probability        int      `json:"probability"`
+	Protocol           string   `json:"protocol"`
+	AllowEstablishment bool     `json:"allowEstablishment,omitempty"`
 }
 
 // GenerateArgs generates injection or cleanup pod arguments for the given spec
@@ -80,6 +81,11 @@ func (s *NetworkFailureSpec) GenerateArgs(mode chaostypes.PodMode, uid types.UID
 			"--hosts",
 		}
 		args = append(args, strings.Split(strings.Join(s.Hosts, " --hosts "), " ")...)
+
+		// allow establishment
+		if s.AllowEstablishment {
+			args = append(args, "--allow-establishment")
+		}
 	case chaostypes.PodModeClean:
 		args = []string{
 			"network-failure",

--- a/cli/injector/network_failure_inject.go
+++ b/cli/injector/network_failure_inject.go
@@ -22,6 +22,7 @@ var networkFailureInjectCmd = &cobra.Command{
 		port, _ := cmd.Flags().GetInt("port")
 		protocol, _ := cmd.Flags().GetString("protocol")
 		probability, _ := cmd.Flags().GetInt("probability")
+		allowEstablishment, _ := cmd.Flags().GetBool("allow-establishment")
 
 		// prepare container
 		c, err := container.New(containerID)
@@ -31,10 +32,11 @@ var networkFailureInjectCmd = &cobra.Command{
 
 		// prepare injection object
 		spec := v1beta1.NetworkFailureSpec{
-			Hosts:       hosts,
-			Port:        port,
-			Protocol:    protocol,
-			Probability: probability,
+			Hosts:              hosts,
+			Port:               port,
+			Protocol:           protocol,
+			Probability:        probability,
+			AllowEstablishment: allowEstablishment,
 		}
 		i, err := injector.NewNetworkFailureInjector(uid, spec, c, log, ms)
 		if err != nil {
@@ -49,6 +51,7 @@ func init() {
 	networkFailureInjectCmd.Flags().Int("port", 0, "Port to drop packets from and to")
 	networkFailureInjectCmd.Flags().String("protocol", "", "Protocol to filter packets on (tcp or udp)")
 	networkFailureInjectCmd.Flags().Int("probability", 100, "Percentage of probability to drop packets (100 is a total drop)")
+	networkFailureInjectCmd.Flags().Bool("allow-establishment", false, "If true, the packet drops only occur once the connection is established")
 
 	_ = networkFailureInjectCmd.MarkFlagRequired("port")
 	_ = networkFailureInjectCmd.MarkFlagRequired("protocol")

--- a/config/crd/bases/chaos.datadoghq.com_disruptions.yaml
+++ b/config/crd/bases/chaos.datadoghq.com_disruptions.yaml
@@ -42,6 +42,8 @@ spec:
               description: NetworkFailureSpec represents a network failure injection
               nullable: true
               properties:
+                allowEstablishment:
+                  type: boolean
                 hosts:
                   items:
                     type: string

--- a/config/samples/chaos_v1beta1_disruption.yaml
+++ b/config/samples/chaos_v1beta1_disruption.yaml
@@ -18,6 +18,7 @@ spec:
     probability: 100 # probability to drop packets (between 0 and 100)
     port: 80 # port to drop packets on
     protocol: tcp # protocol to drop packets on (can be tcp or udp)
+    allowEstablishment: true # allow connection to be established before dropping packets (drops established connections packets only)
   networkLatency: # network latency
     delay: 1000 # delay in ms
     hosts: # destination hosts to add latency to

--- a/docs/network_failure.md
+++ b/docs/network_failure.md
@@ -5,3 +5,9 @@ The `networkFailure` field provides an automated way of dropping the connection 
 The injector injects iptables rules in a dedicated iptables chain. The chain is created during the injection and has a unique name formed with the `CHAOS-` prefix and with a part of the `Disruption` Kubernetes resource UUID. All iptables injection are done in the `filter` table and during the `OUTPUT` step.
 
 On cleaning, it removes all the injected rules by clearing the dedicated chain and by removing it.
+
+## Allow establishment
+
+The `allowEstablishment` field allows you to drop established connections packets only. It means you can allow the connection to be established between the pod and the impacted service but then drop packets.
+
+It adds the `-m conntrack --ctstate ESTABLISHED` flags to the injected iptables `DROP` rules.

--- a/injector/network_failure.go
+++ b/injector/network_failure.go
@@ -257,23 +257,22 @@ func (i networkFailureInjector) generateRuleParts(ip string) []string {
 		strconv.Itoa(i.spec.Port),
 	}
 
-	//Add modules (if any) here
-	ruleParts = append(ruleParts, "-m")
-	numModules := 0
-
-	//Probability Module
+	// Probability Module
 	if i.spec.Probability != 0 && i.spec.Probability != 100 {
-		//Probability expected in decimal format
+		// Probability expected in decimal format
 		var prob = float64(i.spec.Probability) / 100.0
-		ruleParts = append(ruleParts,
-			"statistic", "--mode", "random", "--probability", fmt.Sprintf("%.2f", prob),
+		ruleParts = append(
+			ruleParts,
+			"-m", "statistic", "--mode", "random", "--probability", fmt.Sprintf("%.2f", prob),
 		)
-		numModules++
 	}
 
-	//If no modules were defined, remove the tailing -m
-	if numModules == 0 {
-		ruleParts = ruleParts[:len(ruleParts)-1]
+	// Allow establishment
+	if i.spec.AllowEstablishment {
+		ruleParts = append(
+			ruleParts,
+			"-m", "conntrack", "--ctstate", "ESTABLISHED",
+		)
 	}
 
 	ruleParts = append(ruleParts, "-j", "DROP")

--- a/injector/network_failure_test.go
+++ b/injector/network_failure_test.go
@@ -215,6 +215,20 @@ var _ = Describe("Network Failure", func() {
 				})
 			})
 		})
+
+		Context("using allow establishment", func() {
+			BeforeEach(func() {
+				spec.Hosts = []string{"192.168.0.0/24"}
+				spec.AllowEstablishment = true
+			})
+
+			It("should inject a rule dropping established connection only", func() {
+				ipt.AssertCalled(GinkgoT(), "AppendUnique", mock.Anything, mock.Anything, mock.Anything)
+				ipt.AssertCalled(GinkgoT(), "AppendUnique", "filter", "CHAOS-110e8400446655440000", []string{
+					"-p", "tcp", "-d", "192.168.0.0/24", "--dport", "666", "-m", "conntrack", "--ctstate", "ESTABLISHED", "-j", "DROP",
+				})
+			})
+		})
 	})
 
 	Describe("cleaning", func() {


### PR DESCRIPTION
### What does this PR do?

It adds a feature on the network failure disruption to allow a connection to be established before dropping packets.

### Motivation

Cover a use case where we want the connection to be established before dropping.

### Testing Guidelines

* Apply the sample disruption with the `allowEstablishment` field set to `true`.
* List iptables using the `./scripts/list_iptables.sh` script.
  * The injected DROP rules should have the `-m conntrack --ctstate ESTABLISHED` flag set.
