### PR TITLE
Force node failure disruption level to node instead of pod

### DIFF
--- a/api/v1beta1/node_failure.go
+++ b/api/v1beta1/node_failure.go
@@ -25,7 +25,7 @@ func (s *NodeFailureSpec) GenerateArgs(mode chaostypes.PodMode, level chaostypes
 			"--metrics-sink",
 			sink,
 			"--level",
-			string(level),
+			"node",
 		}
 		if s.Shutdown {
 			args = append(args, "--shutdown")


### PR DESCRIPTION
### What does this PR do?

It forces the node failure disruption to `node` as it does not make sense to inject it at the pod level (it does not even exist). But it keeps the level for the target selection (pod or node).

### Motivation

Fix node failure disruption not working anymore because of the pod level expecting a container ID.