### PR TITLE
Exclude default route gateway IP on network disruption

### DIFF
--- a/injector/network_config.go
+++ b/injector/network_config.go
@@ -198,14 +198,16 @@ func (c *NetworkDisruptionConfigStruct) ApplyOperations() error {
 					return fmt.Errorf("can't add a filter to interface %s: %w", link.Name(), err)
 				}
 			}
-		} else if c.port != 0 && c.protocol != "" {
-			if err := c.TrafficController.AddFilter(link.Name(), "1:0", 0, nil, c.port, c.protocol, "1:4", c.flow); err != nil {
-				return fmt.Errorf("can't add a filter to interface %s: %w", link.Name(), err)
-			}
 		} else {
-			_, nullIP, _ := net.ParseCIDR("0.0.0.0/0")
-			if err := c.TrafficController.AddFilter(link.Name(), "1:0", 0, nullIP, 0, "", "1:4", c.flow); err != nil {
-				return fmt.Errorf("can't add a filter to interface %s: %w", link.Name(), err)
+			if c.port != 0 && c.protocol != "" {
+				if err := c.TrafficController.AddFilter(link.Name(), "1:0", 0, nil, c.port, c.protocol, "1:4", c.flow); err != nil {
+					return fmt.Errorf("can't add a filter to interface %s: %w", link.Name(), err)
+				}
+			} else {
+				_, nullIP, _ := net.ParseCIDR("0.0.0.0/0")
+				if err := c.TrafficController.AddFilter(link.Name(), "1:0", 0, nullIP, 0, "", "1:4", c.flow); err != nil {
+					return fmt.Errorf("can't add a filter to interface %s: %w", link.Name(), err)
+				}
 			}
 		}
 

--- a/network/netlink.go
+++ b/network/netlink.go
@@ -101,8 +101,9 @@ func (a netlinkAdapter) DefaultRoute() (NetlinkRoute, error) {
 		return nil, err
 	}
 
-	// list routes for all interfaces
-	routes, err := handler.RouteList(nil, netlink.FAMILY_V4)
+	// list routes for all interfaces using IPv4
+	// cf. https://godoc.org/golang.org/x/sys/unix#AF_INET for value 2
+	routes, err := handler.RouteList(nil, 2)
 	if err != nil {
 		return nil, err
 	}

--- a/network/netlink_mock.go
+++ b/network/netlink_mock.go
@@ -44,6 +44,13 @@ func (f *NetlinkAdapterMock) RoutesForIP(ip *net.IPNet) ([]NetlinkRoute, error) 
 	return args.Get(0).([]NetlinkRoute), args.Error(1)
 }
 
+//nolint:golint
+func (f *NetlinkAdapterMock) DefaultRoute() (NetlinkRoute, error) {
+	args := f.Called()
+
+	return args.Get(0).(NetlinkRoute), args.Error(1)
+}
+
 // NetlinkLinkMock is a mock implementation of the NetlinkLink interface
 type NetlinkLinkMock struct {
 	mock.Mock
@@ -80,4 +87,11 @@ func (f *NetlinkRouteMock) Link() NetlinkLink {
 	args := f.Called()
 
 	return args.Get(0).(NetlinkLink)
+}
+
+//nolint:golint
+func (f *NetlinkRouteMock) Gateway() net.IP {
+	args := f.Called()
+
+	return args.Get(0).(net.IP)
 }


### PR DESCRIPTION
### What does this PR do?

It always excludes the default route gateway IP when inserting tc rules. It also excludes the `lo` interface from listed interfaces.

### Motivation

Avoid issues when applying broad network disruptions such as dropping everything. Without this, it would cause issues with the pod not being able to communicate with the node hosting it like failing readiness and liveness probes.

### Testing Guidelines

* create a demo pod with a liveness probe
* apply a network disruption with nothing else than a `drop: 100`

Without this feature, the liveness probe should fail. With it, it should not and you should observe a new filter containing the default route gateway IP in it.