### PR TITLE
CORE-467: Collect a duration metric for the entire disruption duration

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -150,6 +150,7 @@ func (r *DisruptionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 
 			// send reconciling duration metric
 			r.handleMetricSinkError(r.MetricsSink.MetricCleanupDuration(time.Since(instance.ObjectMeta.DeletionTimestamp.Time), []string{"name:" + instance.Name, "namespace:" + instance.Namespace}))
+			r.handleMetricSinkError(r.MetricsSink.MetricDisruptionDuration(time.Since(instance.ObjectMeta.CreationTimestamp.Time), []string{"name:" + instance.Name, "namespace:" + instance.Namespace}))
 
 			return ctrl.Result{}, nil
 		}

--- a/metrics/datadog/datadog.go
+++ b/metrics/datadog/datadog.go
@@ -101,6 +101,11 @@ func (d *Sink) MetricInjectDuration(duration time.Duration, tags []string) error
 	return d.timing(metricPrefixController+"inject.duration", duration, tags)
 }
 
+// MetricDisruptionDuration sends timing metric for entire disruption duration
+func (d *Sink) MetricDisruptionDuration(duration time.Duration, tags []string) error {
+	return d.timing(metricPrefixController+"disruption.duration", duration, tags)
+}
+
 // MetricPodsCreated increment pods.created metric
 func (d *Sink) MetricPodsCreated(target, instanceName, namespace string, succeed bool) error {
 	status := boolToStatus(succeed)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -27,6 +27,7 @@ type Sink interface {
 	MetricPodsCreated(target, instanceName, namespace string, succeed bool) error
 	MetricReconcile() error
 	MetricReconcileDuration(duration time.Duration, tags []string) error
+	MetricDisruptionDuration(duration time.Duration, tags []string) error
 	MetricStuckOnRemoval(tags []string) error
 	MetricStuckOnRemovalCount(count float64) error
 	MetricDisruptionsCount(count float64) error

--- a/metrics/noop/noop.go
+++ b/metrics/noop/noop.go
@@ -71,6 +71,13 @@ func (n *Sink) MetricInjectDuration(duration time.Duration, tags []string) error
 	return nil
 }
 
+// MetricDisruptionDuration sends timing metric for entire disruption duration
+func (n *Sink) MetricDisruptionDuration(duration time.Duration, tags []string) error {
+	fmt.Printf("NOOP: MetricDisruptionDuration %v\n", duration)
+
+	return nil
+}
+
 // MetricReconcile increment reconcile metric
 func (n *Sink) MetricReconcile() error {
 	fmt.Println("NOOP: MetricReconcile +1")


### PR DESCRIPTION
### What does this PR do?

Adds a new metric to collect, at the end of cleanup, which captures the time since "now" and the creation timestamp of a disruption, and logs it as `prefix+disruption.duration`

### Motivation

I wanted to use the metric in a screenboard

### Testing Guidelines

I tested locally and confirmed the metric was only emitted once, and the time was correct.

### Additional Notes

Anything else we should know when reviewing?
