### PR TITLE
Publish the chaosli binaries in releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,15 +10,38 @@ builds:
       - amd64
   - id: injector
     binary: injector
+    main: ./cli/injector
     goos:
       - linux
     goarch:
       - amd64
+  - id: handler
+    binary: handler
+    main: ./cli/handler
+    goos:
+      - linux
+    goarch:
+      - amd64
+  - id: chaosli
+    binary: chaosli
+    main: ./cli/chaosli
+    goos:
+      - linux
+      - darwin
 archives:
-  - files:
+  - id: controller
+    builds:
+      - controller
+      - injector
+      - handler
+    files:
     - LICENSE
     - LICENSE-3rdparty.csv
     - NOTICE
     - CHANGELOG.md
     - README.md
     - docs/*
+  - id: chaosli
+    builds:
+      - chaosli
+    format: binary

--- a/cli/chaosli/README.md
+++ b/cli/chaosli/README.md
@@ -1,17 +1,21 @@
 # Chaosli
 
-The Chaos Controller CLI, `chaosli`, is meant to help create a more user friendly and digestible chaos-controller experience. The CLI pairs with your Disruption's definition, giving you information to give you a better sense of what is going on, and what will happen when you apply new disruptions. With features like explain and validation, it gives users, not only a better understanding, but a better experience with the controller.  
-
+The Chaos Controller CLI, `chaosli`, is meant to help create a more user friendly and digestible chaos-controller experience. The CLI pairs with your Disruption's definition, giving you information to give you a better sense of what is going on, and what will happen when you apply new disruptions. With features like explain and validation, it gives users, not only a better understanding, but a better experience with the controller.
 
 #### Table of Contents
 ---
+- Installation
 - Validate
 - Explain
 - Create
 
+#### Installation
+
+Download the `chaosli` binary for your operating system and architecture [from the latest release](https://github.com/DataDog/chaos-controller/releases/latest).
+
 #### Validate
 ---
-Usage: `go run chaosli/main.go validate --path <path to disruption file>`
+Usage: `chaosli validate --path <path to disruption file>`
 
 Description: Validates your disruption file (location defined by `--path`) to make sure everything is correctly formatted, and all options have valid configurations.
 
@@ -22,20 +26,20 @@ Example:
 # Note; We removed the network portion from the actual example for this example, normally
 # network_delay.yaml in examples has a network disruption specified
 
-$ go run chaosli/main.go validate --path=../examples/network_delay.yaml
+$ chaosli validate --path=../examples/network_delay.yaml
 Error: cannot apply an empty disruption - at least one of Network, DNS, DiskPressure, NodeFailure, ContainerFailure, CPUPressure fields is needed
 ```
 
 #### Explain
 ---
-Usage: `go run chaosli/main.go explain --path <path to disruption file>`
+Usage: `chaosli explain --path <path to disruption file>`
 
 Description: Prints out a summary of the disruption (location defined by `--path`).
 
 Example:
 
 ```
-$ go run chaosli/main.go explain --path=../examples/network_delay.yaml
+$ chaosli explain --path=../examples/network_delay.yaml
 This Disruption...
 =======================================================================================================================================
 🧰 has the following metadata  ...
@@ -54,6 +58,6 @@ This Disruption...
 
 #### Creation
 ---
-Usage: `go run chaosli/main.go create --path <path to output generated disruption file>`
+Usage: `chaosli create --path <path to output generated disruption file>`
 
 Description: User friendly input process that helps you create your disruptions from scratch answering simple questions.


### PR DESCRIPTION
## What does this PR do?

- [x] Adds new functionality
- [x] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior: it now builds and publishes the chaosli binaries for linux and darwin OS in releases. It also adds the injector and the handler binaries in the generated controller archive.

Motivation for change: `chaosli` is the CLI used to help with disruptions usage. It looks normal to publish the binary in releases so people can just download it, already compiled for their OS, from the release itself.

## Code Quality

### Testing

- [ ] I used existing unit tests
- [x] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [ ] The documentation is up to date
- [ ] My code is sufficiently commented
- [x] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
