### PR TITLE
CORE-497: add context to injector logger through injector CLI and its chaos-controller controller

### DIFF
--- a/api/generator.go
+++ b/api/generator.go
@@ -18,8 +18,7 @@ type DisruptionArgsGenerator interface {
 
 // AppendCommonArgs is a helper function generating common args and appending them to the given args array
 func AppendCommonArgs(args []string, level chaostypes.DisruptionLevel, containerIDs []string, sink string, dryRun bool,
-	disruptionName string, disruptionNamespace string,
-	targetName string, targetKind string) []string {
+	disruptionName string, disruptionNamespace string, targetName string) []string {
 	args = append(args,
 		// basic args
 		"--metrics-sink", sink,
@@ -30,7 +29,6 @@ func AppendCommonArgs(args []string, level chaostypes.DisruptionLevel, container
 		"--log-context-disruption-name", disruptionName,
 		"--log-context-disruption-namespace", disruptionNamespace,
 		"--log-context-target-name", targetName,
-		"--log-context-target-kind", targetKind,
 	)
 
 	// enable dry-run mode

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -48,7 +48,6 @@ var (
 	disruptionName      string
 	disruptionNamespace string
 	targetName          string
-	targetKind          string
 	configs             []injector.Config
 	signals             chan os.Signal
 	injectors           []injector.Injector
@@ -69,7 +68,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&disruptionName, "log-context-disruption-name", "", "Log value: current disruption name")
 	rootCmd.PersistentFlags().StringVar(&disruptionNamespace, "log-context-disruption-namespace", "", "Log value: current disruption namespace")
 	rootCmd.PersistentFlags().StringVar(&targetName, "log-context-target-name", "", "Log value: current target name")
-	rootCmd.PersistentFlags().StringVar(&targetKind, "log-context-target-kind", "", "Log value: current target kind")
 
 	_ = cobra.MarkFlagRequired(rootCmd.PersistentFlags(), "level")
 	cobra.OnInitialize(initLogger)
@@ -106,10 +104,9 @@ func initLogger() {
 	}
 
 	log = log.With(
-		"disruption-name", disruptionName,
-		"disruption-namespace", disruptionNamespace,
-		"target-name", targetName,
-		"target-kind", targetKind,
+		"disruptionName", disruptionName,
+		"disruptionNamespace", disruptionNamespace,
+		"targetName", targetName,
 	)
 }
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -1015,7 +1015,7 @@ func (r *DisruptionReconciler) generateChaosPods(instance *chaosv1beta1.Disrupti
 		// generate args for pod
 		args := chaosapi.AppendCommonArgs(generator.GenerateArgs(),
 			level, containerIDs, r.MetricsSink.GetSinkName(), instance.Spec.DryRun,
-			string(kind), instance.Namespace, targetName, string(level))
+			instance.Name, instance.Namespace, targetName)
 
 		// append pod to chaos pods
 		*pods = append(*pods, r.generatePod(instance, targetName, targetNodeName, args, kind))


### PR DESCRIPTION
### What does this PR do?
Allows the injector to give better context in its logs, to know faster in which environment it was deployed

### Motivation
Currently, reading the injector logs aren't allowing to know quickly the location of the injection. This aims to facilitate 

### Testing Guidelines
Applying a disruption locally, seeing the new logs tags in each log line

### Additional Notes
/
