### PR TITLE
Fix manager bin path in deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - command:
-        - /manager
+        - /usr/local/bin/manager
         args:
         - --enable-leader-election
         image: controller:latest


### PR DESCRIPTION
### What does this PR do?

The binary path for the controller was wrong since the build rework.