### PR TITLE
Updating artifact metadata script to match spec

### DIFF
--- a/ci/supplement_docker_headers.sh
+++ b/ci/supplement_docker_headers.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
+# https://datadoghq.atlassian.net/wiki/spaces/EEE/pages/890437939/OCI+Artifact+Publishing
 
 DOCKER_CONFIG_DIR="${HOME}/.docker";
 DOCKER_CONFIG="${DOCKER_CONFIG_DIR}/config.json";
-JQ_QUERY=".HttpHeaders[\"X-Meta-OCI-CI-commit_ref\"] = \"${CI_COMMIT_SHA}\" | .HttpHeaders[\"X-Meta-OCI-CI-branch\"] = \"${CI_COMMIT_BRANCH}\" | .HttpHeaders[\"X-Meta-OCI-CI-pipeline_id\"] = \"${CI_PIPELINE_ID}\""
+JQ_QUERY=".HttpHeaders[\"X-Meta-GIT_REPOSITORY\"] = \"${CI_PROJECT_NAME}\" | .HttpHeaders[\"X-Meta-GIT_COMMIT_SHA\"] = \"${CI_COMMIT_SHA}\" | .HttpHeaders[\"X-Meta-GIT_COMMIT_BRANCH\"] = \"${CI_COMMIT_BRANCH}\" | .HttpHeaders[\"X-Meta-GITLAB_CI_PIPELINE_ID\"] = \"${CI_PIPELINE_ID}\""
 
 if [ -e ${DOCKER_CONFIG} ]; then
     TMP_CONFIG=$(mktemp);


### PR DESCRIPTION
We've recently updated the artifact metadata spec, we're adjusting this script to match. To send additional metadata to the registry take a look at the alternative methods of publishing artifact metadata.

 https://datadoghq.atlassian.net/wiki/spaces/EEE/pages/890437939/OCI+Artifact+Publishing