### PR TITLE
Add a --handler-enabled flag to the controller

### DIFF
--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -48,7 +48,7 @@ func (r *Disruption) ValidateCreate() error {
 
 	// handle a disruption using the onInit feature without the handler being enabled
 	if !handlerEnabled && r.Spec.OnInit {
-		return errors.New("the chaos handler is disabled but the disruption onInit field is set to true, please enable the handler by specifying the --handler-enabled flag to the controller if you want to use the onInit feature")
+		return errors.New("the chaos handler is disabled but the disruption onInit field is set to true, please enable the handler by specifying the --handler-enabled flag to the controller if you want to use the onInit feature (requires Kubernetes >= 1.15)")
 	}
 
 	if err := r.Spec.Validate(); err != nil {

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
         - --enable-leader-election
         - --metrics-sink={{ .Values.controller.metricsSink }}
         - --injector-image={{ .Values.images.injector }}:{{ .Values.images.tag }}
+        {{- if .Values.handler.enabled }}
+        - --handler-enabled
+        {{- end }}
         - --handler-image={{ .Values.images.handler }}:{{ .Values.images.tag }}
         - --handler-timeout={{ .Values.handler.timeout }}
         {{- if .Values.images.pullSecrets }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,4 +25,5 @@ injector:
   serviceAccountNamespace: chaos-engineering # namespace where the service account can be found (NOTE: changing this will change the namespace in which the chaos pods are created)
 
 handler:
+  enabled: true # enable the chaos handler (required to use the onInit disruption feature)
   timeout: 1m # time the handler init container will wait before exiting if no signal is received

--- a/docs/features.md
+++ b/docs/features.md
@@ -35,6 +35,8 @@ By default, a disruption affects all containers within the pod. You can restrict
 ## Applying a disruption on pod initialization
 
 > :memo: This mode has some restrictions:
+>   * it requires a 1.15+ Kubernetes cluster
+>   * it requires the `--handler-enabled` flag on the controller container
 >   * it only works for network related (network and dns) disruptions
 >   * it only works with the pod level
 >   * it does not support containers scoping (applying a disruption to only some containers)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,4 +69,27 @@ Internal error occurred: failed calling webhook "chaos-controller-webhook-servic
 You can try disabling the Istio injection on the chaos controller pods. This can be done by adding the following annotation to the Deployment:
 ```
 sidecar.istio.io/inject: "false"
+
+### Handler
+
+The handler container is used to provide the `onInit` disruption feature. It is injected as the first init containers of the targeted pod by the admission webhook on its creation and keeps the pod in the initialization state until an injector unlocks it. It can be enabled with this flag.
+
+```
+--handler-enabled
+```
+
+#### Handler image
+
+The handler image can be specified via this flag.
+
+```
+--handler-image <image>
+```
+
+#### Handler timeout
+
+The handler container can have a timeout to avoid keeping the targeted pod indefinitely in case an error occurs with the injector.
+
+```
+--handler-timeout <duration>
 ```

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 		injectorServiceAccount          string
 		injectorServiceAccountNamespace string
 		injectorImage                   string
+		handlerEnabled                  bool
 		handlerImage                    string
 		handlerTimeout                  time.Duration
 		imagePullSecrets                string
@@ -77,6 +78,7 @@ func main() {
 	pflag.StringVar(&injectorServiceAccount, "injector-service-account", "chaos-injector", "Service account to use for the generated injector pods")
 	pflag.StringVar(&injectorServiceAccountNamespace, "injector-service-account-namespace", "chaos-engineering", "Namespace of the service account to use for the generated injector pods. Should also host the controller.")
 	pflag.StringVar(&injectorImage, "injector-image", "chaos-injector", "Image to pull for the injector pods")
+	pflag.BoolVar(&handlerEnabled, "handler-enabled", false, "Enable the chaos handler for on-init disruptions")
 	pflag.StringVar(&handlerImage, "handler-image", "chaos-handler", "Image to pull for the handler containers")
 	pflag.DurationVar(&handlerTimeout, "handler-timeout", time.Minute, "Handler init container timeout")
 	pflag.StringVar(&imagePullSecrets, "image-pull-secrets", "", "Secrets used for pulling the Docker image from a private registry")
@@ -148,7 +150,7 @@ func main() {
 	go r.ReportMetrics()
 
 	// register disruption validating webhook
-	if err = (&chaosv1beta1.Disruption{}).SetupWebhookWithManager(mgr, logger, ms, deleteOnly); err != nil {
+	if err = (&chaosv1beta1.Disruption{}).SetupWebhookWithManager(mgr, logger, ms, deleteOnly, handlerEnabled); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Disruption")
 		os.Exit(1)
 	}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior: it adds a `--handler-enabled` flag to enable (or disable) the handler. When it is disabled, the admission controller will reject any disruption created with the `onInit: true`.

Motivation for change: the `onInit` function is not available on clusters with a Kubernetes version lower than 1.15 because you can't filter on objects caught by the admission webhook. This flag allows users to disable the feature if they want to run the controller on old clusters by rejecting requests trying to create disruptions using the feature.

## Code Quality

### Testing

- [ ] I used existing unit tests
- [x] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [x] The documentation is up to date
- [x] My code is sufficiently commented
- [x] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
