### PR TITLE
Ignore invalid link index when applying a network disruption

### DIFF
--- a/network/netlink.go
+++ b/network/netlink.go
@@ -59,7 +59,11 @@ func (a netlinkAdapter) LinkList() ([]NetlinkLink, error) {
 
 	for _, route := range routes {
 		if _, found := linksIndexes[route.LinkIndex]; !found {
-			linksIndexes[route.LinkIndex] = struct{}{}
+			// ignore any "invalid" link index
+			// the link index can be 0 for blackhole routes for instance (eq. "*" interface in the routing table)
+			if route.LinkIndex > 0 {
+				linksIndexes[route.LinkIndex] = struct{}{}
+			}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

It ignores any unexpected/invalid link index found in the routing table entries when applying a network disruption.

### Motivation

Some routes have a "blackhole" interface (displayed as `*` in the routing table) with an index of `0`. It is especially true when using the Calico CNI. This special interface can't be retrieved because the index is considered as incorrect, which triggers a bug preventing the network disruption to be applied correctly.

### Testing Guidelines

* start your local cluster with the `--cni=calico` flag (to add to the `minikube start` command in the `Makefile` of the project)
* deploy the controller and the demo pods
* apply a network disruption like this one
```yaml
apiVersion: chaos.datadoghq.com/v1beta1
kind: Disruption
metadata:
  name: network-drop
  namespace: chaos-engineering
spec:
  level: node
  selector:
    kubernetes.io/hostname: "minikube"
  count: 1
  network:
    drop: 1 # percentage of outgoing packets to drop
```

Without the PR, the chaos pod is never ready and fails to apply the disruption. With the PR, the route should be ignored and the disruption should be applied normally.