### PR TITLE
Skip target on injection error instead of stopping the reconcile loop

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -45,3 +45,19 @@ const (
 	// DisruptionLevelNode is a disruption injected at the node level
 	DisruptionLevelNode = "node"
 )
+
+var (
+	// DisruptionKindsInject contains all existing disruption kinds that can be injected
+	DisruptionKindsInject = []DisruptionKind{
+		DisruptionKindNetworkDisruption,
+		DisruptionKindNodeFailure,
+		DisruptionKindCPUPressure,
+		DisruptionKindDiskPressure,
+	}
+
+	// DisruptionKindsClean contains all existing disruption kinds that can be cleaned
+	DisruptionKindsClean = []DisruptionKind{
+		DisruptionKindNetworkDisruption,
+		DisruptionKindDiskPressure,
+	}
+)


### PR DESCRIPTION
### What does this PR do?

It skips targets when we fail to inject. Skipped targets are then removed from the disruption status and not cleaned up later (as injection never happened).

### Motivation

Do not stop the reconcile loop when one target fails (preventing other targets to be injected).