### PR TITLE
Set request context to controller logger

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -167,7 +167,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	err = (&DisruptionReconciler{
 		Client:      k8sClient,
-		Log:         logger,
+		BaseLog:     logger,
 		Recorder:    k8sManager.GetEventRecorderFor("disruption-controller"),
 		MetricsSink: ms,
 		Scheme:      scheme.Scheme,

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 	// create reconciler
 	r := &controllers.DisruptionReconciler{
 		Client:          mgr.GetClient(),
-		Log:             logger,
+		BaseLog:         logger,
 		Scheme:          mgr.GetScheme(),
 		Recorder:        mgr.GetEventRecorderFor("disruption-controller"),
 		MetricsSink:     ms,


### PR DESCRIPTION
### What does this PR do?

It creates a contextual logger for the instance being reconciled.

### Motivation

Always add the request context (instance name and namespace) to the logger tags, wherever it is called.

### Additional Notes

As added as a note in the code, it works because concurrent reconciling is not enabled in the controller. If we enable this feature at some point, we need to consider having one logger per request being reconciled, each one with its own context.
