### PR TITLE
Allow to filter on ingress traffic

### DIFF
--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -22,6 +22,8 @@ type NetworkDisruptionSpec struct {
 	Port int `json:"port,omitempty"`
 	// +kubebuilder:validation:Enum=tcp;udp
 	Protocol string `json:"protocol,omitempty"`
+	// +kubebuilder:validation:Enum=egress;ingress
+	Flow string `json:"flow,omitempty"`
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100
 	Drop int `json:"drop,omitempty"`
@@ -71,6 +73,11 @@ func (s *NetworkDisruptionSpec) GenerateArgs(mode chaostypes.PodMode, uid types.
 		if len(s.Hosts) > 0 {
 			args = append(args, "--hosts")
 			args = append(args, strings.Split(strings.Join(s.Hosts, " --hosts "), " ")...)
+		}
+
+		// append flow
+		if s.Flow != "" {
+			args = append(args, "--flow", s.Flow)
 		}
 	case chaostypes.PodModeClean:
 		args = []string{

--- a/cli/injector/network_disruption_inject.go
+++ b/cli/injector/network_disruption_inject.go
@@ -21,6 +21,7 @@ var networkDisruptionInjectCmd = &cobra.Command{
 		hosts, _ := cmd.Flags().GetStringSlice("hosts")
 		port, _ := cmd.Flags().GetInt("port")
 		protocol, _ := cmd.Flags().GetString("protocol")
+		flow, _ := cmd.Flags().GetString("flow")
 		drop, _ := cmd.Flags().GetInt("drop")
 		corrupt, _ := cmd.Flags().GetInt("corrupt")
 		delay, _ := cmd.Flags().GetUint("delay")
@@ -42,6 +43,7 @@ var networkDisruptionInjectCmd = &cobra.Command{
 			Hosts:          hosts,
 			Port:           port,
 			Protocol:       protocol,
+			Flow:           flow,
 			Drop:           drop,
 			Corrupt:        corrupt,
 			Delay:          delay,
@@ -55,6 +57,7 @@ var networkDisruptionInjectCmd = &cobra.Command{
 func init() {
 	networkDisruptionInjectCmd.Flags().Int("port", 0, "Port to drop packets from and to")
 	networkDisruptionInjectCmd.Flags().String("protocol", "", "Protocol to filter packets on (tcp or udp)")
+	networkDisruptionInjectCmd.Flags().String("flow", "egress", "Flow direction to filter on (either egress or ingress)")
 	networkDisruptionInjectCmd.Flags().Int("drop", 100, "Percentage to drop packets (100 is a total drop)")
 	networkDisruptionInjectCmd.Flags().Int("corrupt", 100, "Percentage to corrupt packets (100 is a total corruption)")
 	networkDisruptionInjectCmd.Flags().Uint("delay", 0, "Delay to add to the given container in ms")

--- a/config/crd/bases/chaos.datadoghq.com_disruptions.yaml
+++ b/config/crd/bases/chaos.datadoghq.com_disruptions.yaml
@@ -80,6 +80,11 @@ spec:
                   maximum: 100
                   minimum: 0
                   type: integer
+                flow:
+                  enum:
+                  - egress
+                  - ingress
+                  type: string
                 hosts:
                   items:
                     type: string

--- a/config/samples/complete.yaml
+++ b/config/samples/complete.yaml
@@ -19,6 +19,7 @@ spec:
       - 10.0.0.0/8 # destination host
     port: 80 # optional, port to drop packets on
     protocol: tcp # optional, protocol to drop packets on (can be tcp or udp, defaults to both)
+    flow: ingress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
     drop: 10 # optional, probability to drop packets (between 0 and 100)
     corrupt: 5 # optional, probability to corrupt packets (between 0 and 100m)
     delay: 1000 # optional, latency to apply to packets in ms

--- a/config/samples/network_disruption.yaml
+++ b/config/samples/network_disruption.yaml
@@ -17,6 +17,7 @@ spec:
       - 10.0.0.0/8 # destination host
     port: 80 # optional, port to drop packets on
     protocol: tcp # optional, protocol to drop packets on (can be tcp or udp, defaults to both)
+    flow: egress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
     drop: 10 # optional, probability to drop packets (between 0 and 100)
     corrupt: 5 # optional, probability to corrupt packets (between 0 and 100)
     delay: 1000 # optional, latency to apply to packets in ms

--- a/docs/network_disruption.md
+++ b/docs/network_disruption.md
@@ -7,6 +7,33 @@ The `network` field provides an automated way of adding disruptions to the outgo
 * `delay` adds the given delay to the outgoing traffic to simulate a slow network
 * `bandwidthLimit` limits the outgoing traffic bandwidth to simulate a bandwidth struggle
 
+## Traffic flow: egress vs. ingress
+
+The `flow` field allows you to either disrupt outgoing traffic (`egress`) or incoming traffic (`ingress`).
+
+### How is it different?
+
+If you're not sure which one you should use, here is a concrete example to let you know how does it work.
+
+Let's say you have 3 pods:
+* `server`: an nginx pod listening on 80
+* `client1`: a pod hitting nginx on port 80
+* `client2`: another pod hitting nginx on port 80
+
+Now let's explore the different use cases.
+
+#### Case 1: I want to disrupt `client1` without impacting `client2`
+
+In this case, you want to target the `client1` pod only and use the `egress` flow so you target packets going from the `client1` pod to the `server` pod.
+
+#### Case 2: I want to disrupt all clients
+
+In this case, you want to target the `server` pod and use the `ingress` flow so you target all incoming packets from both `client1` and `client2` pods.
+
+#### A note on `ingress` flow implementation and UDP
+
+The current implementation of the `ingress` flow is not a real filter on incoming packets but rather a filter on incoming packets answers (ie. outgoing packets). During a TCP communication, when the client sends a packet to the server, the server answers with an acknowledgement packet to confirm that it received the client's packet. By disrupting this acknowledgement packet, it simulates an ingress disruption. It means that `ingress` flow only works for TCP (or if the server uses UDP to send back an answer to the client).
+
 ## Implementation
 
 To apply those disruptions, the `tc` utility is used and the behavior is different according to the use cases.

--- a/injector/network_config_test.go
+++ b/injector/network_config_test.go
@@ -27,6 +27,7 @@ var _ = Describe("Tc", func() {
 		hosts                                []string
 		port                                 int
 		protocol                             string
+		flow                                 string
 		delay                                time.Duration
 		drop                                 int
 		corrupt                              int
@@ -38,7 +39,7 @@ var _ = Describe("Tc", func() {
 		tc = network.TcMock{}
 		tc.On("AddNetem", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		tc.On("AddPrio", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		tc.On("AddFilter", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		tc.On("AddFilter", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		tc.On("AddOutputLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		tc.On("ClearQdisc", mock.Anything).Return(nil)
 		tcIsQdiscClearedCall = tc.On("IsQdiscCleared", mock.Anything).Return(false, nil)
@@ -70,6 +71,7 @@ var _ = Describe("Tc", func() {
 		hosts = []string{}
 		port = 80
 		protocol = "tcp"
+		flow = "egress"
 		delay = time.Second
 		drop = 5
 		corrupt = 10
@@ -77,7 +79,7 @@ var _ = Describe("Tc", func() {
 	})
 
 	JustBeforeEach(func() {
-		config = NewNetworkDisruptionConfig(log, &tc, &nl, nil, hosts, port, protocol)
+		config = NewNetworkDisruptionConfig(log, &tc, &nl, nil, hosts, port, protocol, flow)
 	})
 
 	Describe("AddNetem", func() {
@@ -124,10 +126,10 @@ var _ = Describe("Tc", func() {
 			})
 
 			It("should add a filter to redirect traffic on delayed band", func() {
-				tc.AssertCalled(GinkgoT(), "AddFilter", "lo", "1:0", mock.Anything, "1.1.1.1/32", port, protocol, "1:4")
-				tc.AssertCalled(GinkgoT(), "AddFilter", "lo", "1:0", mock.Anything, "2.2.2.2/32", port, protocol, "1:4")
-				tc.AssertCalled(GinkgoT(), "AddFilter", "eth0", "1:0", mock.Anything, "1.1.1.1/32", port, protocol, "1:4")
-				tc.AssertCalled(GinkgoT(), "AddFilter", "eth0", "1:0", mock.Anything, "2.2.2.2/32", port, protocol, "1:4")
+				tc.AssertCalled(GinkgoT(), "AddFilter", "lo", "1:0", mock.Anything, "1.1.1.1/32", port, protocol, "1:4", flow)
+				tc.AssertCalled(GinkgoT(), "AddFilter", "lo", "1:0", mock.Anything, "2.2.2.2/32", port, protocol, "1:4", flow)
+				tc.AssertCalled(GinkgoT(), "AddFilter", "eth0", "1:0", mock.Anything, "1.1.1.1/32", port, protocol, "1:4", flow)
+				tc.AssertCalled(GinkgoT(), "AddFilter", "eth0", "1:0", mock.Anything, "2.2.2.2/32", port, protocol, "1:4", flow)
 			})
 
 			It("should add delay to the interfaces parent qdisc", func() {

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -24,7 +24,7 @@ type networkDisruptionInjector struct {
 
 // NewNetworkDisruptionInjector creates a NetworkDisruptionInjector object with default drivers
 func NewNetworkDisruptionInjector(uid string, spec v1beta1.NetworkDisruptionSpec, ctn container.Container, log *zap.SugaredLogger, ms metrics.Sink) Injector {
-	config := NewNetworkDisruptionConfigWithDefaults(log, spec.Hosts, spec.Port, spec.Protocol)
+	config := NewNetworkDisruptionConfigWithDefaults(log, spec.Hosts, spec.Port, spec.Protocol, spec.Flow)
 
 	return NewNetworkDisruptionInjectorWithConfig(uid, spec, ctn, log, ms, config)
 }

--- a/network/tc_mock.go
+++ b/network/tc_mock.go
@@ -32,14 +32,14 @@ func (f *TcMock) AddPrio(iface string, parent string, handle uint32, bands uint3
 }
 
 //nolint:golint
-func (f *TcMock) AddFilter(iface string, parent string, handle uint32, ip *net.IPNet, port int, protocol string, flowid string) error {
+func (f *TcMock) AddFilter(iface string, parent string, handle uint32, ip *net.IPNet, port int, protocol string, flowid string, flow string) error {
 	ips := "nil"
 
 	if ip != nil {
 		ips = ip.String()
 	}
 
-	args := f.Called(iface, parent, handle, ips, port, protocol, flowid)
+	args := f.Called(iface, parent, handle, ips, port, protocol, flowid, flow)
 
 	return args.Error(0)
 }

--- a/network/tc_test.go
+++ b/network/tc_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Tc", func() {
 		port              int
 		protocol          string
 		flowid            string
+		flow              string
 	)
 
 	BeforeEach(func() {
@@ -69,6 +70,7 @@ var _ = Describe("Tc", func() {
 		port = 80
 		protocol = "tcp"
 		flowid = "1:2"
+		flow = "egress"
 	})
 
 	Describe("AddNetem", func() {
@@ -127,11 +129,22 @@ var _ = Describe("Tc", func() {
 
 	Describe("AddFilter", func() {
 		JustBeforeEach(func() {
-			tcRunner.AddFilter(iface, parent, handle, ip, port, protocol, flowid)
+			tcRunner.AddFilter(iface, parent, handle, ip, port, protocol, flowid, flow)
 		})
-		Context("add a filter on local IP and port 80 with flowid 1:4", func() {
+
+		Context("add a filter on local IP and port 80 with flowid 1:4 on egress traffic", func() {
 			It("should execute", func() {
 				tcExecuter.AssertCalled(GinkgoT(), "Run", "filter add dev lo root u32 match ip dst 127.0.0.1/32 match ip dport 80 0xffff match ip protocol 6 0xff flowid 1:2")
+			})
+		})
+
+		Context("add a filter on local IP and port 80 with flowid 1:4 on ingress traffic", func() {
+			BeforeEach(func() {
+				flow = "ingress"
+			})
+
+			It("should execute", func() {
+				tcExecuter.AssertCalled(GinkgoT(), "Run", "filter add dev lo root u32 match ip src 127.0.0.1/32 match ip sport 80 0xffff match ip protocol 6 0xff flowid 1:2")
 			})
 		})
 	})


### PR DESCRIPTION
### What does this PR do?

It adds a way to apply network disruptions on incoming traffic via a new `flow` field in the spec. It also logs executed `tc` commands in injector pods for better understanding when debugging.

### Motivation

Allow users to apply packets loss, latency, etc. on incoming traffic. It can be handful when you want to disrupt from server side (because you don't want to/can't target clients or because the clients are outside of Kubernetes for instance).

### Testing Guidelines

* deploy demo sample
* apply network sample but target nginx pod instead of curl with `flow: ingress`

The curl pod should report timeouts as when disrupting the curl pod.

### Additional Notes

This implementation is a trick to simulate ingress traffic filtering. The way it works doesn't really target incoming traffic but rather answers to incoming traffic (the acknowledgement in a TCP communication). This is why it doesn't work for UDP for instance. Everything is detailed in the documentation.