### PR TITLE
Switch injector resources to zero since we have the priority class now

### DIFF
--- a/config/manager/config.yaml
+++ b/config/manager/config.yaml
@@ -76,12 +76,12 @@ data:
             },
             "resources": {
               "limits": {
-                "memory": "100Mi",
-                "cpu": 1
+                "memory": 0,
+                "cpu": 0
               },
               "requests": {
-                "memory": "100Mi",
-                "cpu": 1
+                "memory": 0,
+                "cpu": 0
               }
             }
           }


### PR DESCRIPTION
### What does this PR do?

It switches back injector pods resources request and limit to 0 now that we have the priority class.

### Motivation

By not requesting any resources, we almost ensure that the pod will be scheduled on the targeted node. However, we can't ensure that it won't be evicted since its QoS class will be best effort.

It is an attempt to deal with scheduling issues on low-resources node. If it doesn't work, an adaptative solution should be designed. It would require the controller to allocate resources depending on the disruption type and the targeted node.