### PR TITLE
Fix the Validatecount experience

### DIFF
--- a/api/v1beta1/validations.go
+++ b/api/v1beta1/validations.go
@@ -73,7 +73,7 @@ func GetIntOrPercentValueSafely(intOrStr *intstr.IntOrString) (int, bool, error)
 func ValidateCount(count *intstr.IntOrString) error {
 	value, isPercent, err := GetIntOrPercentValueSafely(count)
 	if err != nil {
-		return err
+		return fmt.Errorf("error determining value of spec.count: %w", err)
 	}
 
 	if isPercent {

--- a/api/v1beta1/validations.go
+++ b/api/v1beta1/validations.go
@@ -52,19 +52,19 @@ func GetIntOrPercentValueSafely(intOrStr *intstr.IntOrString) (int, bool, error)
 		return intOrStr.IntValue(), false, nil
 	case intstr.String:
 		s := intOrStr.StrVal
+		isPercent := false
 
 		if strings.HasSuffix(s, "%") {
 			s = strings.TrimSuffix(intOrStr.StrVal, "%")
-
-			v, err := strconv.Atoi(s)
-			if err != nil {
-				return 0, false, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
-			}
-
-			return v, true, nil
+			isPercent = true
 		}
 
-		return 0, false, fmt.Errorf("invalid type: string is not a percentage")
+		v, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, false, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
+		}
+
+		return v, isPercent, nil
 	}
 
 	return 0, false, fmt.Errorf("invalid type: neither int nor percentage")


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

The chaosli currently always outputs spec.count as a string. It is reasonable, and technically possible, to pass in count as a string. Therefore, we should support specifying spec.count as a string, even when its an integer and not a % value.

## Code Quality

### Testing

- [ ] I used existing unit tests
- [x] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [ ] The documentation is up to date
- [ ] My code is sufficiently commented
- [ ] I have tested to the best of my ability
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
