### PR TITLE
Ensure DNS resolution response is not nil to avoid a panic

### DIFF
--- a/network/dns.go
+++ b/network/dns.go
@@ -47,7 +47,7 @@ func (c dnsClient) Resolve(host string) ([]net.IP, error) {
 
 			for _, server := range dnsConfig.Servers {
 				response, _, err = dnsClient.Exchange(&dnsMessage, fmt.Sprintf("%s:53", server))
-				if len(response.Answer) > 0 {
+				if response != nil && len(response.Answer) > 0 {
 					return nil
 				}
 			}


### PR DESCRIPTION
### What does this PR do?

It checks that the DNS response is not nil before trying to get its answers. It can be nil if an error occured.

### Motivation

Avoid a panic by accessing a nil pointer.