### PR TITLE
CORE-582: Resolve kubernetes.default before disrupting

### DIFF
--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -268,6 +268,10 @@ func (i *networkDisruptionInjector) applyOperations() error {
 		return fmt.Errorf("error resolving apiservers service IP: %w", err)
 	}
 
+	if len(apiservers) == 0 {
+		return fmt.Errorf("could not resolve kubernetes.default service IP")
+	}
+
 	// interfaces for which we need to clean qlen once injection is finished
 	clearTxQlen := []network.NetlinkLink{}
 
@@ -405,10 +409,6 @@ func (i *networkDisruptionInjector) applyOperations() error {
 			if err := i.config.TrafficController.AddFilter(defaultRoute.Link().Name(), "1:0", 0, nil, nil, 0, 0, "arp", "1:1"); err != nil {
 				return fmt.Errorf("error adding filter allowing cloud providers health checks (ARP packets): %w", err)
 			}
-		}
-
-		if len(apiservers) == 0 {
-			return fmt.Errorf("could not resolve kubernetes.default service IP")
 		}
 
 		// allow all communications to this (eventually these) IP


### PR DESCRIPTION
### What does this PR do?

Moves the resolution of `kubernetes.default` to the beginning of `applyOperations`

### Motivation

We were errorring when resolving `kubernetes.default` after disrupting DNS.

### Testing Guidelines

I have confirmed that pod and node level disruptions still work locally on minikube.

### Additional Notes

I am aware that I moved this code out of an `if level == node` block. However, if I put it back into a block, there are scope issues that prevent compilation. Even
```
var apiservers;
if level == node {
   apiservers = getInterfaces()
}
```
wont work, because the compiler will complain that `apiservers` is not used. I've confirmed that pods should and do know of `kubernetes.default`, so resolving this on pods as well should be fine?


```
{"level":"info","ts":1614716654482.3157,"caller":"injector/main.go:200","message":"injecting the disruption"}
{"level":"info","ts":1614716654482.3706,"caller":"injector/network_disruption.go:72","message":"adding network disruptions","drop":100,"duplicate":0,"corrupt":0,"delay":0,"delayJitter":0,"bandwidthLimit":0}
{"level":"info","ts":1614716654485.671,"caller":"injector/network_disruption.go:234","message":"detected default gateway IP 10.128.240.1 on interface ens5"}
{"level":"info","ts":1614716654485.7036,"caller":"injector/network_disruption.go:242","message":"target pod node IP is 10.128.243.108"}
{"level":"info","ts":1614716654485.7754,"caller":"injector/network_disruption.go:151","message":"auto-detecting used interfaces to reach the given hosts","hosts":["10.142.193.71","10.143.28.220","10.143.155.106","10.143.72.195","10.143.0.71","10.142.200.210","10.143.194.65","10.142.197.57","10.143.97.238","10.143.29.156","10.143.249.248","10.142.187.208"]}
{"level":"info","ts":1614716654485.8442,"caller":"injector/network_disruption.go:171","message":"IP 10.142.193.71/32 belongs to interface ens5"}
{"level":"info","ts":1614716654485.9043,"caller":"injector/network_disruption.go:171","message":"IP 10.143.28.220/32 belongs to interface ens5"}
{"level":"info","ts":1614716654485.9587,"caller":"injector/network_disruption.go:171","message":"IP 10.143.155.106/32 belongs to interface ens5"}
{"level":"info","ts":1614716654486.016,"caller":"injector/network_disruption.go:171","message":"IP 10.143.72.195/32 belongs to interface ens5"}
{"level":"info","ts":1614716654486.0667,"caller":"injector/network_disruption.go:171","message":"IP 10.143.0.71/32 belongs to interface ens5"}
{"level":"info","ts":1614716654486.1184,"caller":"injector/network_disruption.go:171","message":"IP 10.142.200.210/32 belongs to interface ens5"}
{"level":"info","ts":1614716654486.1667,"caller":"injector/network_disruption.go:171","message":"IP 10.143.194.65/32 belongs to interface ens5"}
{"level":"info","ts":1614716654486.2317,"caller":"injector/network_disruption.go:171","message":"IP 10.142.197.57/32 belongs to interface ens5"}
{"level":"info","ts":1614716654486.283,"caller":"injector/network_disruption.go:171","message":"IP 10.143.97.238/32 belongs to interface ens5"}
{"level":"info","ts":1614716654486.3398,"caller":"injector/network_disruption.go:171","message":"IP 10.143.29.156/32 belongs to interface ens5"}
{"level":"info","ts":1614716654486.3958,"caller":"injector/network_disruption.go:171","message":"IP 10.143.249.248/32 belongs to interface ens5"}
{"level":"info","ts":1614716654486.4578,"caller":"injector/network_disruption.go:171","message":"IP 10.142.187.208/32 belongs to interface ens5"}
{"level":"info","ts":1614716654486.4768,"caller":"injector/network_disruption.go:151","message":"auto-detecting used interfaces to reach the given hosts","hosts":["kubernetes.default"]}
{"level":"info","ts":1614716654488.5215,"caller":"injector/network_disruption.go:171","message":"IP 10.129.224.1/32 belongs to interface lo"}
{"level":"info","ts":1614716654488.6023,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc qdisc add dev ens5 root handle 1: prio bands 4 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1"}
{"level":"info","ts":1614716654489.9175,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc qdisc add dev ens5 parent 1:4 handle 2: netem loss 100%"}
{"level":"info","ts":1614716654490.721,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.142.193.71/32 flowid 1:4"}
{"level":"info","ts":1614716654491.5579,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.143.28.220/32 flowid 1:4"}
{"level":"info","ts":1614716654492.3079,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.143.155.106/32 flowid 1:4"}
{"level":"info","ts":1614716654493.1118,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.143.72.195/32 flowid 1:4"}
{"level":"info","ts":1614716654493.858,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.143.0.71/32 flowid 1:4"}
{"level":"info","ts":1614716654494.5886,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.142.200.210/32 flowid 1:4"}
{"level":"info","ts":1614716654495.3372,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.143.194.65/32 flowid 1:4"}
{"level":"info","ts":1614716654495.965,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.142.197.57/32 flowid 1:4"}
{"level":"info","ts":1614716654496.7058,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.143.97.238/32 flowid 1:4"}
{"level":"info","ts":1614716654497.3354,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.143.29.156/32 flowid 1:4"}
{"level":"info","ts":1614716654498.0461,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.143.249.248/32 flowid 1:4"}
{"level":"info","ts":1614716654498.6697,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip dst 10.142.187.208/32 flowid 1:4"}
{"level":"info","ts":1614716654499.3142,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip sport 22 0xffff match ip protocol 6 0xff flowid 1:1"}
{"level":"info","ts":1614716654499.9375,"caller":"network/tc.go:63","message":"running tc command: /sbin/tc filter add dev ens5 parent 1:0 u32 match ip protocol 0 0xff flowid 1:1"}
{"level":"info","ts":1614716654500.5789,"caller":"injector/network_disruption.go:92","message":"operations applied successfully"}
{"level":"info","ts":1614716654500.5957,"caller":"injector/network_disruption.go:95","message":"editing pod net_cls cgroup to apply a classid to target container packets"}
{"level":"info","ts":1614716654500.8398,"caller":"injector/main.go:215","message":"disruption injected, now waiting for an exit signal"}
```
A re-run of the gameday on chinook with the exact yaml Sam used in phase 1. No error this time, the pods are all ready