### PR TITLE
Add a way to exclude hosts from network disruptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ minikube-build-manager: minikube-ssh-host manager
 	docker build -t ${MANAGER_IMAGE} -f bin/manager/Dockerfile ./bin/manager/
 	rm -f out/manager.tar
 	docker save -o out/manager.tar ${MANAGER_IMAGE}
-	scp -i $$(minikube ssh-key) -o StrictHostKeyChecking=no out/manager.tar docker@$$(minikube ip):/tmp
+	scp -o IdentitiesOnly=yes -i $$(minikube ssh-key) -o StrictHostKeyChecking=no out/manager.tar docker@$$(minikube ip):/tmp
 	minikube ssh -- sudo ctr -n=k8s.io images import /tmp/manager.tar
 
 minikube-build-injector: minikube-ssh-host injector
@@ -76,7 +76,7 @@ minikube-build-injector: minikube-ssh-host injector
 	docker build -t ${INJECTOR_IMAGE} -f bin/injector/Dockerfile ./bin/injector/
 	rm -f out/injector.tar
 	docker save -o out/injector.tar ${INJECTOR_IMAGE}
-	scp -i $$(minikube ssh-key) -o StrictHostKeyChecking=no out/injector.tar docker@$$(minikube ip):/tmp
+	scp -o IdentitiesOnly=yes -i $$(minikube ssh-key) -o StrictHostKeyChecking=no out/injector.tar docker@$$(minikube ip):/tmp
 	minikube ssh -- sudo ctr -n=k8s.io images import /tmp/injector.tar
 
 minikube-build-handler: minikube-ssh-host handler
@@ -84,7 +84,7 @@ minikube-build-handler: minikube-ssh-host handler
 	docker build -t ${HANDLER_IMAGE} -f bin/handler/Dockerfile ./bin/handler/
 	rm -f out/handler.tar
 	docker save -o out/handler.tar ${HANDLER_IMAGE}
-	scp -i $$(minikube ssh-key) -o StrictHostKeyChecking=no out/handler.tar docker@$$(minikube ip):/tmp
+	scp -o IdentitiesOnly=yes -i $$(minikube ssh-key) -o StrictHostKeyChecking=no out/handler.tar docker@$$(minikube ip):/tmp
 	minikube ssh -- sudo ctr -n=k8s.io images import /tmp/handler.tar
 
 minikube-build: minikube-build-manager minikube-build-injector minikube-build-handler

--- a/api/disruption_kind.go
+++ b/api/disruption_kind.go
@@ -20,8 +20,8 @@ type DisruptionKind interface {
 	Validate() error
 }
 
-// AppendCommonArgs is a helper function generating common args and appending them to the given args array
-func AppendCommonArgs(args []string, level chaostypes.DisruptionLevel, kind chaostypes.DisruptionKindName, containerIDs []string, sink string, dryRun bool,
+// AppendArgs is a helper function generating common and global args and appending them to the given args array
+func AppendArgs(args []string, level chaostypes.DisruptionLevel, kind chaostypes.DisruptionKindName, containerIDs []string, sink string, dryRun bool,
 	disruptionName string, disruptionNamespace string, targetName string, onInit bool, allowedHosts []string) []string {
 	args = append(args,
 		// basic args

--- a/api/disruption_kind.go
+++ b/api/disruption_kind.go
@@ -21,8 +21,8 @@ type DisruptionKind interface {
 }
 
 // AppendCommonArgs is a helper function generating common args and appending them to the given args array
-func AppendCommonArgs(args []string, level chaostypes.DisruptionLevel, containerIDs []string, sink string, dryRun bool,
-	disruptionName string, disruptionNamespace string, targetName string, onInit bool) []string {
+func AppendCommonArgs(args []string, level chaostypes.DisruptionLevel, kind chaostypes.DisruptionKindName, containerIDs []string, sink string, dryRun bool,
+	disruptionName string, disruptionNamespace string, targetName string, onInit bool, allowedHosts []string) []string {
 	args = append(args,
 		// basic args
 		"--metrics-sink", sink,
@@ -43,6 +43,13 @@ func AppendCommonArgs(args []string, level chaostypes.DisruptionLevel, container
 	// enable chaos handler init container notification
 	if onInit {
 		args = append(args, "--on-init")
+	}
+
+	// append allowed hosts for network disruptions
+	if kind == chaostypes.DisruptionKindNetworkDisruption {
+		for _, host := range allowedHosts {
+			args = append(args, "--allowed-hosts", host)
+		}
 	}
 
 	return args

--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -143,7 +143,7 @@ func (s *NetworkDisruptionSpec) GenerateArgs() []string {
 // NetworkDisruptionHostSpecFromString parses the given hosts to host specs
 // The expected format for hosts is <host>;<port>;<protocol>
 func NetworkDisruptionHostSpecFromString(hosts []string) ([]NetworkDisruptionHostSpec, error) {
-	var parsedHosts []NetworkDisruptionHostSpec
+	parsedHosts := []NetworkDisruptionHostSpec{}
 
 	// parse given hosts
 	for _, host := range hosts {
@@ -170,7 +170,7 @@ func NetworkDisruptionHostSpecFromString(hosts []string) ([]NetworkDisruptionHos
 // NetworkDisruptionServiceSpecFromString parses the given services to service specs
 // The expected format for services is <serviceName>;<serviceNamespace>
 func NetworkDisruptionServiceSpecFromString(services []string) ([]NetworkDisruptionServiceSpec, error) {
-	var parsedServices []NetworkDisruptionServiceSpec
+	parsedServices := []NetworkDisruptionServiceSpec{}
 
 	// parse given services
 	for _, service := range services {

--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -22,6 +23,8 @@ const (
 type NetworkDisruptionSpec struct {
 	// +nullable
 	Hosts []NetworkDisruptionHostSpec `json:"hosts,omitempty"`
+	// +nullable
+	AllowedHosts []NetworkDisruptionHostSpec `json:"allowedHosts,omitempty"`
 	// +nullable
 	Services []NetworkDisruptionServiceSpec `json:"services,omitempty"`
 	// +kubebuilder:validation:Enum=egress;ingress
@@ -119,6 +122,11 @@ func (s *NetworkDisruptionSpec) GenerateArgs() []string {
 		args = append(args, "--hosts", fmt.Sprintf("%s;%d;%s", host.Host, host.Port, host.Protocol))
 	}
 
+	// append allowed hosts
+	for _, host := range s.AllowedHosts {
+		args = append(args, "--allowed-hosts", fmt.Sprintf("%s;%d;%s", host.Host, host.Port, host.Protocol))
+	}
+
 	// append services
 	for _, service := range s.Services {
 		args = append(args, "--services", fmt.Sprintf("%s;%s", service.Name, service.Namespace))
@@ -130,4 +138,54 @@ func (s *NetworkDisruptionSpec) GenerateArgs() []string {
 	}
 
 	return args
+}
+
+// NetworkDisruptionHostSpecFromString parses the given hosts to host specs
+// The expected format for hosts is <host>;<port>;<protocol>
+func NetworkDisruptionHostSpecFromString(hosts []string) ([]NetworkDisruptionHostSpec, error) {
+	var parsedHosts []NetworkDisruptionHostSpec
+
+	// parse given hosts
+	for _, host := range hosts {
+		// parse host with format <host>;<port>;<protocol>
+		parsedHost := strings.SplitN(host, ";", 3)
+
+		// cast port to int
+		port, err := strconv.Atoi(parsedHost[1])
+		if err != nil {
+			return nil, fmt.Errorf("unexpected port parameter in %s: %v", host, err)
+		}
+
+		// generate host spec
+		parsedHosts = append(parsedHosts, NetworkDisruptionHostSpec{
+			Host:     parsedHost[0],
+			Port:     port,
+			Protocol: parsedHost[2],
+		})
+	}
+
+	return parsedHosts, nil
+}
+
+// NetworkDisruptionServiceSpecFromString parses the given services to service specs
+// The expected format for services is <serviceName>;<serviceNamespace>
+func NetworkDisruptionServiceSpecFromString(services []string) ([]NetworkDisruptionServiceSpec, error) {
+	var parsedServices []NetworkDisruptionServiceSpec
+
+	// parse given services
+	for _, service := range services {
+		// parse service with format <name>;<namespace>
+		parsedService := strings.Split(service, ";")
+		if len(parsedService) != 2 {
+			return nil, fmt.Errorf("unexpected service format: %s", service)
+		}
+
+		// generate service spec
+		parsedServices = append(parsedServices, NetworkDisruptionServiceSpec{
+			Name:      parsedService[0],
+			Namespace: parsedService[1],
+		})
+	}
+
+	return parsedServices, nil
 }

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -316,6 +316,11 @@ func (in *NetworkDisruptionSpec) DeepCopyInto(out *NetworkDisruptionSpec) {
 		*out = make([]NetworkDisruptionHostSpec, len(*in))
 		copy(*out, *in)
 	}
+	if in.AllowedHosts != nil {
+		in, out := &in.AllowedHosts, &out.AllowedHosts
+		*out = make([]NetworkDisruptionHostSpec, len(*in))
+		copy(*out, *in)
+	}
 	if in.Services != nil {
 		in, out := &in.Services, &out.Services
 		*out = make([]NetworkDisruptionServiceSpec, len(*in))

--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -108,6 +108,24 @@ spec:
               description: NetworkDisruptionSpec represents a network disruption injection
               nullable: true
               properties:
+                allowedHosts:
+                  items:
+                    properties:
+                      host:
+                        type: string
+                      port:
+                        maximum: 65535
+                        minimum: 0
+                        type: integer
+                      protocol:
+                        enum:
+                        - tcp
+                        - udp
+                        - ""
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
                 bandwidthLimit:
                   minimum: 0
                   type: integer

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
         {{- end }}
         - --injector-service-account={{ .Values.injector.serviceAccount }}
         - --injector-service-account-namespace={{ .Values.injector.serviceAccountNamespace }}
+        {{- range .Values.injector.networkDisruption.allowedHosts }}
+        - --injector-network-disruption-allowed-hosts={{ .host }};{{ .port }};{{ .protocol }}
+        {{- end }}
         {{- if .Values.controller.webhook.generateCert }}
         - --admission-webhook-cert-dir=/tmp/k8s-webhook-server/serving-certs
         {{- else }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -23,6 +23,13 @@ injector:
   annotations: {} # extra annotations passed to the chaos injector pods
   serviceAccount: chaos-injector # service account to use for the chaos injector pods
   serviceAccountNamespace: chaos-engineering # namespace where the service account can be found (NOTE: changing this will change the namespace in which the chaos pods are created)
+  networkDisruption: # network disruption general configuration
+    allowedHosts: [] # list of always allowed hosts (even if explicitly blocked by a network disruption)
+    # (here's the expected format, all fields are optional)
+    # allowedHosts:
+    #   - host: 10.0.0.0/8
+    #     port: 80
+    #     protocol: tcp
 
 handler:
   enabled: true # enable the chaos handler (required to use the onInit disruption feature)

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -62,17 +62,18 @@ var (
 // DisruptionReconciler reconciles a Disruption object
 type DisruptionReconciler struct {
 	client.Client
-	BaseLog                         *zap.SugaredLogger
-	Scheme                          *runtime.Scheme
-	Recorder                        record.EventRecorder
-	MetricsSink                     metrics.Sink
-	TargetSelector                  TargetSelector
-	InjectorAnnotations             map[string]string
-	InjectorServiceAccount          string
-	InjectorImage                   string
-	ImagePullSecrets                string
-	log                             *zap.SugaredLogger
-	InjectorServiceAccountNamespace string
+	BaseLog                               *zap.SugaredLogger
+	Scheme                                *runtime.Scheme
+	Recorder                              record.EventRecorder
+	MetricsSink                           metrics.Sink
+	TargetSelector                        TargetSelector
+	InjectorAnnotations                   map[string]string
+	InjectorServiceAccount                string
+	InjectorImage                         string
+	ImagePullSecrets                      string
+	log                                   *zap.SugaredLogger
+	InjectorServiceAccountNamespace       string
+	InjectorNetworkDisruptionAllowedHosts []string
 }
 
 // +kubebuilder:rbac:groups=chaos.datadoghq.com,resources=disruptions,verbs=get;list;watch;create;update;patch;delete
@@ -902,8 +903,8 @@ func (r *DisruptionReconciler) generateChaosPods(instance *chaosv1beta1.Disrupti
 
 		// generate args for pod
 		args := chaosapi.AppendCommonArgs(subspec.GenerateArgs(),
-			level, containerIDs, r.MetricsSink.GetSinkName(), instance.Spec.DryRun,
-			instance.Name, instance.Namespace, targetName, instance.Spec.OnInit)
+			level, kind, containerIDs, r.MetricsSink.GetSinkName(), instance.Spec.DryRun,
+			instance.Name, instance.Namespace, targetName, instance.Spec.OnInit, r.InjectorNetworkDisruptionAllowedHosts)
 
 		// append pod to chaos pods
 		*pods = append(*pods, r.generatePod(instance, targetName, targetNodeName, args, kind))

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -902,7 +902,7 @@ func (r *DisruptionReconciler) generateChaosPods(instance *chaosv1beta1.Disrupti
 		}
 
 		// generate args for pod
-		args := chaosapi.AppendCommonArgs(subspec.GenerateArgs(),
+		args := chaosapi.AppendArgs(subspec.GenerateArgs(),
 			level, kind, containerIDs, r.MetricsSink.GetSinkName(), instance.Spec.DryRun,
 			instance.Name, instance.Namespace, targetName, instance.Spec.OnInit, r.InjectorNetworkDisruptionAllowedHosts)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,7 +38,7 @@ The injector image to use can be specified via this flag and can be useful in ca
 
 ### Injector network disruption allowed hosts
 
-As explained [in the network disruption documentation](../docs/network_disruption_hosts.md), you can globally (for all network disruptions) exclude some hosts from network disruptions. This list of host can be specified with the `--injector-network-disruption-allowed-hosts` flag:
+As explained [in the network disruption documentation](../docs/network_disruption_hosts.md), you can globally (for all network disruptions) exclude some hosts from network disruptions. This list of hosts can be specified with the `--injector-network-disruption-allowed-hosts` flag:
 
 ```
 --injector-network-disruption-allowed-hosts 10.0.0.1;53;udp

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,6 +36,14 @@ The injector image to use can be specified via this flag and can be useful in ca
 --injector-image <image>
 ```
 
+### Injector network disruption allowed hosts
+
+As explained [in the network disruption documentation](../docs/network_disruption_hosts.md), you can globally (for all network disruptions) exclude some hosts from network disruptions. This list of host can be specified with the `--injector-network-disruption-allowed-hosts` flag:
+
+```
+--injector-network-disruption-allowed-hosts 10.0.0.1;53;udp
+```
+
 ### Image Pull Secrets
 
 To [pull the Docker images from a private registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry) which is behind authentication you can create a Kubernetes Secret and set the flag below:

--- a/docs/network_disruption_hosts.md
+++ b/docs/network_disruption_hosts.md
@@ -32,6 +32,26 @@ network:
       namespace: example_namespace
 ```
 
+## Q: How can I exclude some hosts from being disrupted?
+
+It is sometimes handy to disrupt all packets going to a whole CIDR but excluding some of them. You have two ways to exclude some hosts from being disrupted in a network disruption:
+* from the disruption itself, so it applies to this disruption only
+* from the controller, so it applies to all network disruptions even when not specified explicitly
+
+### From the disruption
+
+You can specify hosts to exclude in the `allowedHosts` field of a network disruption with the same format as the `hosts` field. [Here's an example illustrating that](../examples/network_allowed_hosts.yaml).
+
+### From the controller
+
+You can pass a flag to the controller to specify hosts which would be excluded from all disruptions even when not specified in the disruption itself. The flag to use is `--injector-network-disruption-allowed-hosts` and has the same format as the flag passed to the injector container: `<host>;<port>;<protocol>`.
+
+```
+--injector-network-disruption-allowed-hosts 10.0.0.1;53;udp
+```
+
+It can be configured easily [in the chart values.yaml file](../chart/values.yaml).
+
 ## Notation
 
 Although the `hosts` field is handled in the same way for both pod and node level disruptions, different network interfaces may be targeted based node configurations. For example, pods that have their own networking interface work differently than pods that use their hosts' networking directly:

--- a/examples/complete.yaml
+++ b/examples/complete.yaml
@@ -25,6 +25,10 @@ spec:
       - host: 10.0.0.0/8 # optional, IP, CIDR or hostname to filter on
         port: 80 # optional, port to drop packets on
         protocol: tcp # optional, protocol to drop packets on (can be tcp or udp, defaults to both)
+    allowedHosts: # optional, list of excluded hosts which would not be disrupted
+      - host: 10.0.0.1 # optional, IP, CIDR or hostname to filter on
+        port: 80 # optional, port to filter on
+        protocol: tcp # optional, protocol to filter on (can be tcp or udp, defaults to both)
     services: # optional, list of destination Kubernetes services to filter on
       - name: foo # service name
         namespace: bar # service namespace

--- a/examples/demo.yaml
+++ b/examples/demo.yaml
@@ -60,6 +60,12 @@ spec:
       containers:
       - name: nginx
         image: nginx
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 3
+          periodSeconds: 3
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/network_allowed_hosts.yaml
+++ b/examples/network_allowed_hosts.yaml
@@ -1,0 +1,23 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+apiVersion: chaos.datadoghq.com/v1beta1
+kind: Disruption
+metadata:
+  name: network-drop
+  namespace: chaos-demo
+spec:
+  level: pod
+  selector:
+    app: demo-curl
+  count: 1
+  network:
+    drop: 100 # percentage of outgoing packets to drop
+    hosts: # optional, list of destination hosts to filter on
+      - host: 10.0.0.0/8 # optional, IP, CIDR or hostname to filter on
+        port: 80 # optional, port to drop packets on
+        protocol: tcp # optional, protocol to drop packets on (can be tcp or udp, defaults to both)
+    allowedHosts: # optional, list of excluded hosts which would not be disrupted
+      - host: 10.0.0.1 # optional, IP, CIDR or hostname to filter on

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -343,7 +343,7 @@ func (i *networkDisruptionInjector) applyOperations() error {
 
 	// add filters for allowed hosts
 	if err := i.addFiltersForHosts(interfaces, i.spec.AllowedHosts, "1:1"); err != nil {
-		return fmt.Errorf("error adding filter for alloed hosts: %w", err)
+		return fmt.Errorf("error adding filter for allowed hosts: %w", err)
 	}
 
 	return nil

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -23,12 +23,6 @@ import (
 // linkOperation represents a tc operation on a set of network interfaces combined with the parent to bind to and the handle identifier to use
 type linkOperation func([]string, string, uint32) error
 
-type ipPortProtocol struct {
-	IP       *net.IPNet
-	Port     int
-	Protocol string
-}
-
 // networkDisruptionService describes a parsed Kubernetes service, representing an (ip, port, protocol) tuple
 type networkDisruptionService struct {
 	ip       *net.IPNet
@@ -415,8 +409,10 @@ func (i *networkDisruptionInjector) addFiltersForServices(interfaces []string, f
 
 	for _, service := range services {
 		// handle flow direction
-		var srcPort, dstPort int
-		var srcIP, dstIP *net.IPNet
+		var (
+			srcPort, dstPort int
+			srcIP, dstIP     *net.IPNet
+		)
 
 		switch i.spec.Flow {
 		case v1beta1.FlowEgress:
@@ -447,8 +443,10 @@ func (i *networkDisruptionInjector) addFiltersForHosts(interfaces []string, host
 
 		for _, ip := range ips {
 			// handle flow direction
-			var srcPort, dstPort int
-			var srcIP, dstIP *net.IPNet
+			var (
+				srcPort, dstPort int
+				srcIP, dstIP     *net.IPNet
+			)
 
 			switch i.spec.Flow {
 			case v1beta1.FlowEgress:


### PR DESCRIPTION
## What does this PR do?

- [x] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior: it adds two ways to exclude hosts from a network disruption (from the disruption itself, or from the controller so it is applied for all network disruptions).

Motivation for change: we sometimes need to disrupt a whole CIDR except one or two IPs which is not doable currently.

## Code Quality

### Testing

- [x] I used existing unit tests
- [x] I manually tested locally
- [x] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [x] The documentation is up to date
- [x] My code is sufficiently commented
- [x] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
