### PR TITLE
Adding working update to continue on a single injection error

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -701,13 +701,12 @@ func (r *DisruptionReconciler) WatchStuckOnRemoval() {
 // element is the string to be removed from the list
 func remove(element string, slice []string) ([]string, error) {
 	for i, value := range slice {
-
 		if value == element {
 			return append(slice[:i], slice[i+1:]...), nil
 		}
 	}
 
-	return nil, fmt.Errorf("Could not find element in list to remove")
+	return nil, fmt.Errorf("could not find element in list to remove")
 }
 
 // This method returns a scaled value from an IntOrString type. If the IntOrString


### PR DESCRIPTION
### What does this PR do?

When the controller attempts to create an injection pod for a corresponding target pod, currently, if there is an error when trying to create this injection on any of the target pods, the reconciler will return and error out. Which means that if there are target pods that were going to get injection pods after the one target pod that errored, they would not get their injections because of that return error.

This kind of behaviour is not ideal, therefore this PR will continue with the injection pods even if an attempt on a target pod fails. On Failure we log and event everything and continue on. 

An edge case (which has been accounted for in the PR) is the fact that when you try to just continue after a failure of creating an injection pod for a target pod, that target pod is still listed in the Disruption resource. This is a problem because when you try to cleanup the disruptions, it is stuck on that target pod which has no injection pod corresponding to it (because we continued). Therefore it makes sense that if an injection pod is not created for a targeted pod, it should not be present in the Disruption and therefore not be considered in cleanup. This lead me to remove all targeted pods which fail the injection creation step from the disruption resource list of target pods.

### Testing Guidelines

I created two deployments, both with labels demo.
One of the deployments creates a pod with a container named demo2 and the other deployment with a container named demo1.

I then implicitly added some test code in `getContainerID`. Instead of defaulting to the first container, if it cannot find the container, it will throw an error. 

So I create a network latency disruption specifying demo2 (So the pods with container name demo1 should error in the Reconciler and therefore no injection pod should be created for it).

This works as intended, only one injection pod is created, the other is not and logs and events corresponding with the state of things. 

Clean-ups are successful and not StuckOnRemoval after the change regarding removing failed targeted pods from the disruption itself.
