### PR TITLE
CORE-702: Validation call from CLI PR

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -131,7 +131,7 @@ func (s *DisruptionSpec) Validate() error {
 func (s *DisruptionSpec) validateGlobalDisruptionScope() error {
 	// Rule: no targeted container if disruption is node-level
 	if len(s.Containers) > 0 && s.Level == chaostypes.DisruptionLevelNode {
-		return errors.New("cannot target specific containers in a node-level disruption")
+		return errors.New("cannot target specific containers because the level configuration is set to node")
 	}
 
 	// Rule: at least one disruption field
@@ -140,7 +140,7 @@ func (s *DisruptionSpec) validateGlobalDisruptionScope() error {
 		s.Network == nil &&
 		s.NodeFailure == nil &&
 		s.DiskPressure == nil {
-		return errors.New("cannot apply an empty disruption - you need to add at least one of Network, DNS, DiskPressure, NodeFailure, CPUPressure fields")
+		return errors.New("cannot apply an empty disruption - at least one of Network, DNS, DiskPressure, NodeFailure, CPUPressure fields is needed")
 	}
 
 	return nil

--- a/cli/chaosli/cmd/explain.go
+++ b/cli/chaosli/cmd/explain.go
@@ -233,6 +233,10 @@ var explainCmd = &cobra.Command{
 	Use:   "explain",
 	Short: "explains disruption config",
 	Long:  `translates the yaml of the disruption configuration to english.`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		path, _ := cmd.Flags().GetString("path")
+		return validatePath(path)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		path, _ := cmd.Flags().GetString("path")
 		explanation(path)
@@ -241,10 +245,6 @@ var explainCmd = &cobra.Command{
 
 func explanation(path string) {
 	var disruption v1beta1.Disruption
-
-	if path == "" {
-		fmt.Println(pathError)
-	}
 
 	fullPath, err := filepath.Abs(path)
 

--- a/cli/chaosli/cmd/root.go
+++ b/cli/chaosli/cmd/root.go
@@ -6,13 +6,13 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
+	goyaml "github.com/ghodss/yaml"
 
 	"github.com/spf13/cobra"
 
@@ -87,22 +87,22 @@ func initConfig() {
 	}
 }
 
-func DisruptionFromFile(path string) (v1beta1.DisruptionSpec, error) {
+func DisruptionFromFile(path string) (v1beta1.Disruption, error) {
 	yaml, err := os.Open(filepath.Clean(path))
 	if err != nil {
-		return v1beta1.DisruptionSpec{}, err
+		return v1beta1.Disruption{}, err
 	}
 
 	yamlBytes, err := ioutil.ReadAll(yaml)
 	if err != nil {
-		return v1beta1.DisruptionSpec{}, err
+		return v1beta1.Disruption{}, err
 	}
 
-	parsedSpec := v1beta1.DisruptionSpec{}
-	err = json.Unmarshal(yamlBytes, &parsedSpec)
+	parsedSpec := v1beta1.Disruption{}
+	err = goyaml.Unmarshal(yamlBytes, &parsedSpec)
 
 	if err != nil {
-		return v1beta1.DisruptionSpec{}, err
+		return v1beta1.Disruption{}, err
 	}
 
 	return parsedSpec, nil

--- a/cli/chaosli/cmd/root.go
+++ b/cli/chaosli/cmd/root.go
@@ -22,8 +22,6 @@ import (
 
 var cfgFile string
 
-const pathError string = "No Path Given, Exiting..."
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "chaosli",
@@ -109,5 +107,13 @@ func DisruptionFromFile(path string) (v1beta1.Disruption, error) {
 }
 
 func DisruptionToFile(path string, spec v1beta1.DisruptionSpec) error {
+	return nil
+}
+
+func validatePath(filePath string) error {
+	if filePath == "" {
+		return fmt.Errorf("no path given, exiting")
+	}
+
 	return nil
 }

--- a/cli/chaosli/cmd/validate.go
+++ b/cli/chaosli/cmd/validate.go
@@ -8,7 +8,6 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -26,7 +25,7 @@ var validateCmd = &cobra.Command{
 		path, _ := cmd.Flags().GetString("path")
 		return validatePath(path)
 	},
-	Run: ValidateDisruption,
+	RunE: ValidateDisruption,
 }
 
 func validate(filePath string) string {
@@ -41,14 +40,16 @@ func init() {
 	validateCmd.Flags().String("path", "", "The path to the disruption file to be validated.")
 }
 
-func ValidateDisruption(cmd *cobra.Command, args []string) {
+func ValidateDisruption(cmd *cobra.Command, args []string) error {
 	path, _ := cmd.Flags().GetString("path")
 	disruption, _ := DisruptionFromFile(path)
 
 	err := disruption.Spec.Validate()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+
+	return nil
 }
 
 func validatePath(filePath string) error {

--- a/cli/chaosli/cmd/validate.go
+++ b/cli/chaosli/cmd/validate.go
@@ -7,7 +7,14 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
 
+	goyaml "github.com/ghodss/yaml"
+
+	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/spf13/cobra"
 )
 
@@ -15,10 +22,11 @@ var validateCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "validate disruption config",
 	Long:  `validates the yaml of the disruption for structure.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		path, _ := cmd.Flags().GetString("path")
-		fmt.Println(validate(path))
+		return validatePath(path)
 	},
+	Run: ValidateDisruption,
 }
 
 func validate(filePath string) string {
@@ -31,4 +39,43 @@ func validate(filePath string) string {
 
 func init() {
 	validateCmd.Flags().String("path", "", "The path to the disruption file to be validated.")
+}
+
+func ValidateDisruption(cmd *cobra.Command, args []string) {
+	path, _ := cmd.Flags().GetString("path")
+	disruption, _ := DisruptionFromFile(path)
+
+	err := disruption.Spec.Validate()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func validatePath(filePath string) error {
+	if filePath == "" {
+		return fmt.Errorf("no path given, exiting")
+	}
+
+	return nil
+}
+
+func DisruptionFromFile(path string) (v1beta1.Disruption, error) {
+	yaml, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return v1beta1.Disruption{}, err
+	}
+
+	yamlBytes, err := ioutil.ReadAll(yaml)
+	if err != nil {
+		return v1beta1.Disruption{}, err
+	}
+
+	parsedSpec := v1beta1.Disruption{}
+	err = goyaml.Unmarshal(yamlBytes, &parsedSpec)
+
+	if err != nil {
+		return v1beta1.Disruption{}, err
+	}
+
+	return parsedSpec, nil
 }

--- a/cli/chaosli/cmd/validate.go
+++ b/cli/chaosli/cmd/validate.go
@@ -6,8 +6,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -19,28 +17,25 @@ var validateCmd = &cobra.Command{
 		path, _ := cmd.Flags().GetString("path")
 		return validatePath(path)
 	},
-	RunE: ValidateDisruption,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path, _ := cmd.Flags().GetString("path")
+		return ValidateDisruption(path)
+	},
 }
 
 func init() {
 	validateCmd.Flags().String("path", "", "The path to the disruption file to be validated.")
 }
 
-func ValidateDisruption(cmd *cobra.Command, args []string) error {
-	path, _ := cmd.Flags().GetString("path")
-	disruption, _ := DisruptionFromFile(path)
-
-	err := disruption.Spec.Validate()
+func ValidateDisruption(path string) error {
+	disruption, err := DisruptionFromFile(path)
 	if err != nil {
 		return err
 	}
 
-	return nil
-}
-
-func validatePath(filePath string) error {
-	if filePath == "" {
-		return fmt.Errorf("no path given, exiting")
+	err = disruption.Spec.Validate()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/cli/chaosli/cmd/validate.go
+++ b/cli/chaosli/cmd/validate.go
@@ -7,13 +7,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 
-	goyaml "github.com/ghodss/yaml"
-
-	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/spf13/cobra"
 )
 
@@ -26,14 +20,6 @@ var validateCmd = &cobra.Command{
 		return validatePath(path)
 	},
 	RunE: ValidateDisruption,
-}
-
-func validate(filePath string) string {
-	if filePath == "" {
-		return pathError
-	}
-
-	return "Validation TODO"
 }
 
 func init() {
@@ -58,25 +44,4 @@ func validatePath(filePath string) error {
 	}
 
 	return nil
-}
-
-func DisruptionFromFile(path string) (v1beta1.Disruption, error) {
-	yaml, err := os.Open(filepath.Clean(path))
-	if err != nil {
-		return v1beta1.Disruption{}, err
-	}
-
-	yamlBytes, err := ioutil.ReadAll(yaml)
-	if err != nil {
-		return v1beta1.Disruption{}, err
-	}
-
-	parsedSpec := v1beta1.Disruption{}
-	err = goyaml.Unmarshal(yamlBytes, &parsedSpec)
-
-	if err != nil {
-		return v1beta1.Disruption{}, err
-	}
-
-	return parsedSpec, nil
 }

--- a/go.sum
+++ b/go.sum
@@ -363,7 +363,6 @@ github.com/kr/pty v1.1.5 h1:hyz3dwM5QLc1Rfoz4FuWJQG5BN7tc6K1MndAUnGpQr4=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -527,7 +526,6 @@ github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.7.0 h1:xVKxvI7ouOI5I+U9s2eeiUfMaWBVoXA3AWskkrqK0VM=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=


### PR DESCRIPTION
## What does this PR do?

- [X] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior:
Whole validation is now called from the CLI command `chaosli validate --...`

Motivation for change:

## Code Quality

### Testing

- [ ] I used existing unit tests
- [X] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [X] The documentation is up to date
- [X] My code is sufficiently commented
- [X] I have tested to the best of my ability
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
