### PR TITLE
CORE-623: use zap logger after logger init

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,14 +78,14 @@ func main() {
 		Port:               9443,
 	})
 	if err != nil {
-		logger.Error(err, "unable to start manager")
+		logger.Errorw("unable to start manager", "error", err)
 		os.Exit(1)
 	}
 
 	// metrics sink
 	ms, err := metrics.GetSink(types.SinkDriver(sink), types.SinkAppController)
 	if err != nil {
-		logger.Error(err, "error while creating metric sink")
+		logger.Errorw("error while creating metric sink", "error", err)
 	}
 
 	if ms.MetricRestart() != nil {
@@ -94,10 +94,10 @@ func main() {
 
 	// handle metrics sink client close on exit
 	defer func() {
-		logger.Info("closing metrics sink client before exiting", "sink", ms.GetSinkName())
+		logger.Infow("closing metrics sink client before exiting", "sink", ms.GetSinkName())
 
 		if err := ms.Close(); err != nil {
-			logger.Error(err, "error closing metrics sink client", "sink", ms.GetSinkName())
+			logger.Errorw("error closing metrics sink client", "sink", ms.GetSinkName(), "error", err)
 		}
 	}()
 
@@ -114,17 +114,17 @@ func main() {
 	}
 
 	if err := r.SetupWithManager(mgr); err != nil {
-		logger.Error(err, "unable to create controller", "controller", "Disruption")
+		logger.Errorw("unable to create controller", "controller", "Disruption", "error", err)
 		os.Exit(1)
 	}
 
 	go r.ReportMetrics()
 	// +kubebuilder:scaffold:builder
 
-	logger.Info("restarting chaos-controller")
+	logger.Infow("restarting chaos-controller")
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		logger.Error(err, "problem running manager")
+		logger.Errorw("problem running manager", "error", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Change logger used in most of `main.go` file

### Motivation
We are using multiple loggers in the controller `main.go` file which can be very misleading. Let’s use a single one, the Zap one. It will also fix some info logs not being sent on controller startup.

### Testing Guidelines
start/restart the controller and witness the log call now formatted by zap

### Additional Notes

/
