### PR TITLE
Use github repos for spdx because it no longer exists in the pip repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,8 +123,8 @@ jobs:
     executor: python
     steps:
       - checkout
-      - python_install_requirements
       - alpine_install_git
+      - python_install_requirements
       - run:
           name: Ensure 3rd-party licenses are up-to-date
           command: inv license-check
@@ -134,6 +134,7 @@ jobs:
     executor: python
     steps:
       - checkout
+      - alpine_install_git
       - python_install_requirements
       - run:
           name: Ensure license header is present

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -8,9 +8,6 @@ RUN curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download
     mv kubebuilder_${version}_linux_${arch} kubebuilder && \
     mv kubebuilder /usr/local/
 
-# git
-RUN apt-get install -y --no-install-recommends git
-
 # golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.23.1
 


### PR DESCRIPTION
### What does this PR do?

Uses the spdx github repos directly to install spdx-lookup instead of using the pip repository (where it no longer exists).

### Motivation

Need this library for license checking.