### PR TITLE
Fix network disruption failing to be injected on a node with multiple…

### DIFF
--- a/injector/network_disruption_test.go
+++ b/injector/network_disruption_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Failure", func() {
 		nl.On("LinkByName", "lo").Return(nllink1, nil)
 		nl.On("LinkByName", "eth0").Return(nllink2, nil)
 		nl.On("LinkByName", "eth1").Return(nllink3, nil)
-		nl.On("DefaultRoute").Return(nlroute2, nil)
+		nl.On("DefaultRoutes").Return([]network.NetlinkRoute{nlroute2}, nil)
 
 		// dns
 		dns = &network.DNSMock{}

--- a/network/netlink_mock.go
+++ b/network/netlink_mock.go
@@ -38,10 +38,10 @@ func (f *NetlinkAdapterMock) LinkByName(name string) (NetlinkLink, error) {
 }
 
 //nolint:golint
-func (f *NetlinkAdapterMock) DefaultRoute() (NetlinkRoute, error) {
+func (f *NetlinkAdapterMock) DefaultRoutes() ([]NetlinkRoute, error) {
 	args := f.Called()
 
-	return args.Get(0).(NetlinkRoute), args.Error(1)
+	return args.Get(0).([]NetlinkRoute), args.Error(1)
 }
 
 // NetlinkLinkMock is a mock implementation of the NetlinkLink interface


### PR DESCRIPTION
… default routes

## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior: the netlink adapter now returns all possible default routes instead of the first found one only.

Motivation for change: we recently changed the behavior of routes listing in the netlink adapter from listing routes in the default routing table to listing all routes in all routing tables. It can happen that a node has multiple default routes in different routing tables. In this case, only the first found one was taken which could lead to unexpected behaviors.

## Code Quality

### Testing

- [x] I used existing unit tests
- [x] I manually tested locally
- [x] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [x] The documentation is up to date
- [x] My code is sufficiently commented
- [x] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
