### PR TITLE
CORE-417: Pass --level flag to injector for node_failures

### DIFF
--- a/api/v1beta1/node_failure.go
+++ b/api/v1beta1/node_failure.go
@@ -24,6 +24,8 @@ func (s *NodeFailureSpec) GenerateArgs(mode chaostypes.PodMode, level chaostypes
 			"inject",
 			"--metrics-sink",
 			sink,
+			"--level",
+			string(level),
 		}
 		if s.Shutdown {
 			args = append(args, "--shutdown")


### PR DESCRIPTION
### What does this PR do?

Pass the --level flag to `injector/main.go` when using a `node_failure` disruption

### Motivation

Even though the node_failure disruption takes down an entire node, it still needs to use the specified label selector to target either pods or nodes. Furthermore, `injector/main.go` errors if `--level` isn't passed. So even though `injector/node_failure.go` doesn't read the `--level` flag, we should still just pass it in at `api/v1beta1/node_failure.go`.

### Testing Guidelines

I tested locally with minikube and found that this does fix the problem. @Azoam, ideas on how else we could test this? Neither the controller tests nor `injector/node_failure_test.go` seem capable of catching this bug.

### Additional Notes

The fact that this wasn't tested for the original node level PR makes me worry that node_failure.go wasn't intended to be usable to target nodes? But nothing in that PR or its description imply that, so this fix is likely sufficient.