### PR TITLE
Ignore some edge cases failures from the injector on deletion

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -449,8 +449,45 @@ func (r *DisruptionReconciler) cleanDisruption(instance *chaosv1beta1.Disruption
 
 		// terminate running chaos pods to trigger cleanup
 		for _, chaosPod := range chaosPods {
-			// if the chaos pod has succeeded, remove the finalizer so it can be garbage collected
-			if chaosPod.Status.Phase == corev1.PodSucceeded || chaosPod.Status.Phase == corev1.PodPending || ignoreCleanupStatus {
+			removeFinalizer := false
+			deletePod := false
+
+			// check the chaos pod status to determine if we can safely delete it or not
+			switch chaosPod.Status.Phase {
+			case corev1.PodSucceeded, corev1.PodPending:
+				// pod has terminated or is pending
+				// we can remove the pod and the finalizer and it'll be garbage collected
+				removeFinalizer = true
+				deletePod = true
+			case corev1.PodRunning:
+				// pod is still running
+				// we delete it to trigger termination but we keep the finalizer until it has terminated to eventually catch an error during cleanup
+				deletePod = true
+			case corev1.PodFailed:
+				// pod has failed
+				// we need to determine if we can remove it safely or if we need to block disruption deletion
+				// check if a container has been created (if not, the disruption was not injected)
+				if len(chaosPod.Status.ContainerStatuses) == 0 {
+					removeFinalizer = true
+					deletePod = true
+				}
+
+				// check if the container was able to start or not
+				// if not, we can safely delete the pod since the disruption was not injected
+				for _, cs := range chaosPod.Status.ContainerStatuses {
+					if cs.Name == "injector" {
+						if cs.State.Terminated != nil && cs.State.Terminated.Reason == "StartError" {
+							removeFinalizer = true
+							deletePod = true
+						}
+
+						break
+					}
+				}
+			}
+
+			// remove the finalizer if needed or if we should ignore the cleanup status
+			if removeFinalizer || ignoreCleanupStatus {
 				r.log.Infow("chaos pod completed, removing finalizer", "target", target, "chaosPod", chaosPod.Name)
 
 				controllerutil.RemoveFinalizer(&chaosPod, chaosPodFinalizer)
@@ -460,17 +497,20 @@ func (r *DisruptionReconciler) cleanDisruption(instance *chaosv1beta1.Disruption
 				}
 			}
 
-			// if the chaos pod is running or pending, delete it to trigger the termination and the cleanup
-			if chaosPod.Status.Phase == corev1.PodRunning || chaosPod.Status.Phase == corev1.PodPending {
-				r.log.Infow("terminating chaos pod to trigger cleanup", "target", target, "chaosPod", chaosPod.Name)
+			// delete the chaos pod if needed and only if it has not been deleted already
+			if deletePod || ignoreCleanupStatus {
+				if chaosPod.DeletionTimestamp == nil || chaosPod.DeletionTimestamp.Time.IsZero() {
+					r.log.Infow("terminating chaos pod to trigger cleanup", "target", target, "chaosPod", chaosPod.Name)
 
-				if err := r.Client.Delete(context.Background(), &chaosPod); client.IgnoreNotFound(err) != nil {
-					r.log.Errorw("error terminating chaos pod", "error", err, "target", target, "chaosPod", chaosPod.Name)
+					if err := r.Client.Delete(context.Background(), &chaosPod); client.IgnoreNotFound(err) != nil {
+						r.log.Errorw("error terminating chaos pod", "error", err, "target", target, "chaosPod", chaosPod.Name)
+					}
 				}
 			}
 
-			// if the chaos pod has failed, declare the disruption as stuck on removal so it can be investigated
-			if chaosPod.Status.Phase == corev1.PodFailed && !ignoreCleanupStatus {
+			// if the chaos pod finalizer must not be removed and the chaos pod must not be deleted
+			// and the cleanup status must not be ignored, we are stuck and won't be able to remove the disruption
+			if !removeFinalizer && !deletePod && !ignoreCleanupStatus {
 				r.log.Infow("instance seems stuck on removal for this target, please check manually", "target", target, "chaosPod", chaosPod.Name)
 				r.Recorder.Event(instance, "Warning", "StuckOnRemoval", "Instance is stuck on removal because of chaos pods not being able to terminate correctly, please check pods logs before manually removing their finalizer")
 


### PR DESCRIPTION
### What does this PR do?

It escapes some cases where the injector has failed but can be removed safely because it could not inject anything, which happens when:

- no containers could be created (evicted at creation, out of pods error, etc.)
- the injector container has been created but could not start (`StartError` error)

### Motivation

Do not stuck the disruption deletion for cases we could ignore safely.

### Testing Guidelines

It is hard to test all cases as they happen in very specific conditions. Best bet is to try to feature on a big cluster with multiple thousands of nodes to have a chance to catch such cases.