### PR TITLE
Allow empty string as protocol in network disruption protocol enum list

### DIFF
--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -20,7 +20,7 @@ type NetworkDisruptionSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=65535
 	Port int `json:"port,omitempty"`
-	// +kubebuilder:validation:Enum=tcp;udp
+	// +kubebuilder:validation:Enum=tcp;udp;""
 	Protocol string `json:"protocol,omitempty"`
 	// +kubebuilder:validation:Enum=egress;ingress
 	Flow string `json:"flow,omitempty"`

--- a/config/crd/bases/chaos.datadoghq.com_disruptions.yaml
+++ b/config/crd/bases/chaos.datadoghq.com_disruptions.yaml
@@ -98,6 +98,7 @@ spec:
                   enum:
                   - tcp
                   - udp
+                  - ""
                   type: string
               type: object
             nodeFailure:


### PR DESCRIPTION
### What does this PR do?

It allows to pass an empty string as protocol in the network disruption protocol enum list.

### Motivation

The protocol field is optional. It can take the values `tcp` or `udp`, or be omitted. However, an empty string (which is the default string value in Go) doesn't pass the validation filters while it is catched properly in the code. While the good practice is to not specify the field at all, there are some cases where it can be handy to pass an empty string to say "no protocol". This PR allows this to work.