### PR TITLE
CORE-450: Add manifests diff check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ jobs:
           command: |
             go mod tidy
             git diff --exit-code
+  # this will fail if changes in packages are checked into git but the updated manifests are not
   manifests:
     executor: golang
     steps:


### PR DESCRIPTION
### What does this PR do?

This PR makes the CI fail if changes in packages related to chaos-controller have been modified and checked into git but the corresponding manifest has not. 

### Motivation

https://datadoghq.atlassian.net/browse/CORE-450

