### PR TITLE
CORE-586: Fix the local Kubernetes version to 1.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,16 +99,16 @@ else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
-# fixing kubernetes version at 1.17.0 because of this issue:
-# https://github.com/kubernetes/minikube/issues/7179
-# please remove once Minikube ships with a non-broken (> 1.18.0) version
+# fixing kubernetes version at 1.19.X because of this issue: https://github.com/kubernetes/kubernetes/issues/97288
+# once the following fix is released (https://github.com/kubernetes/kubernetes/pull/97980), planned for 1.21, we can use the latest
+# Kubernetes version again
 minikube-start:
 	minikube start \
 		--vm-driver=virtualbox \
 		--container-runtime=containerd \
 		--memory=4096 \
 		--cpus=4 \
-		--kubernetes-version=1.20.0 \
+		--kubernetes-version=1.19.9 \
 		--disk-size=50GB \
 		--extra-config=apiserver.enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota \
 		--iso-url=https://public-chaos-controller.s3.amazonaws.com/minikube/minikube-2021-01-18.iso

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Chaos Controller
 
+**Latest Kubernetes version supported: 1.19.x ([more info](#kubernetes-120x-known-issues))**
+
 The Chaos Controller was created to facilitate automation requirements in Datadog chaos experiments. It helps to deal with failures during chaos engineering events by abstracting them, especially when dealing with big deployments or complex network operations. It introduces a custom Kubernetes resource named `Disruption`.
 
 ## Table of Contents
@@ -122,3 +124,7 @@ This flag can be enabled specifically on the controller configuration itself (th
 ## Contributing
 
 Please read the [contributing documentation](CONTRIBUTING.md) for more information.
+
+## Kubernetes 1.20.x known issues
+
+[The following issue](https://github.com/kubernetes/kubernetes/issues/97288) prevents the controller from running properly on Kubernetes 1.20.x. We don't plan to support this version. [The fix](https://github.com/kubernetes/kubernetes/pull/97980) should be released with Kubernetes 1.21.


### PR DESCRIPTION
### What does this PR do?

It fixes the Kubernetes version used for local development to 1.19.9. It also adds some more information about the currently supported Kubernetes version.

### Motivation

Kubernetes 1.20 introduced a bug which can prevent a disruption from being cleaned up correctly. The bug is fixed in 1.21. We do not plan to support 1.20 so far as it would add some extra and specific logic to the controller, only for this bug to be supported.

### Additional Notes

You need to delete and re-create your local cluster to use the newly defined version.