### PR TITLE
Allow advanced target selectors in disruptions

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -39,10 +39,12 @@ import (
 type DisruptionSpec struct {
 	// +kubebuilder:validation:Required
 	Count *intstr.IntOrString `json:"count"` // number of pods to target in either integer form or percent form appended with a %
-	// +kubebuilder:validation:Required
-	Selector labels.Set `json:"selector"`         // label selector
-	DryRun   bool       `json:"dryRun,omitempty"` // enable dry-run mode
-	OnInit   bool       `json:"onInit,omitempty"` // enable disruption on init
+	// +nullable
+	Selector labels.Set `json:"selector,omitempty"` // label selector
+	// +nullable
+	AdvancedSelector []metav1.LabelSelectorRequirement `json:"advancedSelector,omitempty"` // advanced label selector
+	DryRun           bool                              `json:"dryRun,omitempty"`           // enable dry-run mode
+	OnInit           bool                              `json:"onInit,omitempty"`           // enable disruption on init
 	// +kubebuilder:validation:Enum=pod;node;""
 	Level      chaostypes.DisruptionLevel `json:"level,omitempty"`
 	Containers []string                   `json:"containers,omitempty"`
@@ -133,6 +135,11 @@ func (s *DisruptionSpec) Validate() error {
 
 // Validate applies rules for disruption global scope
 func (s *DisruptionSpec) validateGlobalDisruptionScope() error {
+	// Rule: at least one kind of selector is set
+	if s.Selector.AsSelector().Empty() && len(s.AdvancedSelector) == 0 {
+		return errors.New("either selector or advancedSelector field must be set")
+	}
+
 	// Rule: no targeted container if disruption is node-level
 	if len(s.Containers) > 0 && s.Level == chaostypes.DisruptionLevelNode {
 		return errors.New("cannot target specific containers because the level configuration is set to node")

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -20,7 +20,8 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/api/authentication/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -190,6 +191,13 @@ func (in *DisruptionSpec) DeepCopyInto(out *DisruptionSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.AdvancedSelector != nil {
+		in, out := &in.AdvancedSelector, &out.AdvancedSelector
+		*out = make([]v1.LabelSelectorRequirement, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Containers != nil {
 		in, out := &in.Containers, &out.Containers
 		*out = make([]string, len(*in))
@@ -247,7 +255,7 @@ func (in *DisruptionStatus) DeepCopyInto(out *DisruptionStatus) {
 	}
 	if in.UserInfo != nil {
 		in, out := &in.UserInfo, &out.UserInfo
-		*out = new(v1.UserInfo)
+		*out = new(authenticationv1.UserInfo)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -36,6 +36,32 @@ spec:
         spec:
           description: DisruptionSpec defines the desired state of Disruption
           properties:
+            advancedSelector:
+              items:
+                description: A label selector requirement is a selector that contains
+                  values, a key, and an operator that relates the key and values.
+                properties:
+                  key:
+                    description: key is the label key that the selector applies to.
+                    type: string
+                  operator:
+                    description: operator represents a key's relationship to a set
+                      of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                    type: string
+                  values:
+                    description: values is an array of string values. If the operator
+                      is In or NotIn, the values array must be non-empty. If the operator
+                      is Exists or DoesNotExist, the values array must be empty. This
+                      array is replaced during a strategic merge patch.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - key
+                - operator
+                type: object
+              nullable: true
+              type: array
             containers:
               items:
                 type: string
@@ -204,10 +230,10 @@ spec:
               additionalProperties:
                 type: string
               description: Set is a map of label:value. It implements Labels.
+              nullable: true
               type: object
           required:
           - count
-          - selector
           type: object
         status:
           description: DisruptionStatus defines the observed state of Disruption

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -561,10 +561,12 @@ func (r *DisruptionReconciler) selectTargets(instance *chaosv1beta1.Disruption) 
 	r.log.Infow("selecting targets to inject disruption to", "selector", instance.Spec.Selector.String())
 
 	// validate the given label selector to avoid any formating issues due to special chars
-	if err := validateLabelSelector(instance.Spec.Selector.AsSelector()); err != nil {
-		r.Recorder.Event(instance, "Warning", "InvalidLabelSelector", fmt.Sprintf("%s. No targets will be selected.", err.Error()))
+	if instance.Spec.Selector != nil {
+		if err := validateLabelSelector(instance.Spec.Selector.AsSelector()); err != nil {
+			r.Recorder.Event(instance, "Warning", "InvalidLabelSelector", fmt.Sprintf("%s. No targets will be selected.", err.Error()))
 
-		return err
+			return err
+		}
 	}
 
 	// select either pods or nodes depending on the disruption level

--- a/docs/features.md
+++ b/docs/features.md
@@ -24,6 +24,17 @@ The `Disruption` resource uses [label selectors](https://kubernetes.io/docs/conc
 
 **NOTE:** If you are targeting pods, the disruption must be created in the same namespace as the targeted pods.
 
+### Advanced targeting
+
+In addition to the simple `selector` field matching an exact key/value label, one can do some more advanced targeting with the `advancedSelector` field. It uses the [label selector requirements mechanism](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#LabelSelectorRequirement) allowing to match labels with the following operator:
+
+* `Exists`: the label with the specified key is present, no matter the value
+* `DoesNotExist`: the label with the specified key is not present
+* `In`: the label with the specified key has a value strictly equal to one of the given values
+* `NotIn`: the label with the specified key has a value not matching any of the given values
+
+You can look at [an example of the expected format](../examples/advanced_selector.yaml) to know how to use it.
+
 ### Targeting a specific pod
 
 How can you target a specific pod by name, if it doesn't have a unique label selector you can use? The `Disruption` spec doesn't support field selectors at this time, so selecting by name isn't possible. However, you can use the `kubectl label pods` command, e.g., `kubectl label pods $podname unique-label-for-this-disruption=target-me` to dynamically add a unique label to the pod, which you can use as your label selector in the `Disruption` spec.

--- a/examples/advanced_selector.yaml
+++ b/examples/advanced_selector.yaml
@@ -1,0 +1,28 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+apiVersion: chaos.datadoghq.com/v1beta1
+kind: Disruption
+metadata:
+  name: advanced-selector
+  namespace: chaos-demo
+spec:
+  level: pod
+  advancedSelector: # advanced selectors can select targets on something else than an exact key/value match
+    - key: app
+      operator: Exists
+  # - key: app
+  #   operator: DoesNotExist
+  # - key: app
+  #   operator: In
+  #   values:
+  #     - curl
+  # - key: app
+  #   operator: NotIn
+  #   values:
+  #     - nginx
+  count: 1
+  network:
+    drop: 10

--- a/examples/complete.yaml
+++ b/examples/complete.yaml
@@ -13,7 +13,20 @@ spec:
   level: pod # level the disruption should be injected at (can be either pod or node, defaults to pod)
   selector: # label selector[s] to target pods
     app: demo
-    team: developers
+    team: developer
+  advancedSelector: # advanced selectors can select targets on something else than an exact key/value match
+    - key: app
+      operator: Exists
+  # - key: app
+  #   operator: DoesNotExist
+  # - key: app
+  #   operator: In
+  #   values:
+  #     - curl
+  # - key: app
+  #   operator: NotIn
+  #   values:
+  #     - nginx
   containers: # optional, name of the containers to target within the targeted pod, by default all pods are targeted
     - demo
     - demo2


### PR DESCRIPTION
## What does this PR do?

- [x] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior: it adds the possibility to specify advanced label selectors which can select targets with something else than the regular key/value exact match. Possible operators are:
* `Exists` to select targets having a specific key
* `DoesNotExist` to select targets not having a specific key
* `In` to select targets having a key with a value matching a set of values
* `NotIn` to select targets having a key with a value not matching a set of values

Note that the advanced selector itself fills the current selector use case of matching an exact key/value but I decided to keep both fields for multiple reasons:
* the obvious one is for compatibility issues as format between both selectors are totally different
* the not obvious one is that specify an exact key/value match would be way more complex with advanced selectors (more complex than it should be at least)
  * as the exact key/value match is 99% of our use cases, I'd prefer to keep it simple and let advanced users using the advanced selectors when needed

Here's what advanced selectors look like:
```yaml
apiVersion: chaos.datadoghq.com/v1beta1
kind: Disruption
metadata:
  name: advanced-selector
  namespace: chaos-demo
spec:
  advancedSelector:
    - key: app
      operator: Exists
    - key: app
      operator: DoesNotExists
    - key: app
      operator: In
      values:
        - curl
    - key: app
      operator: NotIn
      values:
        - nginx
```

Motivation for change: we sometimes need to select targets having a specific key with potentially different values, or which does not have a specific key, etc. This feature allows more flexibility in target selection and mixes well with the existing selector.

## Code Quality

### Testing

- [x] I used existing unit tests
- [x] I manually tested locally
- [x] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [x] The documentation is up to date
- [x] My code is sufficiently commented
- [x] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
