### PR TITLE
Add a label with the disruption name to chaos pods to ease filtering

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -496,6 +496,7 @@ func (r *DisruptionReconciler) generatePod(instance *chaosv1beta1.Disruption, ta
 	pod.ObjectMeta.Namespace = instance.Namespace
 	pod.ObjectMeta.Labels[chaostypes.TargetLabel] = targetName
 	pod.ObjectMeta.Labels[chaostypes.DisruptionKindLabel] = string(kind)
+	pod.ObjectMeta.Labels[chaostypes.DisruptionNameLabel] = instance.Name
 	pod.Spec.NodeName = targetNodeName
 	pod.Spec.Containers[0].Image = image
 	pod.Spec.Containers[0].Args = args

--- a/types/types.go
+++ b/types/types.go
@@ -34,6 +34,9 @@ const (
 	DisruptionLevelPod = "pod"
 	// DisruptionLevelNode is a disruption injected at the node level
 	DisruptionLevelNode = "node"
+
+	// DisruptionNameLabel is the label used to identify the disruption name for a chaos pod
+	DisruptionNameLabel = "chaos.datadoghq.com/disruption"
 )
 
 var (


### PR DESCRIPTION
### What does this PR do?

It adds an extra label `chaos.datadoghq.com/disruption` to the generated chaos pods containing the related disruption name.

### Motivation

Make chaos pods filtering easier when working with `kubectl`.

### Testing Guidelines

* apply any disruption
* list chaos pods using `kubectl -n <NAMESPACE> get pods -l chaos.datadoghq.com/disruption=<DISRUPTION_NAME>`

It should return the disruption associated chaos pods.