### PR TITLE
Store request user info in disruption status on create

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -26,6 +26,7 @@ import (
 
 	chaosapi "github.com/DataDog/chaos-controller/api"
 	chaostypes "github.com/DataDog/chaos-controller/types"
+	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -67,6 +68,8 @@ type DisruptionStatus struct {
 	Targets []string `json:"targets,omitempty"`
 	// +nullable
 	IgnoredTargets []string `json:"ignoredTargets,omitempty"`
+	// +nullable
+	UserInfo *authv1.UserInfo `json:"userInfo,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -20,6 +20,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -243,6 +244,11 @@ func (in *DisruptionStatus) DeepCopyInto(out *DisruptionStatus) {
 		in, out := &in.IgnoredTargets, &out.IgnoredTargets
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.UserInfo != nil {
+		in, out := &in.UserInfo, &out.UserInfo
+		*out = new(v1.UserInfo)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -216,6 +216,34 @@ spec:
                 type: string
               nullable: true
               type: array
+            userInfo:
+              description: UserInfo holds the information about the user needed to
+                implement the user.Info interface.
+              nullable: true
+              properties:
+                extra:
+                  additionalProperties:
+                    description: ExtraValue masks the value so protobuf can generate
+                    items:
+                      type: string
+                    type: array
+                  description: Any additional information provided by the authenticator.
+                  type: object
+                groups:
+                  description: The names of groups this user is a part of.
+                  items:
+                    type: string
+                  type: array
+                uid:
+                  description: A unique value that identifies this user across time.
+                    If this user is deleted and another user by the same name is added,
+                    they will have different UIDs.
+                  type: string
+                username:
+                  description: The name that uniquely identifies this user among all
+                    active users.
+                  type: string
+              type: object
           type: object
       type: object
   version: v1beta1

--- a/chart/templates/webhook.yaml
+++ b/chart/templates/webhook.yaml
@@ -75,6 +75,37 @@ webhooks:
     resources:
     - pods
 ---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+  {{- if not .Values.controller.webhook.generateCert }}
+    cert-manager.io/inject-ca-from: chaos-engineering/chaos-controller-serving-cert
+  {{- end }}
+  name: chaos-controller-disruption-user-info
+webhooks:
+- clientConfig:
+  {{- if not .Values.controller.webhook.generateCert }}
+    caBundle: Cg==
+  {{- else }}
+    caBundle: {{ b64enc $ca.Cert }}
+  {{- end }}
+    service:
+      name: chaos-controller-webhook-service
+      namespace: chaos-engineering
+      path: /mutate-chaos-datadoghq-com-v1beta1-disruption-user-info
+  failurePolicy: Fail
+  name: chaos-controller-admission-webhook.chaos-engineering.svc
+  rules:
+  - apiGroups:
+    - "chaos.datadoghq.com"
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    resources:
+    - disruptions
+---
 {{- if not .Values.controller.webhook.generateCert }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate

--- a/main.go
+++ b/main.go
@@ -165,6 +165,14 @@ func main() {
 		},
 	})
 
+	// register user info mutating webhook
+	mgr.GetWebhookServer().Register("/mutate-chaos-datadoghq-com-v1beta1-disruption-user-info", &webhook.Admission{
+		Handler: &chaoswebhook.UserInfoMutator{
+			Client: mgr.GetClient(),
+			Log:    logger,
+		},
+	})
+
 	// +kubebuilder:scaffold:builder
 
 	logger.Infow("restarting chaos-controller")

--- a/webhook/user_info.go
+++ b/webhook/user_info.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/DataDog/chaos-controller/api/v1beta1"
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type UserInfoMutator struct {
+	Client  client.Client
+	Log     *zap.SugaredLogger
+	decoder *admission.Decoder
+}
+
+func (m *UserInfoMutator) InjectDecoder(d *admission.Decoder) error {
+	m.decoder = d
+
+	return nil
+}
+
+func (m *UserInfoMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	dis := &v1beta1.Disruption{}
+
+	// ensure decoder is set
+	if m.decoder == nil {
+		m.Log.Errorw("webhook decoder seems to be nil while it should not, aborting")
+
+		return admission.Errored(http.StatusInternalServerError, nil)
+	}
+
+	// decode object
+	err := m.decoder.Decode(req, dis)
+	if err != nil {
+		m.Log.Errorw("error decoding disruption object", "error", err, "name", req.Name, "namespace", req.Namespace)
+
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// retrieve user info
+	m.Log.Infow("storing user info in disrution", "name", dis.Name, "namespace", dis.Namespace)
+
+	dis.Status.UserInfo = &req.UserInfo
+
+	marshaled, err := json.Marshal(dis)
+	if err != nil {
+		m.Log.Errorw("error encoding modified disruption object", "error", err, "name", dis.Name, "namespace", dis.Namespace)
+
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
+}


### PR DESCRIPTION
## What does this PR do?

- [x] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior: we now store the user info contained in the creation request of disruptions. Those data contain, for instance, the username of the one who created the disruption. It can be re-used later to reach out to this user (through Slack?).

Motivation for change: get more disruption creation context.

## Code Quality

### Testing

- [ ] I used existing unit tests
- [x] I manually tested locally
- [x] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [x] The documentation is up to date
- [x] My code is sufficiently commented
- [x] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
