### PR TITLE
CORE-586: Remove finalizer if manually deleted based on very fragile …

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -537,6 +537,14 @@ func (r *DisruptionReconciler) handleChaosPodsTermination(instance *chaosv1beta1
 						removeFinalizer = true
 					}
 
+					if cs.State.Waiting != nil && cs.State.Waiting.Reason == "ContainerCreating" &&
+						cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Reason == "ContainerStatusUnknown" &&
+						strings.Contains(cs.LastTerminationState.Terminated.Message, "container could not be located when the pod was deleted") {
+						r.log.Infow("chaos pod failed readiness probe during termination, removing finalizer", "chaosPod", chaosPod.Name)
+
+						removeFinalizer = true
+					}
+
 					break
 				}
 			}


### PR DESCRIPTION
…message parsing

### What does this PR do?

Checks for the exact container status we expect when a pod has been manually deleted, so that we can remove the finalizer.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

I've confirmed three cases locally:
1. Manually deleting the pod ✅ 
2. Manually deleting the disruption ✅ 
3. The pod errors, doesn't clean, but then I try to delete the disruption, does the pod stay stuck_on_removal? ✅ 

### Additional Notes

I don't like this solution? But I wanted to share the code