### PR TITLE
Pin goroutine stresser threads to the right cpuset

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -608,6 +608,7 @@ k8s.io/client-go,k8s.io/client-go/util/workqueue,Apache-2.0
 k8s.io/klog,k8s.io/klog,Apache-2.0
 k8s.io/klog/v2,k8s.io/klog/v2,Apache-2.0
 k8s.io/kube-openapi,k8s.io/kube-openapi/pkg/util/proto,Apache-2.0
+k8s.io/kubernetes,k8s.io/kubernetes/pkg/kubelet/cm/cpuset,Apache-2.0
 k8s.io/utils,k8s.io/utils/buffer,Apache-2.0
 k8s.io/utils,k8s.io/utils/integer,Apache-2.0
 k8s.io/utils,k8s.io/utils/pointer,Apache-2.0

--- a/cgroup/cgroup.go
+++ b/cgroup/cgroup.go
@@ -45,7 +45,7 @@ func NewManager(dryRun bool, path string) (Manager, error) {
 	}, nil
 }
 
-// read reads the given cgroup file data and returns it as a string
+// read reads the given cgroup file data and returns it as a string, truncating leading \n char
 func (m manager) read(path string) (string, error) {
 	//nolint:gosec
 	data, err := ioutil.ReadFile(path)
@@ -85,7 +85,7 @@ func (m manager) generatePath(kind string) string {
 	return fmt.Sprintf("%s%s/%s", m.mount, kind, m.path)
 }
 
-// Write writes the given data to the given cgroup kind
+// Read reads the given cgroup file data and returns the content as a string
 func (m manager) Read(kind, file string) (string, error) {
 	path := fmt.Sprintf("%s/%s", m.generatePath(kind), file)
 

--- a/cgroup/cgroup.go
+++ b/cgroup/cgroup.go
@@ -7,15 +7,18 @@ package cgroup
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/DataDog/chaos-controller/env"
 )
 
 // Manager represents a cgroup manager able to join the given cgroup
 type Manager interface {
-	Join(kind string, pid int) error
+	Join(kind string, pid int, inherit bool) error
+	Read(kind, file string) (string, error)
 	Write(kind, file, data string) error
 	Exists(kind string) (bool, error)
 	DiskThrottleRead(identifier, bps int) error
@@ -40,6 +43,17 @@ func NewManager(dryRun bool, path string) (Manager, error) {
 		path:   path,
 		mount:  mount,
 	}, nil
+}
+
+// read reads the given cgroup file data and returns it as a string
+func (m manager) read(path string) (string, error) {
+	//nolint:gosec
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("error reading cgroup file %s: %w", path, err)
+	}
+
+	return strings.TrimSuffix(string(data), "\n"), nil
 }
 
 // write appends the given data to the given cgroup file path
@@ -72,6 +86,13 @@ func (m manager) generatePath(kind string) string {
 }
 
 // Write writes the given data to the given cgroup kind
+func (m manager) Read(kind, file string) (string, error) {
+	path := fmt.Sprintf("%s/%s", m.generatePath(kind), file)
+
+	return m.read(path)
+}
+
+// Write writes the given data to the given cgroup kind
 func (m manager) Write(kind, file, data string) error {
 	path := fmt.Sprintf("%s/%s", m.generatePath(kind), file)
 
@@ -93,8 +114,16 @@ func (m manager) Exists(kind string) (bool, error) {
 }
 
 // Join adds the given PID to the given cgroup
-func (m manager) Join(kind string, pid int) error {
-	path := fmt.Sprintf("%s/cgroup.procs", m.generatePath(kind))
+// If inherit is set to true, all PID of the same group will be moved to the cgroup (writing to cgroup.procs file)
+// Otherwise, only the given PID will be moved to the cgroup (writing to tasks file)
+func (m manager) Join(kind string, pid int, inherit bool) error {
+	file := "tasks"
+
+	if inherit {
+		file = "cgroup.procs"
+	}
+
+	path := fmt.Sprintf("%s/%s", m.generatePath(kind), file)
 
 	return m.write(path, strconv.Itoa(pid))
 }

--- a/cgroup/cgroup_mock.go
+++ b/cgroup/cgroup_mock.go
@@ -13,10 +13,17 @@ type ManagerMock struct {
 }
 
 //nolint:golint
-func (f *ManagerMock) Join(kind string, pid int) error {
-	args := f.Called(kind, pid)
+func (f *ManagerMock) Join(kind string, pid int, inherit bool) error {
+	args := f.Called(kind, pid, inherit)
 
 	return args.Error(0)
+}
+
+//nolint:golint
+func (f *ManagerMock) Read(kind, file string) (string, error) {
+	args := f.Called(kind, file)
+
+	return args.String(0), args.Error(1)
 }
 
 //nolint:golint

--- a/docs/cpu_pressure.md
+++ b/docs/cpu_pressure.md
@@ -4,7 +4,7 @@ The `cpuPressure` field generates CPU load on the targeted pod.
 
 ## How it works
 
-Containers achieve resource limitation (cpu, disk, memory) through cgroups. cgroups have the directory format `/sys/fs/cgroup/<kind>/<name>/`, and we can add a process to a cgroup by appending its `PID` to `cgroups.procs` file. Docker containers get their own cgroup as illustrated by `PID 1873` below:
+Containers achieve resource limitation (cpu, disk, memory) through cgroups. cgroups have the directory format `/sys/fs/cgroup/<kind>/<name>/`, and we can add a process to a cgroup by appending its `PID` to the `cgroups.procs` or the `tasks` files (depending on the use case). Docker containers get their own cgroup as illustrated by `PID 1873` below:
 
 <p align="center"><kbd>
     <img src="img/cpu/cgroup_all.png" width=500 align="center" />
@@ -12,19 +12,20 @@ Containers achieve resource limitation (cpu, disk, memory) through cgroups. cgro
 
 > :open_book: More information on how cgroups work [here](https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt).
 
-To join the CPU cgroup, the injector will:
-* retrieve the targeted pod container cgroup path from the container data
-* write its own [process group ID](https://linux.die.net/man/3/getpgid) to the `cgroup.procs` file
-
 The `/sys/fs/cgroup` directory of the host must be mounted in the injector pod at the `/mnt/cgroup` path for it to work.
 
 <p align="center"><kbd>
     <img src="img/cpu/cgroup_injected.png" width=500 align="center" />
 </kbd></p>
 
-The injector pod starts and joins the targeted pod container CPU cgroup. It then starts as many goroutines as available CPU (or specified limit) and starts an infinite loop.
+When the injector pod starts:
 
-The injector increases its own priority to the maximum value (`-20`) to ensure to take as much CPU time as possible. It is done before goroutines start and on the whole process group, so every threads created the injector also have the maximum priority.
+* It parses the `cpuset.cpus` file (located in the target `cpuset` cgroup) to retrieve cores allocated to the target processes.
+* It creates one goroutine per allocated core. Each goroutine is locked on the thread they are running on. By doing so, it forces the Go runtime scheduler to create one thread per locked goroutine.
+* Each goroutine joins the target `cpu` and `cpuset` cgroups.
+  * Joining the `cpuset` cgroup is important to both have the same number of allocated cores as the target as well as the same allocated cores so we ensure that the goroutines threads will be scheduled on the same cores as the target processes
+* Each goroutine renices itself to the highest priority (`-20`) so the Linux scheduler will always give it the priority to consume CPU time over other running processes
+* Each goroutine starts an infinite loop to consume as much CPU as possible
 
 <p align="center"><kbd>
     <img src="img/cpu/cgroup_disrupted.png" width=500 align="center" />

--- a/go.mod
+++ b/go.mod
@@ -48,5 +48,6 @@ require (
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
+	k8s.io/kubernetes v1.13.0
 	sigs.k8s.io/controller-runtime v0.6.2
 )

--- a/go.sum
+++ b/go.sum
@@ -836,6 +836,7 @@ k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 h1:Oh3Mzx5pJ+yIumsAD0MOECPVeXsVot0UkiaCGVyfGQY=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
+k8s.io/kubernetes v1.13.0 h1:qTfB+u5M92k2fCCCVP2iuhgwwSOv1EkAkvQY1tQODD8=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 h1:v8ud2Up6QK1lNOKFgiIVrZdMg7MpmSnvtrOieolJKoE=

--- a/injector/cpu_pressure.go
+++ b/injector/cpu_pressure.go
@@ -7,18 +7,19 @@ package injector
 
 import (
 	"fmt"
-	"os"
 	"runtime"
-	"syscall"
+	"sync"
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/process"
 	"github.com/DataDog/chaos-controller/stress"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 type cpuPressureInjector struct {
-	spec   v1beta1.CPUPressureSpec
-	config CPUPressureInjectorConfig
+	spec     v1beta1.CPUPressureSpec
+	config   CPUPressureInjectorConfig
+	routines int
 }
 
 // CPUPressureInjectorConfig is the CPU pressure injector config
@@ -33,7 +34,7 @@ type CPUPressureInjectorConfig struct {
 func NewCPUPressureInjector(spec v1beta1.CPUPressureSpec, config CPUPressureInjectorConfig) Injector {
 	// create stresser
 	if config.Stresser == nil {
-		config.Stresser = stress.NewCPU(config.DryRun, runtime.NumCPU())
+		config.Stresser = stress.NewCPU(config.DryRun)
 	}
 
 	if config.StresserExit == nil {
@@ -52,38 +53,113 @@ func NewCPUPressureInjector(spec v1beta1.CPUPressureSpec, config CPUPressureInje
 }
 
 func (i cpuPressureInjector) Inject() error {
-	// retrieve thread group ID
-	tgid, err := syscall.Getpgid(os.Getpid())
+	// read cpuset allocated cores
+	i.config.Log.Infow("retrieving target cpuset allocated cores")
+
+	cpusetCores, err := i.config.Cgroup.Read("cpuset", "cpuset.cpus")
 	if err != nil {
-		return fmt.Errorf("error retrieving thread group ID: %w", err)
+		return fmt.Errorf("failed to read the target allocated cpus from the cpuset cgroup: %w", err)
 	}
 
-	// join container CPU cgroup
-	i.config.Log.Infow("joining target CPU cgroup")
-
-	if err := i.config.Cgroup.Join("cpu", tgid); err != nil {
-		return fmt.Errorf("failed to inject CPU pressure: %w", err)
+	// parse allocated cores
+	cores, err := cpuset.Parse(cpusetCores)
+	if err != nil {
+		return fmt.Errorf("error parsing cpuset allocated cores: %w", err)
 	}
 
-	// prioritize the current process
-	i.config.Log.Info("highering current process priority")
+	i.config.Log.Infow(fmt.Sprintf("target identified to be running on %d cores", cores.Size()), "cores", cores.ToSlice())
 
-	if err := i.config.ProcessManager.Prioritize(); err != nil {
-		return fmt.Errorf("error highering the current process priority: %w", err)
+	// set new GOMAXPROCS value
+	oldMaxProcs := runtime.GOMAXPROCS(cores.Size())
+	i.config.Log.Infof("changed GOMAXPROCS value from %d to %d", oldMaxProcs, cores.Size())
+
+	wg := sync.WaitGroup{}
+	succeeded := true
+	tids := []int{}
+
+	// create one stress goroutine per allocated core
+	// each goroutine is locked on its current thread, without any other routines running on it
+	// it allows to have a 1 routine = 1 thread pattern
+	// each thread is then moved to the target cpu and cpuset cgroups so it can be schedule on the target allocated cores
+	// each thread is also niced to the highest priority
+	// because of linux scheduling, each thread will occupy a different core of allocated cores when stressing the cpu
+	for _, core := range cores.ToSlice() {
+		wg.Add(1)
+
+		go func(core int) {
+			var err error
+
+			defer func() {
+				if err != nil {
+					succeeded = false
+
+					wg.Done()
+				}
+			}()
+
+			// lock the routine on the current thread
+			runtime.LockOSThread()
+			defer runtime.UnlockOSThread()
+
+			// retrieve current thread PID
+			pid := i.config.ProcessManager.ThreadID()
+
+			// join target CPU cgroup
+			i.config.Log.Infow("joining target CPU cgroup", "core", core, "pid", pid)
+
+			if err = i.config.Cgroup.Join("cpu", pid, false); err != nil {
+				i.config.Log.Errorw("failed join the target CPU cgroup", "error", err, "core", core, "pid", pid)
+
+				return
+			}
+
+			// join target cpuset cgroup in case it is used to pin the target on specific cores
+			i.config.Log.Infow("joining target cpuset cgroup", "core", core, "pid", pid)
+
+			if err = i.config.Cgroup.Join("cpuset", pid, false); err != nil {
+				i.config.Log.Errorw("failed to join the target cpuset cgroup", "error", err, "core", core, "pid", pid)
+
+				return
+			}
+
+			// prioritize the current process
+			i.config.Log.Infow("highering current process priority", "core", core, "pid", pid)
+
+			if err = i.config.ProcessManager.Prioritize(); err != nil {
+				i.config.Log.Errorw("error highering the current process priority", "error", err, "core", core, "pid", pid)
+
+				return
+			}
+
+			i.config.Log.Infow("starting the stresser", "core", core, "pid", pid)
+
+			tids = append(tids, pid)
+			i.routines++
+
+			wg.Done()
+			i.config.Stresser.Stress(i.config.StresserExit)
+		}(core)
 	}
 
-	// start eating CPU in separate goroutines
-	// we start one goroutine per available CPU
-	i.config.Log.Infow("initializing load generator routines", "routines", runtime.NumCPU())
+	// wait for stress routines to finish initializing
+	wg.Wait()
 
-	go i.config.Stresser.Stress(i.config.StresserExit)
+	if !succeeded {
+		return fmt.Errorf("at least one stresser routine failed to execute")
+	}
+
+	i.config.Log.Infow("all routines have been created successfully, now stressing", "routinesPID", tids)
 
 	return nil
 }
 
 func (i cpuPressureInjector) Clean() error {
-	// exit the stresser
-	i.config.StresserExit <- struct{}{}
+	i.config.Log.Info("killing routines")
+
+	// exit the stress routines
+	for r := 0; r < i.routines; r++ {
+		i.config.StresserExit <- struct{}{}
+	}
 
 	i.config.Log.Info("all routines has been killed, exiting")
 

--- a/injector/cpu_pressure_test.go
+++ b/injector/cpu_pressure_test.go
@@ -32,7 +32,8 @@ var _ = Describe("Failure", func() {
 	BeforeEach(func() {
 		// cgroup
 		cgroupManager = &cgroup.ManagerMock{}
-		cgroupManager.On("Join", mock.Anything, mock.Anything).Return(nil)
+		cgroupManager.On("Join", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		cgroupManager.On("Read", "cpuset", "cpuset.cpus").Return("0-1", nil)
 
 		// container
 		ctn = &container.ContainerMock{}
@@ -47,6 +48,7 @@ var _ = Describe("Failure", func() {
 		// manager
 		manager = &process.ManagerMock{}
 		manager.On("Prioritize").Return(nil)
+		manager.On("ThreadID").Return(666)
 
 		//config
 		config = CPUPressureInjectorConfig{
@@ -82,8 +84,10 @@ var _ = Describe("Failure", func() {
 			stresserExit <- struct{}{}
 		})
 
-		It("should join the CPU cgroup", func() {
-			cgroupManager.AssertCalled(GinkgoT(), "Join", "cpu", mock.Anything)
+		It("should join the cpu and cpuset cgroups", func() {
+			cgroupManager.AssertCalled(GinkgoT(), "Join", "cpu", 666, false)
+			cgroupManager.AssertCalled(GinkgoT(), "Join", "cpuset", 666, false)
+			cgroupManager.AssertNumberOfCalls(GinkgoT(), "Join", 4)
 		})
 
 		It("should prioritize the current process", func() {

--- a/process/process.go
+++ b/process/process.go
@@ -5,30 +5,8 @@
 
 package process
 
-import "syscall"
-
-const (
-	maxPriorityValue = -20
-)
-
 // Manager manages the current process
 type Manager interface {
 	Prioritize() error
-}
-
-type manager struct{}
-
-// NewManager creates a new process manager
-func NewManager() Manager {
-	return manager{}
-}
-
-// Prioritize set the priority of the current process group to the max value (-20)
-func (p manager) Prioritize() error {
-	pgid := syscall.Getpgrp()
-	if err := syscall.Setpriority(syscall.PRIO_PGRP, pgid, maxPriorityValue); err != nil {
-		return err
-	}
-
-	return nil
+	ThreadID() int
 }

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+package process
+
+import "syscall"
+
+const (
+	maxPriorityValue = -20
+)
+
+type manager struct{}
+
+// NewManager creates a new process manager
+func NewManager() Manager {
+	return manager{}
+}
+
+// Prioritize set the priority of the current process group to the max value (-20)
+func (p manager) Prioritize() error {
+	pgid := syscall.Getpgrp()
+	if err := syscall.Setpriority(syscall.PRIO_PGRP, pgid, maxPriorityValue); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ThreadID returns the caller thread PID
+func (p manager) ThreadID() int {
+	return syscall.Gettid()
+}

--- a/process/process_mock.go
+++ b/process/process_mock.go
@@ -18,3 +18,10 @@ func (f *ManagerMock) Prioritize() error {
 
 	return args.Error(0)
 }
+
+//nolint:golint
+func (f *ManagerMock) ThreadID() int {
+	args := f.Called()
+
+	return args.Int(0)
+}

--- a/process/process_other.go
+++ b/process/process_other.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+// +build !linux
+
+package process
+
+import "errors"
+
+type manager struct{}
+
+// NewManager creates a new process manager
+func NewManager() Manager {
+	return manager{}
+}
+
+// Prioritize set the priority of the current process group to the max value (-20)
+func (p manager) Prioritize() error {
+	return errors.New("unsupported")
+}
+
+// ThreadID returns the caller thread PID
+func (p manager) ThreadID() int {
+	return -1
+}

--- a/vendor/k8s.io/kubernetes/LICENSE
+++ b/vendor/k8s.io/kubernetes/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cpuset.go"],
+    importpath = "k8s.io/kubernetes/pkg/kubelet/cm/cpuset",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/klog:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["cpuset_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/OWNERS
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- derekwaynecarr
+- vishh
+- ConnorDoyle
+- sjenning

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/cpuset.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/cpuset.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpuset
+
+import (
+	"bytes"
+	"fmt"
+	"k8s.io/klog"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Builder is a mutable builder for CPUSet. Functions that mutate instances
+// of this type are not thread-safe.
+type Builder struct {
+	result CPUSet
+	done   bool
+}
+
+// NewBuilder returns a mutable CPUSet builder.
+func NewBuilder() Builder {
+	return Builder{
+		result: CPUSet{
+			elems: map[int]struct{}{},
+		},
+	}
+}
+
+// Add adds the supplied elements to the result. Calling Add after calling
+// Result has no effect.
+func (b Builder) Add(elems ...int) {
+	if b.done {
+		return
+	}
+	for _, elem := range elems {
+		b.result.elems[elem] = struct{}{}
+	}
+}
+
+// Result returns the result CPUSet containing all elements that were
+// previously added to this builder. Subsequent calls to Add have no effect.
+func (b Builder) Result() CPUSet {
+	b.done = true
+	return b.result
+}
+
+// CPUSet is a thread-safe, immutable set-like data structure for CPU IDs.
+type CPUSet struct {
+	elems map[int]struct{}
+}
+
+// NewCPUSet returns a new CPUSet containing the supplied elements.
+func NewCPUSet(cpus ...int) CPUSet {
+	b := NewBuilder()
+	for _, c := range cpus {
+		b.Add(c)
+	}
+	return b.Result()
+}
+
+// Size returns the number of elements in this set.
+func (s CPUSet) Size() int {
+	return len(s.elems)
+}
+
+// IsEmpty returns true if there are zero elements in this set.
+func (s CPUSet) IsEmpty() bool {
+	return s.Size() == 0
+}
+
+// Contains returns true if the supplied element is present in this set.
+func (s CPUSet) Contains(cpu int) bool {
+	_, found := s.elems[cpu]
+	return found
+}
+
+// Equals returns true if the supplied set contains exactly the same elements
+// as this set (s IsSubsetOf s2 and s2 IsSubsetOf s).
+func (s CPUSet) Equals(s2 CPUSet) bool {
+	return reflect.DeepEqual(s.elems, s2.elems)
+}
+
+// Filter returns a new CPU set that contains all of the elements from this
+// set that match the supplied predicate, without mutating the source set.
+func (s CPUSet) Filter(predicate func(int) bool) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		if predicate(cpu) {
+			b.Add(cpu)
+		}
+	}
+	return b.Result()
+}
+
+// FilterNot returns a new CPU set that contains all of the elements from this
+// set that do not match the supplied predicate, without mutating the source
+// set.
+func (s CPUSet) FilterNot(predicate func(int) bool) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		if !predicate(cpu) {
+			b.Add(cpu)
+		}
+	}
+	return b.Result()
+}
+
+// IsSubsetOf returns true if the supplied set contains all the elements
+func (s CPUSet) IsSubsetOf(s2 CPUSet) bool {
+	result := true
+	for cpu := range s.elems {
+		if !s2.Contains(cpu) {
+			result = false
+			break
+		}
+	}
+	return result
+}
+
+// Union returns a new CPU set that contains all of the elements from this
+// set and all of the elements from the supplied set, without mutating
+// either source set.
+func (s CPUSet) Union(s2 CPUSet) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		b.Add(cpu)
+	}
+	for cpu := range s2.elems {
+		b.Add(cpu)
+	}
+	return b.Result()
+}
+
+// Intersection returns a new CPU set that contains all of the elements
+// that are present in both this set and the supplied set, without mutating
+// either source set.
+func (s CPUSet) Intersection(s2 CPUSet) CPUSet {
+	return s.Filter(func(cpu int) bool { return s2.Contains(cpu) })
+}
+
+// Difference returns a new CPU set that contains all of the elements that
+// are present in this set and not the supplied set, without mutating either
+// source set.
+func (s CPUSet) Difference(s2 CPUSet) CPUSet {
+	return s.FilterNot(func(cpu int) bool { return s2.Contains(cpu) })
+}
+
+// ToSlice returns a slice of integers that contains all elements from
+// this set.
+func (s CPUSet) ToSlice() []int {
+	result := []int{}
+	for cpu := range s.elems {
+		result = append(result, cpu)
+	}
+	sort.Ints(result)
+	return result
+}
+
+// String returns a new string representation of the elements in this CPU set
+// in canonical linux CPU list format.
+//
+// See: http://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS
+func (s CPUSet) String() string {
+	if s.IsEmpty() {
+		return ""
+	}
+
+	elems := s.ToSlice()
+
+	type rng struct {
+		start int
+		end   int
+	}
+
+	ranges := []rng{{elems[0], elems[0]}}
+
+	for i := 1; i < len(elems); i++ {
+		lastRange := &ranges[len(ranges)-1]
+		// if this element is adjacent to the high end of the last range
+		if elems[i] == lastRange.end+1 {
+			// then extend the last range to include this element
+			lastRange.end = elems[i]
+			continue
+		}
+		// otherwise, start a new range beginning with this element
+		ranges = append(ranges, rng{elems[i], elems[i]})
+	}
+
+	// construct string from ranges
+	var result bytes.Buffer
+	for _, r := range ranges {
+		if r.start == r.end {
+			result.WriteString(strconv.Itoa(r.start))
+		} else {
+			result.WriteString(fmt.Sprintf("%d-%d", r.start, r.end))
+		}
+		result.WriteString(",")
+	}
+	return strings.TrimRight(result.String(), ",")
+}
+
+// MustParse CPUSet constructs a new CPU set from a Linux CPU list formatted
+// string. Unlike Parse, it does not return an error but rather panics if the
+// input cannot be used to construct a CPU set.
+func MustParse(s string) CPUSet {
+	res, err := Parse(s)
+	if err != nil {
+		klog.Fatalf("unable to parse [%s] as CPUSet: %v", s, err)
+	}
+	return res
+}
+
+// Parse CPUSet constructs a new CPU set from a Linux CPU list formatted string.
+//
+// See: http://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS
+func Parse(s string) (CPUSet, error) {
+	b := NewBuilder()
+
+	// Handle empty string.
+	if s == "" {
+		return b.Result(), nil
+	}
+
+	// Split CPU list string:
+	// "0-5,34,46-48 => ["0-5", "34", "46-48"]
+	ranges := strings.Split(s, ",")
+
+	for _, r := range ranges {
+		boundaries := strings.Split(r, "-")
+		if len(boundaries) == 1 {
+			// Handle ranges that consist of only one element like "34".
+			elem, err := strconv.Atoi(boundaries[0])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			b.Add(elem)
+		} else if len(boundaries) == 2 {
+			// Handle multi-element ranges like "0-5".
+			start, err := strconv.Atoi(boundaries[0])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			end, err := strconv.Atoi(boundaries[1])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			// Add all elements to the result.
+			// e.g. "0-5", "46-48" => [0, 1, 2, 3, 4, 5, 46, 47, 48].
+			for e := start; e <= end; e++ {
+				b.Add(e)
+			}
+		}
+	}
+	return b.Result(), nil
+}
+
+// Clone returns a copy of this CPU set.
+func (s CPUSet) Clone() CPUSet {
+	b := NewBuilder()
+	for elem := range s.elems {
+		b.Add(elem)
+	}
+	return b.Result()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -714,6 +714,8 @@ k8s.io/klog
 k8s.io/klog/v2
 # k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
 k8s.io/kube-openapi/pkg/util/proto
+# k8s.io/kubernetes v1.13.0
+k8s.io/kubernetes/pkg/kubelet/cm/cpuset
 # k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
 k8s.io/utils/buffer
 k8s.io/utils/integer


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior: the CPU pressure now relies on the `cpuset` allocated CPUs, and it also manages threads at the injector level instead of at the stresser level.

Motivation for change: relying on the target `cpuset` cgroup to pin the stress threads on specific cores ensures us that the stress will occur on cores actually used by the target. For instance, let's take a container with only 2 allocated cores on a 4 cores node: if the injector pod is not pinned on the same cores, it could eventually stress the 2 other cores which is totally useless. When stressing the node itself, if the injector pod is contained on only 2 cores, it won't be able to stress all cores as well.

The second motivation to manage stress threads in the injector itself is because it was buggy with a multi-container pod as a target: the injector was moving the thread group leader in the target CPU cgroup, which moves all threads of the injector process to this cgroup. With a multi-container pod, because we create one injector per container, all threads were moved from one target to another until the last one of the list. It also fixes this bug.

## Code Quality

### Testing

- [x] I used existing unit tests
- [x] I manually tested locally
- [x] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [x] The documentation is up to date
- [x] My code is sufficiently commented
- [x] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
