### PR TITLE
Move demo resources to `chaos-demo` namespace by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,14 +50,14 @@ To deploy a new version of the CRD by modifying your local `api/v1beta1/disrupti
 
 The [samples](examples/) contains sample data which can be used to test your changes.
 
-[demo.yaml](examples/demo.yaml) contains testing resources you can apply directly to your cluster in whatever namespace you choose (it can be `chaos-engineering`) by running:
-  * `kubectl -n chaos-engineering apply -f examples/demo.yaml`
+[demo.yaml](examples/demo.yaml) contains testing resources you can apply directly to your cluster in whatever namespace you choose (`chaos-demo` by default) by running:
+  * `kubectl apply -f examples/demo.yaml`
 
 Once you define your test manifest, run:
-  * `kubectl -n chaos-engineering apply -f examples/<manifest>.yaml`
+  * `kubectl apply -f examples/<manifest>.yaml`
 
 To remove the disruption, run:
-  * `kubectl -n chaos-engineering delete -f examples/<manifest>.yaml`
+  * `kubectl delete -f examples/<manifest>.yaml`
 
 See [development guide](docs/development.md) for more robust documentation and tips!
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: node-failure
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   selector: # a label selector used to target resources
     app: demo-curl

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,13 +2,13 @@
 
 ## Testing Locally
 
-[demo.yaml](examples/demo.yaml) contains testing resources you can apply directly to your cluster in whatever namespace you choose (it can be `chaos-engineering`) by running:
-  * `kubectl -n chaos-engineering apply -f examples/demo.yaml`
+[demo.yaml](examples/demo.yaml) contains testing resources you can apply directly to your cluster in whatever namespace you choose (`chaos-demo` by default), by running:
+  * `kubectl apply -f examples/demo.yaml`
 
 ## Applying your Manifest
 
 Once you define your test manifest, run:
-  * `kubectl -n chaos-engineering apply -f examples/<manifest>.yaml`
+  * `kubectl apply -f examples/<manifest>.yaml`
 
 
 <p align="center"><kbd>
@@ -30,20 +30,20 @@ An explanitory error message like the following will print:
 
 ### Reapplying a manifest
 
-Because Chaos Controller disruptions are immutable, the correct way to reapply a manifest after edit is actually to delete the resource entirely and then apply. Modifying an already applied manifest file and then reapplying it by only running `kubectl -n chaos-engineering> apply -f examples/<manifest>.yaml` will print an error message like the following:
+Because Chaos Controller disruptions are immutable, the correct way to reapply a manifest after edit is actually to delete the resource entirely and then apply. Modifying an already applied manifest file and then reapplying it by only running `kubectl apply -f examples/<manifest>.yaml` will print an error message like the following:
 
 ```
-Error from server (a disruption spec can't be edited, please delete and recreate it if needed): error when applying patch: {"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"chaos.datadoghq.com/v1beta1\",\"kind\":\"Disruption\",\"metadata\":{\"annotations\":{},\"name\":\"network-drop\",\"namespace\":\"chaos-engineering\"},\"spec\":{\"count\":10,\"level\":\"pod\",\"network\":{\"drop\":100,\"hosts\":[{\"host\":\"10.0.0.0/8\"},{\"port\":80}]},\"selector\":{\"app\":\"demo-curl\"}}}\n"}},"spec":{"count":10}}
+Error from server (a disruption spec can't be edited, please delete and recreate it if needed): error when applying patch: {"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"chaos.datadoghq.com/v1beta1\",\"kind\":\"Disruption\",\"metadata\":{\"annotations\":{},\"name\":\"network-drop\",\"namespace\":\"chaos-demo\"},\"spec\":{\"count\":10,\"level\":\"pod\",\"network\":{\"drop\":100,\"hosts\":[{\"host\":\"10.0.0.0/8\"},{\"port\":80}]},\"selector\":{\"app\":\"demo-curl\"}}}\n"}},"spec":{"count":10}}
 to:
 Resource: "chaos.datadoghq.com/v1beta1, Resource=disruptions", GroupVersionKind: "chaos.datadoghq.com/v1beta1, Kind=Disruption"
-Name: "network-drop", Namespace: "chaos-engineering"
+Name: "network-drop", Namespace: "chaos-demo"
 for: "examples/network_drop.yaml": admission webhook "chaos-controller-admission-webhook.chaos-engineering.svc" denied the request: a disruption spec can't be edited, please delete and recreate it if needed
 ```
 
 ## Deleting your Manifest
 
 Once you are done testing, you can remove the disruption by running:
-  * `kubectl -n chaos-engineering delete -f examples/<manifest>.yaml`
+  * `kubectl delete -f examples/<manifest>.yaml`
 
 <p align="center"><kbd>
     <img src="../docs/img/deployment/delete.png" width=800 align="center" />
@@ -60,19 +60,19 @@ If your pod gets stuck in terminating, it's possible that there was an issue wit
 ## Basic Troubleshooting
 
 See the existing disruptions (corresponding to `metadata.name`):
-* ```kubectl -n chaos-engineering get disruptions```
+* ```kubectl get disruptions```
 
 Get a detailed overview of the live disruption (spec, finalizer, major events, etc)
-* ```kubectl -n chaos-engineering describe disruption <disruption name>```
+* ```kubectl describe disruption <disruption name>```
 
 See the chaos pods (with names like `chaos-network-delay-llczv`, `chaos-network-drop-qlqnw`):
 * ```kubectl -n chaos-engineering get pods```
 
 Check the logs of the resource:
-* ```kubectl -n chaos-engineering logs <pod name>```
+* ```kubectl logs <pod name>```
 
-Get a detailed overview of the resource (finaliers, major events, allocated IP address, containers, etc):
-* ```kubectl -n chaos-engineering describe pod <pod name>```
+Get a detailed overview of the resource (finalizers, major events, allocated IP address, containers, etc):
+* ```kubectl describe pod <pod name>```
 
 More complex troubleshooting on the [faq.md](docs/faq.md) page.
 

--- a/examples/complete.yaml
+++ b/examples/complete.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: disruption-sample
-  namespace: chaos-engineering # disruption resource must be in the same namespace as targeted pods
+  namespace: chaos-demo # disruption resource must be in the same namespace as targeted pods
 spec:
   dryRun: false # optional, enable dry-run mode (chaos pods will be created but won't inject anything)
   level: pod # level the disruption should be injected at (can be either pod or node, defaults to pod)

--- a/examples/containers_targeting.yaml
+++ b/examples/containers_targeting.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: containers-targeting
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:

--- a/examples/count_percentage.yaml
+++ b/examples/count_percentage.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: count-percentage
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:

--- a/examples/cpu_pressure.yaml
+++ b/examples/cpu_pressure.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: cpu-pressure
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:

--- a/examples/demo.yaml
+++ b/examples/demo.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: demo
-  namespace: default
+  namespace: chaos-demo
   labels:
     type: local
 spec:
@@ -24,7 +24,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: demo
-  namespace: default
+  namespace: chaos-demo
 spec:
   storageClassName: manual
   accessModes:
@@ -37,7 +37,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: demo-nginx
-  namespace: default
+  namespace: chaos-demo
   labels:
     app: demo-nginx
 spec:
@@ -58,7 +58,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: demo-curl
-  namespace: default
+  namespace: chaos-demo
   labels:
     app: demo-curl
 spec:
@@ -75,7 +75,7 @@ spec:
       - name: curl
         image: appropriate/curl
         command: ["/bin/sh"]
-        args: ["-c", "while true; do curl -vvv http://demo.chaos-engineering.svc.cluster.local:8080; sleep 1; done"]
+        args: ["-c", "while true; do curl -vvv http://demo.chaos-demo.svc.cluster.local:8080; sleep 1; done"]
         volumeMounts:
         - mountPath: /mnt/data
           name: data
@@ -98,7 +98,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: demo
-  namespace: default
+  namespace: chaos-demo
 spec:
   ports:
     - port: 8080

--- a/examples/demo.yaml
+++ b/examples/demo.yaml
@@ -5,6 +5,13 @@
 
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: chaos-demo
+  labels:
+    name: chaos-demo
+---
+apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: demo

--- a/examples/disk_pressure_read.yaml
+++ b/examples/disk_pressure_read.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: disk-pressure-read
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:

--- a/examples/disk_pressure_write.yaml
+++ b/examples/disk_pressure_write.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: disk-pressure-write
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:

--- a/examples/dns.yaml
+++ b/examples/dns.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: dns
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:

--- a/examples/dry_run.yaml
+++ b/examples/dry_run.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: dry-run
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   dryRun: true # enable dry-run mode (chaos pods will be created but won't inject anything)
   level: pod

--- a/examples/level_node.yaml
+++ b/examples/level_node.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: level-node
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: node # impact the whole node instead of a single pod
   selector:

--- a/examples/network_bandwidth_limitation.yaml
+++ b/examples/network_bandwidth_limitation.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: network-bandwidth-limitation
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:

--- a/examples/network_corrupt.yaml
+++ b/examples/network_corrupt.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: network-corrupt
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:

--- a/examples/network_delay.yaml
+++ b/examples/network_delay.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: network-delay
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:

--- a/examples/network_drop.yaml
+++ b/examples/network_drop.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: network-drop
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:

--- a/examples/network_duplication.yaml
+++ b/examples/network_duplication.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: network-duplication
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   selector:
     app: demo-curl

--- a/examples/network_filters.yaml
+++ b/examples/network_filters.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: network-filters
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:
@@ -21,4 +21,4 @@ spec:
         protocol: tcp # optiona, the protocol to filter on
     services: # filter on Kubernetes services; this will correctly handle the port differences in node vs. pod-level disruptions
       - name: demo # service name
-        namespace: chaos-engineering # service namespace
+        namespace: chaos-demo # service namespace

--- a/examples/network_ingress.yaml
+++ b/examples/network_ingress.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: network-ingress
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   level: pod
   selector:

--- a/examples/node_failure.yaml
+++ b/examples/node_failure.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: node-failure
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   selector:
     app: demo-curl

--- a/examples/node_failure_shutdown.yaml
+++ b/examples/node_failure_shutdown.yaml
@@ -7,7 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: node-failure-shutdown
-  namespace: chaos-engineering
+  namespace: chaos-demo
 spec:
   selector:
     app: demo-curl


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [x] Improves Documentation

A brief description of changes to implementation or controller behavior:

- Removes the specification of namespace in the example commands in the docs
- Moves all examples to the `chaos-demo` namespace

Motivation for change:

- We want to put our examples outside `chaos-engineering` for 2 reasons. To make it obvious that disruptions can be applied anywhere, not just in chaos-engineering, and to make running `demo.yaml` locally for testing exercise the codepaths related to operating in namespaces outside of `chaos-engineering`
- Users don't need it explained how to specify a namespace; the specification is redundant as all the examples specify a namespace; it clutters the command explanations

## Code Quality

### Testing

- [ ] I used existing unit tests
- [ ] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [x] The documentation is up to date
- [ ] My code is sufficiently commented
- [ ] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
