### PR TITLE
Rename target_pod tag to target and remove phase tag from metrics

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -329,7 +329,7 @@ func (r *DisruptionReconciler) startInjection(instance *chaosv1beta1.Disruption)
 				// create the pod
 				if err = r.Create(context.Background(), chaosPod); err != nil {
 					r.Recorder.Event(instance, "Warning", "Create failed", fmt.Sprintf("Injection pod for disruption \"%s\" failed to be created", instance.Name))
-					r.handleMetricSinkError(r.MetricsSink.MetricPodsCreated(target, instance.Name, instance.Namespace, "inject", false))
+					r.handleMetricSinkError(r.MetricsSink.MetricPodsCreated(target, instance.Name, instance.Namespace, false))
 
 					return fmt.Errorf("error creating chaos pod: %w", err)
 				}
@@ -344,7 +344,7 @@ func (r *DisruptionReconciler) startInjection(instance *chaosv1beta1.Disruption)
 				// send metrics and events
 				r.Recorder.Event(instance, "Normal", "Created", fmt.Sprintf("Created disruption injection pod for \"%s\"", instance.Name))
 				r.recordEventOnTarget(instance, target, "Warning", "Disrupted", fmt.Sprintf("Pod %s from disruption %s targeted this resourcer for injection", chaosPod.Name, instance.Name))
-				r.handleMetricSinkError(r.MetricsSink.MetricPodsCreated(target, instance.Name, instance.Namespace, "inject", true))
+				r.handleMetricSinkError(r.MetricsSink.MetricPodsCreated(target, instance.Name, instance.Namespace, true))
 			} else {
 				r.log.Infow("an injection pod is already existing for the selected target", "target", target, "chaosPod", chaosPod.Name)
 			}

--- a/metrics/datadog/datadog.go
+++ b/metrics/datadog/datadog.go
@@ -102,9 +102,9 @@ func (d *Sink) MetricInjectDuration(duration time.Duration, tags []string) error
 }
 
 // MetricPodsCreated increment pods.created metric
-func (d *Sink) MetricPodsCreated(targetPod, instanceName, namespace, phase string, succeed bool) error {
+func (d *Sink) MetricPodsCreated(target, instanceName, namespace string, succeed bool) error {
 	status := boolToStatus(succeed)
-	tags := []string{"phase:" + phase, "target_pod:" + targetPod, "name:" + instanceName, "status:" + status, "namespace:" + namespace}
+	tags := []string{"target:" + target, "name:" + instanceName, "status:" + status, "namespace:" + namespace}
 
 	return d.metricWithStatus(metricPrefixController+"pods.created", tags)
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -24,7 +24,7 @@ type Sink interface {
 	MetricCleanupDuration(duration time.Duration, tags []string) error
 	MetricInjectDuration(duration time.Duration, tags []string) error
 	MetricInjected(succeed bool, kind string, tags []string) error
-	MetricPodsCreated(targetPod, instanceName, namespace, phase string, succeed bool) error
+	MetricPodsCreated(target, instanceName, namespace string, succeed bool) error
 	MetricReconcile() error
 	MetricReconcileDuration(duration time.Duration, tags []string) error
 	MetricStuckOnRemoval(tags []string) error

--- a/metrics/noop/noop.go
+++ b/metrics/noop/noop.go
@@ -80,7 +80,7 @@ func (n *Sink) MetricReconcileDuration(duration time.Duration, tags []string) er
 }
 
 // MetricPodsCreated increment pods.created metric
-func (n *Sink) MetricPodsCreated(targetPod, instanceName, namespace, phase string, succeed bool) error {
+func (n *Sink) MetricPodsCreated(target, instanceName, namespace string, succeed bool) error {
 	fmt.Println("NOOP: MetricPodsCreated +1")
 
 	return nil


### PR DESCRIPTION
### What does this PR do?

* It renames the `target_pod` tag to `target` as we don't only target pods now
* It removes the `phase` tag which does not make sense now that we have a single long-running chaos pod instead of a pair of short-living chaos pods