### PR TITLE
Fix spelling error on demo sample

### DIFF
--- a/config/samples/demo.yaml
+++ b/config/samples/demo.yaml
@@ -101,4 +101,4 @@ spec:
     - port: 8080
       targetPort: 80
   selector:
-    app: demo-ngin
+    app: demo-nginx


### PR DESCRIPTION
### What does this PR do?

This PR fixes the spelling error in the demo sample yaml.

### Motivation

While testing the chaos-controller, I detected a spelling error on the demo sample config preventing the demo curl pod to work.

### Testing Guidelines

### Additional Notes
