### PR TITLE
Ignore already cleaned qdiscs during network disruption cleanup

### DIFF
--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -487,19 +487,9 @@ func (i *networkDisruptionInjector) clearOperations() error {
 			return fmt.Errorf("can't retrieve link %s: %w", linkName, err)
 		}
 
-		// ensure qdisc isn't cleared before clearing it to avoid any tc error
-		cleared, err := i.config.TrafficController.IsQdiscCleared(link.Name())
-		if err != nil {
-			return fmt.Errorf("can't ensure the %s link qdisc is cleared or not: %w", link.Name(), err)
-		}
-
 		// clear link qdisc if needed
-		if !cleared {
-			if err := i.config.TrafficController.ClearQdisc(link.Name()); err != nil {
-				return fmt.Errorf("can't delete the %s link qdisc: %w", link.Name(), err)
-			}
-		} else {
-			i.config.Log.Infof("%s link qdisc is already cleared, skipping", link.Name())
+		if err := i.config.TrafficController.ClearQdisc(link.Name()); err != nil {
+			return fmt.Errorf("can't delete the %s link qdisc: %w", link.Name(), err)
 		}
 	}
 

--- a/injector/network_disruption_test.go
+++ b/injector/network_disruption_test.go
@@ -32,7 +32,6 @@ var _ = Describe("Failure", func() {
 		cgroupManager                                           *cgroup.ManagerMock
 		cgroupManagerExistsCall                                 *mock.Call
 		tc                                                      *network.TcMock
-		tcIsQdiscClearedCall                                    *mock.Call
 		nl                                                      *network.NetlinkAdapterMock
 		nllink1, nllink2, nllink3                               *network.NetlinkLinkMock
 		nllink1TxQlenCall, nllink2TxQlenCall, nllink3TxQlenCall *mock.Call
@@ -60,7 +59,6 @@ var _ = Describe("Failure", func() {
 		tc.On("AddCgroupFilter", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		tc.On("AddOutputLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		tc.On("ClearQdisc", mock.Anything).Return(nil)
-		tcIsQdiscClearedCall = tc.On("IsQdiscCleared", mock.Anything).Return(false, nil)
 
 		// netlink
 		nllink1 = &network.NetlinkLinkMock{}
@@ -276,23 +274,11 @@ var _ = Describe("Failure", func() {
 			netnsManager.AssertCalled(GinkgoT(), "Exit")
 		})
 
-		Context("with a non-cleared qdisc", func() {
+		Context("qdisc cleanup should happen", func() {
 			It("should clear the interfaces qdisc", func() {
 				tc.AssertCalled(GinkgoT(), "ClearQdisc", "lo")
 				tc.AssertCalled(GinkgoT(), "ClearQdisc", "eth0")
 				tc.AssertCalled(GinkgoT(), "ClearQdisc", "eth1")
-			})
-		})
-
-		Context("with an already cleared qdisc", func() {
-			BeforeEach(func() {
-				tcIsQdiscClearedCall.Return(true, nil)
-			})
-
-			It("should not clear the interfaces qdisc", func() {
-				tc.AssertNotCalled(GinkgoT(), "ClearQdisc", "lo")
-				tc.AssertNotCalled(GinkgoT(), "ClearQdisc", "eth0")
-				tc.AssertNotCalled(GinkgoT(), "ClearQdisc", "eth1")
 			})
 		})
 

--- a/network/tc_mock.go
+++ b/network/tc_mock.go
@@ -69,10 +69,3 @@ func (f *TcMock) ClearQdisc(iface string) error {
 
 	return args.Error(0)
 }
-
-//nolint:golint
-func (f *TcMock) IsQdiscCleared(iface string) (bool, error) {
-	args := f.Called(iface)
-
-	return args.Bool(0), args.Error(1)
-}


### PR DESCRIPTION
### What does this PR do?

It does not error when cleaning an already cleaned up qdisc.

### Motivation

Be idempotent during network disruption cleanup to avoid being stuck for something already cleaned up.

### Testing Guidelines

* apply the drop example at node level
* ssh into the node and manually clear the qdisc `tc qdisc del dev <DEV> root`
* delete the disruption

It should not error anymore.

### Additional Notes

I removed the `IsQdiscCleared` function that was not working because the default output for a non-cleared qdisc is not always the same depending on the interface configuration.
