### PR TITLE
CORE-458: Gather ongoing duration separately from completed duration …

### DIFF
--- a/metrics/datadog/datadog.go
+++ b/metrics/datadog/datadog.go
@@ -101,9 +101,14 @@ func (d *Sink) MetricInjectDuration(duration time.Duration, tags []string) error
 	return d.timing(metricPrefixController+"inject.duration", duration, tags)
 }
 
-// MetricDisruptionDuration sends timing metric for entire disruption duration
-func (d *Sink) MetricDisruptionDuration(duration time.Duration, tags []string) error {
-	return d.timing(metricPrefixController+"disruption.duration", duration, tags)
+// MetricDisruptionCompletedDuration sends timing metric for entire disruption duration
+func (d *Sink) MetricDisruptionCompletedDuration(duration time.Duration, tags []string) error {
+	return d.timing(metricPrefixController+"disruption.completed_duration", duration, tags)
+}
+
+// MetricDisruptionOngoingDuration sends timing metric for disruption duration so far
+func (d *Sink) MetricDisruptionOngoingDuration(duration time.Duration, tags []string) error {
+	return d.timing(metricPrefixController+"disruption.ongoing_duration", duration, tags)
 }
 
 // MetricPodsCreated increment pods.created metric

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -27,7 +27,8 @@ type Sink interface {
 	MetricPodsCreated(target, instanceName, namespace string, succeed bool) error
 	MetricReconcile() error
 	MetricReconcileDuration(duration time.Duration, tags []string) error
-	MetricDisruptionDuration(duration time.Duration, tags []string) error
+	MetricDisruptionCompletedDuration(duration time.Duration, tags []string) error
+	MetricDisruptionOngoingDuration(duration time.Duration, tags []string) error
 	MetricStuckOnRemoval(tags []string) error
 	MetricStuckOnRemovalGauge(gauge float64) error
 	MetricDisruptionsGauge(gauge float64) error

--- a/metrics/noop/noop.go
+++ b/metrics/noop/noop.go
@@ -71,9 +71,16 @@ func (n *Sink) MetricInjectDuration(duration time.Duration, tags []string) error
 	return nil
 }
 
-// MetricDisruptionDuration sends timing metric for entire disruption duration
-func (n *Sink) MetricDisruptionDuration(duration time.Duration, tags []string) error {
-	fmt.Printf("NOOP: MetricDisruptionDuration %v\n", duration)
+// MetricDisruptionCompletedDuration sends timing metric for entire disruption duration
+func (n *Sink) MetricDisruptionCompletedDuration(duration time.Duration, tags []string) error {
+	fmt.Printf("NOOP: MetricDisruptionCompletedDuration %v\n", duration)
+
+	return nil
+}
+
+// MetricDisruptionOngoingDuration sends timing metric for disruption duration so far
+func (n *Sink) MetricDisruptionOngoingDuration(duration time.Duration, tags []string) error {
+	fmt.Printf("NOOP: MetricDisruptionOngoingDuration %v %s\n", duration, tags)
 
 	return nil
 }


### PR DESCRIPTION
…to monitor for long disruptions

### What does this PR do?

This renames the `prefix+disruption.duration` to `prefix+disruption.completed_duration` and adds a `prefix+disruption.ongoing_duration` metric.

### Motivation

I began to add the monitor in CORE-458 needed to alert on long injections, when I realized that the current metric only alerts when a disruption is completed, which is very useful for showing stats on how long disruptions are intentionally run for, but doesn't help at all for alerting on disruptions that are left alive for too long.

### Testing Guidelines

I tested locally and confirmed we still emit a completed metric, and that the ongoing metrics are tracked separately per disruption.

### Additional Notes

The names of these metrics should be changed if you don't like them.
