### PR TITLE
api: Add a maximum value for networkLatency.delay

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -104,6 +104,7 @@ func (s *NetworkFailureSpec) GenerateArgs(mode chaostypes.PodMode, uid types.UID
 
 // NetworkLatencySpec represents a network latency injection
 type NetworkLatencySpec struct {
+	// +kubebuilder:validation:Maximum=59999
 	Delay uint `json:"delay"`
 	// +nullable
 	Hosts []string `json:"hosts,omitempty"`

--- a/config/crd/bases/chaos.datadoghq.com_disruptions.yaml
+++ b/config/crd/bases/chaos.datadoghq.com_disruptions.yaml
@@ -65,6 +65,7 @@ spec:
               nullable: true
               properties:
                 delay:
+                  maximum: 59999
                   type: integer
                 hosts:
                   items:


### PR DESCRIPTION
### What does this PR do?
tc has a maximum latency value of 60000ms (excluded). This adds the corresponding
validation to the api to enforce it at application time, instead of having the command fail later

### Motivation
When using a value of 60000 or more, applying the spec succeeds, but the container applying it errors. Stopping it at the api layer makes the failure more visible

### Testing Guidelines

When trying to apply a config with a delay of 1000000ms:
```
$ kubectl apply -f config/samples/chaos_v1beta1_disruption.yaml
The Disruption "disruption-sample" is invalid: spec.networkLatency.delay: Invalid value: 60000: spec.networkLatency.delay in body should be less than or equal to 60000
```