### PR TITLE
Do not exit on metrics sink initialization error in the injector

### DIFF
--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -71,6 +71,8 @@ func initMetricsSink() {
 
 	ms, err = metrics.GetSink(types.SinkDriver(sink), types.SinkAppInjector)
 	if err != nil {
-		log.Fatalw("error while creating metric sink", "error", err)
+		log.Errorw("error while creating metric sink, switching to noop sink", "error", err)
+
+		ms, _ = metrics.GetSink(types.SinkDriverNoop, types.SinkAppInjector)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

It switches from a fatal error to a simple error if the metrics sink initialization fails in the chaos-injector.

### Motivation

Avoid the injector to fail on startup when such an error occurs.