### PR TITLE
chaosli validators shouldnt require input, survey.Required exists for…

### DIFF
--- a/cli/chaosli/cmd/create.go
+++ b/cli/chaosli/cmd/create.go
@@ -52,6 +52,8 @@ var createCmd = &cobra.Command{
 		if err != nil {
 			fmt.Printf("writeFile err: %v", err)
 		}
+
+		fmt.Printf("We wrote your disruption to %s, thanks!", path)
 	},
 }
 
@@ -596,6 +598,10 @@ func indexOfString(slice []string, indexed string) int {
 
 func percentageValidator(val interface{}) error {
 	if str, ok := val.(string); ok {
+		if str == "" {
+			return nil
+		}
+
 		input := intstr.Parse(str)
 		value, _, _ := v1beta1.GetIntOrPercentValueSafely(&input)
 
@@ -611,6 +617,10 @@ func percentageValidator(val interface{}) error {
 
 func integerValidator(val interface{}) error {
 	if str, ok := val.(string); ok {
+		if str == "" {
+			return nil
+		}
+
 		_, err := strconv.Atoi(str)
 		if err != nil {
 			return fmt.Errorf("this value must be an integer: got %v", err)


### PR DESCRIPTION
… that

## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves Documentation

I hadn't realized that the other validators were enforcing responses on non-required inputs. This PR fixes this, and also adds a nice message at the end, telling you where to find your yaml

## Code Quality

### Testing

- [ ] I used existing unit tests
- [x] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [ ] The documentation is up to date
- [ ] My code is sufficiently commented
- [ ] I have tested to the best of my ability
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
