### PR TITLE
Restore computeHash control flow to 911e426583

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -278,13 +278,15 @@ func (r *DisruptionReconciler) computeHash(instance *chaosv1beta1.Disruption) (b
 
 			return false, nil
 		}
+	} else {
+		// store the computed hash
+		r.Log.Info("storing resource spec hash to detect further changes in spec", "instance", instance.Name, "namespace", instance.Namespace)
+		instance.Status.SpecHash = &specHash
+
+		return true, r.Update(context.Background(), instance)
 	}
 
-	// store the computed hash
-	r.Log.Info("storing resource spec hash to detect further changes in spec", "instance", instance.Name, "namespace", instance.Namespace)
-	instance.Status.SpecHash = &specHash
-
-	return true, r.Update(context.Background(), instance)
+	return true, nil
 }
 
 // cleanDisruption triggers the cleanup of the given instance


### PR DESCRIPTION
### What does this PR do?

Reverts a small portion of https://github.com/DataDog/chaos-controller/pull/217 to restore control flow of the `computeHash` method to how it was at https://github.com/DataDog/chaos-controller/blob/911e426583239878b889bcb3bd3d57205cb035a2/controllers/disruption_controller.go#L161-L166

### Motivation

While testing other code, I noticed that every single disruption I was applying saw this error printed in the controller manager logs:
```
2021-01-13T21:17:42.353Z	ERROR	controller	Reconciler error	{"reconcilerGroup": "chaos.datadoghq.com", "reconcilerKind": "Disruption", "controller": "disruption", "name": "core-414", "namespace": "chaos-engineering", "error": "error computing instance spec hash: Operation cannot be fulfilled on disruptions.chaos.datadoghq.com \"core-414\": the object has been modified; please apply your changes to the latest version and try again"}
github.com/go-logr/zapr.(*zapLogger).Error
	/Users/philip.thompson/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/Users/philip.thompson/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:237
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/Users/philip.thompson/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:209
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/Users/philip.thompson/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:188
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/Users/philip.thompson/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/Users/philip.thompson/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/Users/philip.thompson/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.Until
	/Users/philip.thompson/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90

```

I assumed this must be related to the recent changes to `computeHash` and tried to figure out what was different, as it was mostly a restructuring. I noticed that in the case where `instance.Status.SpecHash != nil && *instance.Status.SpecHash == specHash` that different behavior occurred before and after #217. Specifically, we are now calling `r.Update(context.Background(), instance)`, when we weren't previously. Though I'm not exactly sure why this update is problematic, given the spechash is the same, I can confirm this is what's causing the error.

### Testing Guidelines

Yes, I tested before and after #217 to confirm that was what caused the new ERROR log message. After applying my changes, I can confirm they no longer occur. Then, I applied a disruption, mutated the spec, and re-applied, and found that the appropriate log message and disruption event were logged:
```
2021-01-13T21:33:43.662Z	DEBUG	controller-runtime.manager.events	Warning	{"object": {"kind":"Disruption","namespace":"chaos-engineering","name":"core-414","uid":"965aba4d-24ee-46de-bcf9-a11960a27309","apiVersion":"chaos.datadoghq.com/v1beta1","resourceVersion":"694"}, "reason": "Mutated", "message": "A mutation in the disruption spec has been detected. This resource is immutable and changes have no effect. Please delete and re-create the resource for changes to be effective."}
```

### Additional Notes

Anything else we should know when reviewing?
