### PR TITLE
Create a chaos-engineering namespace for local testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ If you want to test the controller locally (without having to redeploy a new ima
 * build the new image of the controller with your local changes
   * `make docker-build`
 * deploy the CRD and the controller on the minikube cluster
+  * `kubectl create ns chaos-engineering`
   * `make install && make deploy`
 
 If the controller is already deployed, you'll have to remove the running pod for changes to be applied.

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ uninstall: manifests
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
 	cd config/manager && kustomize edit set image controller=${MANAGER_IMAGE}
-	kustomize build config/default | kubectl apply -f -
+	kustomize build config/default | kubectl -n chaos-engineering apply -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -4,7 +4,7 @@
 # Copyright 2020 Datadog, Inc.
 
 # Adds namespace to all resources.
-namespace: default
+namespace: chaos-engineering
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/samples/chaos_v1beta1_disruption.yaml
+++ b/config/samples/chaos_v1beta1_disruption.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: disruption-sample
-  namespace: default # disruption resource must be in the same namespace as targeted pods
+  namespace: chaos-engineering # disruption resource must be in the same namespace as targeted pods
 spec:
   selector: # label selector to target pods
     app: demo

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -8,7 +8,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: demo
-  namespace: default
+  namespace: chaos-engineering
   labels:
     app: demo
 spec:


### PR DESCRIPTION
### What does this PR do?

It moves resources in the `config/` folder to a `chaos-engineering` namespace instead of the default one.

### Motivation

Keep things at the right place.

### Additional Notes

You should recreate your local environment once merged (or remove all the resources created in the `default` namespace and re-run the commands in the contributing doc).
