### PR TITLE
Move controller configuration to a configmap

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,48 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chaos-controller-config
+  namespace: chaos-engineering
+data:
+  config.yaml: |
+    controller:
+      metricsAddr: "127.0.0.1:8080"
+      leaderElection: true
+      metricsSink: {{ .Values.controller.metricsSink | quote }}
+      deleteOnly: {{ .Values.controller.deleteOnly }}
+      imagePullSecrets: {{ .Values.images.pullSecrets }}
+      webhook:
+        {{- if .Values.controller.webhook.generateCert }}
+        certDir: /tmp/k8s-webhook-server/serving-certs
+        {{- else }}
+        certDir: {{ .Values.controller.webhook.certDir | quote }}
+        {{- end }}
+        host: {{ .Values.controller.webhook.host | quote }}
+        port: {{ .Values.controller.webhook.port }}
+    injector:
+      image: {{ .Values.images.injector | quote }}
+      {{- if .Values.injector.annotations }}
+      annotations:
+        {{- range $key, $val := .Values.injector.annotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+      {{- end }}
+      serviceAccount:
+        name: {{ .Values.injector.serviceAccount | quote }}
+        namespace: {{ .Values.injector.serviceAccountNamespace | quote }}
+      {{- if .Values.injector.networkDisruption.allowedHosts }}
+      networkDisruption:
+        allowedHosts:
+          {{- range $index, $allowedHost := .Values.injector.networkDisruption.allowedHosts }}
+          - {{ printf "%s;%v;%s" ($allowedHost.host | default "") ($allowedHost.port | default "") ($allowedHost.protocol | default "") | quote }}
+          {{- end }}
+      {{- end }}
+    handler:
+      enabled: {{ .Values.handler.enabled }}
+      image: {{ .Values.images.handler | quote }}
+      timeout: {{ .Values.handler.timeout | quote }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -36,37 +36,7 @@ spec:
         command:
         - /usr/local/bin/manager
         args:
-        - --metrics-addr=127.0.0.1:8080
-        - --enable-leader-election
-        - --metrics-sink={{ .Values.controller.metricsSink }}
-        - --injector-image={{ .Values.images.injector }}:{{ .Values.images.tag }}
-        {{- if .Values.handler.enabled }}
-        - --handler-enabled
-        {{- end }}
-        - --handler-image={{ .Values.images.handler }}:{{ .Values.images.tag }}
-        - --handler-timeout={{ .Values.handler.timeout }}
-        {{- if .Values.images.pullSecrets }}
-        - --image-pull-secrets={{ .Values.images.pullSecrets }}
-        {{- end }}
-        {{- if .Values.controller.deleteOnly }}
-        - --delete-only
-        {{- end }}
-        {{- range $key, $val := .Values.injector.annotations }}
-        - --injector-annotations
-        - {{ $key }}={{ $val }}
-        {{- end }}
-        - --injector-service-account={{ .Values.injector.serviceAccount }}
-        - --injector-service-account-namespace={{ .Values.injector.serviceAccountNamespace }}
-        {{- range .Values.injector.networkDisruption.allowedHosts }}
-        - --injector-network-disruption-allowed-hosts={{ .host }};{{ .port }};{{ .protocol }}
-        {{- end }}
-        {{- if .Values.controller.webhook.generateCert }}
-        - --admission-webhook-cert-dir=/tmp/k8s-webhook-server/serving-certs
-        {{- else }}
-        - --admission-webhook-cert-dir={{ .Values.controller.webhook.certDir }}
-        {{- end }}
-        - --admission-webhook-host={{ .Values.controller.webhook.host }}
-        - --admission-webhook-port={{ .Values.controller.webhook.port }}
+        - --config=/etc/chaos-controller/config.yaml
         ports:
         - containerPort: 9443
           name: webhook-server
@@ -82,6 +52,9 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+        - mountPath: /etc/chaos-controller
+          name: config
+          readOnly: true
       {{- if .Values.images.pullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.images.pullSecrets }}
@@ -92,3 +65,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: chaos-controller-webhook-secret
+      - name: config
+        configMap:
+          name: chaos-controller-config

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0
 	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,7 +79,6 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3k
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775 h1:cHzBGGVew0ezFsq2grfy2RsB8hO/eNyBgOLHBCqfR1U=
 github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLIdUjrmSXlK9pkrsDlLHbO8jiB8X8JnOc=

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -37,6 +38,7 @@ import (
 	"github.com/DataDog/chaos-controller/metrics"
 	"github.com/DataDog/chaos-controller/metrics/types"
 	chaoswebhook "github.com/DataDog/chaos-controller/webhook"
+	"github.com/spf13/viper"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -51,43 +53,107 @@ func init() {
 	_ = chaosv1beta1.AddToScheme(scheme)
 }
 
+type config struct {
+	Controller controllerConfig `json:"controller"`
+	Injector   injectorConfig   `json:"injector"`
+	Handler    handlerConfig    `json:"handler"`
+}
+
+type controllerConfig struct {
+	MetricsAddr      string                  `json:"metricsAddr"`
+	MetricsSink      string                  `json:"metricsSink"`
+	ImagePullSecrets string                  `json:"imagePullSecrets"`
+	DeleteOnly       bool                    `json:"deleteOnly"`
+	LeaderElection   bool                    `json:"leaderElection"`
+	Webhook          controllerWebhookConfig `json:"webhook"`
+}
+
+type controllerWebhookConfig struct {
+	CertDir string `json:"certDir"`
+	Host    string `json:"host"`
+	Port    int    `json:"port"`
+}
+
+type injectorConfig struct {
+	Image             string                          `json:"image"`
+	Annotations       map[string]string               `json:"annotations"`
+	ServiceAccount    injectorServiceAccountConfig    `json:"serviceAccount"`
+	NetworkDisruption injectorNetworkDisruptionConfig `json:"networkDisruption"`
+}
+
+type injectorServiceAccountConfig struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+type injectorNetworkDisruptionConfig struct {
+	AllowedHosts []string `json:"allowedHosts"`
+}
+
+type handlerConfig struct {
+	Enabled bool          `json:"enabled"`
+	Image   string        `json:"image"`
+	Timeout time.Duration `json:"timeout"`
+}
+
 func main() {
 	var (
-		metricsAddr                           string
-		enableLeaderElection                  bool
-		deleteOnly                            bool
-		sink                                  string
-		injectorAnnotations                   map[string]string
-		injectorServiceAccount                string
-		injectorServiceAccountNamespace       string
-		injectorImage                         string
-		injectorNetworkDisruptionAllowedHosts []string
-		handlerEnabled                        bool
-		handlerImage                          string
-		handlerTimeout                        time.Duration
-		imagePullSecrets                      string
-		admissionWebhookCertDir               string
-		admissionWebhookHost                  string
-		admissionWebhookPort                  int
+		configPath string
+		cfg        config
 	)
 
-	pflag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	pflag.BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	pflag.BoolVar(&deleteOnly, "delete-only", false,
+	// parse flags
+	pflag.StringVar(&configPath, "config", "", "Configuration file path")
+
+	pflag.StringVar(&cfg.Controller.MetricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	handleFatalError(viper.BindPFlag("controller.metrics.addr", pflag.Lookup("metrics-addr")))
+
+	pflag.BoolVar(&cfg.Controller.LeaderElection, "enable-leader-election", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	handleFatalError(viper.BindPFlag("controller.leaderElection", pflag.Lookup("enable-leader-election")))
+
+	pflag.BoolVar(&cfg.Controller.DeleteOnly, "delete-only", false,
 		"Enable delete only mode which will not allow new disruption to start and will only continue to clean up and remove existing disruptions.")
-	pflag.StringToStringVar(&injectorAnnotations, "injector-annotations", map[string]string{}, "Annotations added to the generated injector pods")
-	pflag.StringVar(&injectorServiceAccount, "injector-service-account", "chaos-injector", "Service account to use for the generated injector pods")
-	pflag.StringVar(&injectorServiceAccountNamespace, "injector-service-account-namespace", "chaos-engineering", "Namespace of the service account to use for the generated injector pods. Should also host the controller.")
-	pflag.StringVar(&injectorImage, "injector-image", "chaos-injector", "Image to pull for the injector pods")
-	pflag.StringSliceVar(&injectorNetworkDisruptionAllowedHosts, "injector-network-disruption-allowed-hosts", []string{}, "List of hosts always allowed by network disruptions (format: <host>;<port>;<protocol>)")
-	pflag.BoolVar(&handlerEnabled, "handler-enabled", false, "Enable the chaos handler for on-init disruptions")
-	pflag.StringVar(&handlerImage, "handler-image", "chaos-handler", "Image to pull for the handler containers")
-	pflag.DurationVar(&handlerTimeout, "handler-timeout", time.Minute, "Handler init container timeout")
-	pflag.StringVar(&imagePullSecrets, "image-pull-secrets", "", "Secrets used for pulling the Docker image from a private registry")
-	pflag.StringVar(&sink, "metrics-sink", "noop", "Metrics sink (datadog, or noop)")
-	pflag.StringVar(&admissionWebhookCertDir, "admission-webhook-cert-dir", "", "Admission webhook certificate directory to search for tls.crt and tls.key files")
-	pflag.StringVar(&admissionWebhookHost, "admission-webhook-host", "", "Host used by the admission controller to serve requests")
-	pflag.IntVar(&admissionWebhookPort, "admission-webhook-port", 9443, "Port used by the admission controller to serve requests")
+	handleFatalError(viper.BindPFlag("controller.deleteOnly", pflag.Lookup("delete-only")))
+
+	pflag.StringVar(&cfg.Controller.ImagePullSecrets, "image-pull-secrets", "", "Secrets used for pulling the Docker image from a private registry")
+	handleFatalError(viper.BindPFlag("controller.imagePullSecrets", pflag.Lookup("image-pull-secrets")))
+
+	pflag.StringVar(&cfg.Controller.MetricsSink, "metrics-sink", "noop", "Metrics sink (datadog, or noop)")
+	handleFatalError(viper.BindPFlag("controller.metricsSink", pflag.Lookup("metrics-sink")))
+
+	pflag.StringToStringVar(&cfg.Injector.Annotations, "injector-annotations", map[string]string{}, "Annotations added to the generated injector pods")
+	handleFatalError(viper.BindPFlag("injector.annotations", pflag.Lookup("injector-annotations")))
+
+	pflag.StringVar(&cfg.Injector.ServiceAccount.Name, "injector-service-account", "chaos-injector", "Service account to use for the generated injector pods")
+	handleFatalError(viper.BindPFlag("injector.serviceAccount.name", pflag.Lookup("injector-service-account")))
+
+	pflag.StringVar(&cfg.Injector.ServiceAccount.Namespace, "injector-service-account-namespace", "chaos-engineering", "Namespace of the service account to use for the generated injector pods. Should also host the controller.")
+	handleFatalError(viper.BindPFlag("injector.serviceAccount.namespace", pflag.Lookup("injector-service-account-namespace")))
+
+	pflag.StringVar(&cfg.Injector.Image, "injector-image", "chaos-injector", "Image to pull for the injector pods")
+	handleFatalError(viper.BindPFlag("injector.image", pflag.Lookup("injector-image")))
+
+	pflag.StringSliceVar(&cfg.Injector.NetworkDisruption.AllowedHosts, "injector-network-disruption-allowed-hosts", []string{}, "List of hosts always allowed by network disruptions (format: <host>;<port>;<protocol>)")
+	handleFatalError(viper.BindPFlag("injector.networkDisruption.allowedHosts", pflag.Lookup("injector-network-disruption-allowed-hosts")))
+
+	pflag.BoolVar(&cfg.Handler.Enabled, "handler-enabled", false, "Enable the chaos handler for on-init disruptions")
+	handleFatalError(viper.BindPFlag("handler.enabled", pflag.Lookup("handler-enabled")))
+
+	pflag.StringVar(&cfg.Handler.Image, "handler-image", "chaos-handler", "Image to pull for the handler containers")
+	handleFatalError(viper.BindPFlag("handler.image", pflag.Lookup("handler-image")))
+
+	pflag.DurationVar(&cfg.Handler.Timeout, "handler-timeout", time.Minute, "Handler init container timeout")
+	handleFatalError(viper.BindPFlag("handler.timeout", pflag.Lookup("handler-timeout")))
+
+	pflag.StringVar(&cfg.Controller.Webhook.CertDir, "admission-webhook-cert-dir", "", "Admission webhook certificate directory to search for tls.crt and tls.key files")
+	handleFatalError(viper.BindPFlag("controller.webhook.certDir", pflag.Lookup("admission-webhook-cert-dir")))
+
+	pflag.StringVar(&cfg.Controller.Webhook.Host, "admission-webhook-host", "", "Host used by the admission controller to serve requests")
+	handleFatalError(viper.BindPFlag("controller.webhook.host", pflag.Lookup("admission-webhook-host")))
+
+	pflag.IntVar(&cfg.Controller.Webhook.Port, "admission-webhook-port", 9443, "Port used by the admission controller to serve requests")
+	handleFatalError(viper.BindPFlag("controller.webhook.port", pflag.Lookup("admission-webhook-port")))
+
 	pflag.Parse()
 
 	logger, err := log.NewZapLogger()
@@ -96,14 +162,35 @@ func main() {
 		os.Exit(1)
 	}
 
+	// load configuration file if present
+	if configPath != "" {
+		logger.Infow("loading configuration file", "config", configPath)
+
+		viper.SetConfigFile(configPath)
+
+		if err := viper.ReadInConfig(); err != nil {
+			logger.Fatalw("error loading configuration file", "error", err)
+		}
+
+		if err := viper.Unmarshal(&cfg); err != nil {
+			logger.Fatalw("error unmarshaling configuration", "error", err)
+		}
+
+		viper.WatchConfig()
+		viper.OnConfigChange(func(in fsnotify.Event) {
+			logger.Info("configuration has changed, restarting")
+			os.Exit(0)
+		})
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
-		MetricsBindAddress: metricsAddr,
-		LeaderElection:     enableLeaderElection,
+		MetricsBindAddress: cfg.Controller.MetricsAddr,
+		LeaderElection:     cfg.Controller.LeaderElection,
 		LeaderElectionID:   "75ec2fa4.datadoghq.com",
-		Host:               admissionWebhookHost,
-		Port:               admissionWebhookPort,
-		CertDir:            admissionWebhookCertDir,
+		Host:               cfg.Controller.Webhook.Host,
+		Port:               cfg.Controller.Webhook.Port,
+		CertDir:            cfg.Controller.Webhook.CertDir,
 	})
 	if err != nil {
 		logger.Errorw("unable to start manager", "error", err)
@@ -111,7 +198,7 @@ func main() {
 	}
 
 	// metrics sink
-	ms, err := metrics.GetSink(types.SinkDriver(sink), types.SinkAppController)
+	ms, err := metrics.GetSink(types.SinkDriver(cfg.Controller.MetricsSink), types.SinkAppController)
 	if err != nil {
 		logger.Errorw("error while creating metric sink", "error", err)
 	}
@@ -137,12 +224,12 @@ func main() {
 		Recorder:                              mgr.GetEventRecorderFor("disruption-controller"),
 		MetricsSink:                           ms,
 		TargetSelector:                        controllers.RunningTargetSelector{},
-		InjectorAnnotations:                   injectorAnnotations,
-		InjectorServiceAccount:                injectorServiceAccount,
-		InjectorImage:                         injectorImage,
-		InjectorServiceAccountNamespace:       injectorServiceAccountNamespace,
-		InjectorNetworkDisruptionAllowedHosts: injectorNetworkDisruptionAllowedHosts,
-		ImagePullSecrets:                      imagePullSecrets,
+		InjectorAnnotations:                   cfg.Injector.Annotations,
+		InjectorServiceAccount:                cfg.Injector.ServiceAccount.Name,
+		InjectorImage:                         cfg.Injector.Image,
+		InjectorServiceAccountNamespace:       cfg.Injector.ServiceAccount.Namespace,
+		InjectorNetworkDisruptionAllowedHosts: cfg.Injector.NetworkDisruption.AllowedHosts,
+		ImagePullSecrets:                      cfg.Controller.ImagePullSecrets,
 	}
 
 	if err := r.SetupWithManager(mgr); err != nil {
@@ -153,7 +240,7 @@ func main() {
 	go r.ReportMetrics()
 
 	// register disruption validating webhook
-	if err = (&chaosv1beta1.Disruption{}).SetupWebhookWithManager(mgr, logger, ms, deleteOnly, handlerEnabled); err != nil {
+	if err = (&chaosv1beta1.Disruption{}).SetupWebhookWithManager(mgr, logger, ms, cfg.Controller.DeleteOnly, cfg.Handler.Enabled); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Disruption")
 		os.Exit(1)
 	}
@@ -163,8 +250,8 @@ func main() {
 		Handler: &chaoswebhook.ChaosHandlerMutator{
 			Client:  mgr.GetClient(),
 			Log:     logger,
-			Image:   handlerImage,
-			Timeout: handlerTimeout,
+			Image:   cfg.Handler.Image,
+			Timeout: cfg.Handler.Timeout,
 		},
 	})
 
@@ -182,6 +269,14 @@ func main() {
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		logger.Errorw("problem running manager", "error", err)
+		os.Exit(1)
+	}
+}
+
+// handleFatalError logs the given error and exits if err is not nil
+func handleFatalError(err error) {
+	if err != nil {
+		setupLog.Error(err, "fatal error occurred on setup")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

- [x] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior: it adds the possibility to configure the controller with a configuration file (essentially through a configmap) instead of relying on CLI flags only. The controller automatically restarts on configuration change (can take a bit of time since it relies on inotify).

Motivation for change: configuration file can be an easier way to configure the controller (more readable, can easily be templated with secrets, etc.).

## Code Quality

### Testing

- [ ] I used existing unit tests
- [x] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [ ] The documentation is up to date
- [x] My code is sufficiently commented
- [x] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
