### PR TITLE
CORE-467: Replace "count" metrics with more accurate gauge names

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -967,23 +967,23 @@ func (r *DisruptionReconciler) ReportMetrics() {
 
 			chaosPods, err := r.getChaosPods(&d, nil)
 			if err != nil {
-				r.log.Errorw("error sending pods.count metric", "error", err)
+				r.log.Errorw("error listing chaos pods to send pods.gauge metric", "error", err)
 			}
 
 			chaosPodsCount += len(chaosPods)
 		}
 
 		// send metrics
-		if err := r.MetricsSink.MetricStuckOnRemovalCount(float64(stuckOnRemoval)); err != nil {
-			r.log.Errorw("error sending stuck_on_removal_count metric", "error", err)
+		if err := r.MetricsSink.MetricStuckOnRemovalGauge(float64(stuckOnRemoval)); err != nil {
+			r.log.Errorw("error sending stuck_on_removal_total metric", "error", err)
 		}
 
-		if err := r.MetricsSink.MetricDisruptionsCount(float64(len(l.Items))); err != nil {
-			r.log.Errorw("error sending disruptions.count metric", "error", err)
+		if err := r.MetricsSink.MetricDisruptionsGauge(float64(len(l.Items))); err != nil {
+			r.log.Errorw("error sending disruptions.gauge metric", "error", err)
 		}
 
-		if err := r.MetricsSink.MetricPodsCount(float64(chaosPodsCount)); err != nil {
-			r.log.Errorw("error sending pods.count metric", "error", err)
+		if err := r.MetricsSink.MetricPodsGauge(float64(chaosPodsCount)); err != nil {
+			r.log.Errorw("error sending pods.gauge metric", "error", err)
 		}
 	}
 }

--- a/metrics/datadog/datadog.go
+++ b/metrics/datadog/datadog.go
@@ -114,19 +114,19 @@ func (d *Sink) MetricStuckOnRemoval(tags []string) error {
 	return d.metricWithStatus(metricPrefixController+"disruptions.stuck_on_removal", tags)
 }
 
-// MetricStuckOnRemovalCount sends disruptions.stuck_on_removal_count metric containing the count of stuck disruptions
-func (d *Sink) MetricStuckOnRemovalCount(count float64) error {
-	return d.client.Gauge(metricPrefixController+"disruptions.stuck_on_removal_total", count, []string{}, 1)
+// MetricStuckOnRemovalGauge sends disruptions.stuck_on_removal_total metric containing the gauge of stuck disruptions
+func (d *Sink) MetricStuckOnRemovalGauge(gauge float64) error {
+	return d.client.Gauge(metricPrefixController+"disruptions.stuck_on_removal_total", gauge, []string{}, 1)
 }
 
-// MetricDisruptionsCount sends the disruptions.count metric counting ongoing disruptions
-func (d *Sink) MetricDisruptionsCount(count float64) error {
-	return d.client.Gauge(metricPrefixController+"disruptions.count", count, []string{}, 1)
+// MetricDisruptionsGauge sends the disruptions.gauge metric counting ongoing disruptions
+func (d *Sink) MetricDisruptionsGauge(gauge float64) error {
+	return d.client.Gauge(metricPrefixController+"disruptions.gauge", gauge, []string{}, 1)
 }
 
-// MetricPodsCount sends the pods.count metric counting existing chaos pods
-func (d *Sink) MetricPodsCount(count float64) error {
-	return d.client.Gauge(metricPrefixController+"pods.count", count, []string{}, 1)
+// MetricPodsGauge sends the pods.gauge metric counting existing chaos pods
+func (d *Sink) MetricPodsGauge(gauge float64) error {
+	return d.client.Gauge(metricPrefixController+"pods.gauge", gauge, []string{}, 1)
 }
 
 func boolToStatus(succeed bool) string {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -28,9 +28,9 @@ type Sink interface {
 	MetricReconcile() error
 	MetricReconcileDuration(duration time.Duration, tags []string) error
 	MetricStuckOnRemoval(tags []string) error
-	MetricStuckOnRemovalCount(count float64) error
-	MetricDisruptionsCount(count float64) error
-	MetricPodsCount(count float64) error
+	MetricStuckOnRemovalGauge(gauge float64) error
+	MetricDisruptionsGauge(gauge float64) error
+	MetricPodsGauge(gauge float64) error
 }
 
 // GetSink returns an initiated sink

--- a/metrics/noop/noop.go
+++ b/metrics/noop/noop.go
@@ -99,23 +99,23 @@ func (n *Sink) MetricStuckOnRemoval(tags []string) error {
 	return nil
 }
 
-// MetricStuckOnRemovalCount sends disruptions.stuck_on_removal_count metric
-func (n *Sink) MetricStuckOnRemovalCount(count float64) error {
-	fmt.Printf("NOOP: MetricStuckOnRemovalCount %f\n", count)
+// MetricStuckOnRemovalGauge sends disruptions.stuck_on_removal_total metric
+func (n *Sink) MetricStuckOnRemovalGauge(gauge float64) error {
+	fmt.Printf("NOOP: MetricStuckOnRemovalGauge %f\n", gauge)
 
 	return nil
 }
 
-// MetricDisruptionsCount sends disruptions.count metric
-func (n *Sink) MetricDisruptionsCount(count float64) error {
-	fmt.Printf("NOOP: MetricDisruptionsCount %f\n", count)
+// MetricDisruptionsGauge sends disruptions.gauge metric
+func (n *Sink) MetricDisruptionsGauge(gauge float64) error {
+	fmt.Printf("NOOP: MetricDisruptionsGauge %f\n", gauge)
 
 	return nil
 }
 
-// MetricPodsCount sends pods.count metric
-func (n *Sink) MetricPodsCount(count float64) error {
-	fmt.Printf("NOOP: MetricPodsCount %f\n", count)
+// MetricPodsGauge sends pods.gauge metric
+func (n *Sink) MetricPodsGauge(gauge float64) error {
+	fmt.Printf("NOOP: MetricPodsGauge %f\n", gauge)
 
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Renames all of our gauge metrics that are named "count" with the name "gauge"

### Motivation

The inaccurate names make it hard to have real count metrics named "count"

### Testing Guidelines

Absolutely none, no

### Additional Notes

What do we use `MetricStuckOnRemoval` for? I only see in `MetricStuckOnRemovalGauge` actually reported when I check the dd metrics explorer