### PR TITLE
Enable autopush to dockerhub on release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,7 +161,7 @@ release-docker-hub-ref:
 
 release-docker-hub-tag:
   <<: *release-docker-hub
-  when: manual
+  when: always
   only:
     - tags
   variables:


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior: it enables autopush to docker hub on release creation now that we have a stable process.

Motivation for change: stop forgetting about pushing to docker hub registry.

## Code Quality

### Testing

- [ ] I used existing unit tests
- [ ] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [ ] The documentation is up to date
- [ ] My code is sufficiently commented
- [ ] I have tested to the best of my ability
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
