### PR TITLE
Target only interfaces listed in the routing table when no host is specified

### DIFF
--- a/injector/network_config.go
+++ b/injector/network_config.go
@@ -102,7 +102,7 @@ func (c *NetworkDisruptionConfigStruct) getInterfacesByIP(hosts []string) (map[s
 			}
 		}
 	} else {
-		c.Log.Info("no hosts specified, all interfaces (except lo) will be impacted")
+		c.Log.Info("no hosts specified, all interfaces will be impacted")
 
 		// prepare links/IP association by pre-creating links
 		// exclude lo interface
@@ -110,6 +110,7 @@ func (c *NetworkDisruptionConfigStruct) getInterfacesByIP(hosts []string) (map[s
 		if err != nil {
 			c.Log.Fatalf("can't list links: %w", err)
 		}
+
 		for _, link := range links {
 			if link.Name() != "lo" {
 				c.Log.Infof("adding interface %s", link.Name())

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -72,7 +72,7 @@ func (i networkDisruptionInjector) Inject() {
 		}
 	}()
 
-	i.log.Infow("adding network disruptions", "drop", i.spec.Drop, "corrupt", i.spec.Corrupt)
+	i.log.Infow("adding network disruptions", "drop", i.spec.Drop, "corrupt", i.spec.Corrupt, "delay", i.spec.Delay, "bandwidthLimit", i.spec.BandwidthLimit)
 
 	// add netem
 	if i.spec.Delay > 0 || i.spec.Drop > 0 || i.spec.Corrupt > 0 {


### PR DESCRIPTION
### What does this PR do?

It filters interfaces to list only interfaces present in the routing table.

### Motivation

When no host is specified, all interfaces are targeted. When running such a network disruption on a network host pod, it can target a lot of unexpected interfaces such as veth pairs.

### Testing Guidelines

* apply any network disruption without specifying the `hosts` field and on a network host pod

Listing interfaces should be limited to those present in the routing table (`eth0`, `eth1` and `bridge` for minikube, no veth pairs):

```
{"level":"info","ts":1603965985.2704437,"caller":"injector/network_config.go:105","msg":"no hosts specified, all interfaces will be impacted"}
{"level":"info","ts":1603965985.2707894,"caller":"injector/network_config.go:116","msg":"adding interface eth0"}
{"level":"info","ts":1603965985.2708437,"caller":"injector/network_config.go:116","msg":"adding interface bridge"}
{"level":"info","ts":1603965985.2708497,"caller":"injector/network_config.go:116","msg":"adding interface eth1"}
```