### PR TITLE
Send more metrics from the validating admission webhook

### DIFF
--- a/chart/templates/webhook.yaml
+++ b/chart/templates/webhook.yaml
@@ -37,6 +37,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - disruptions
 ---

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -17,7 +17,13 @@ Here's the list of metrics sent by the controller and the injector.
 * `chaos.controller.disruptions.stuck_on_removal_total` is the total count of existing disruption being flagged as stuck on removal
 * `chaos.controller.disruptions.gauge` is the total count of existing disruption
 * `chaos.controller.disruptions.count` increments when a disruption is created
-* `chaos.controller.validation.failed` increments when a disruption fails ValidateCreate in the admission webhook
+
+### Admission webhooks
+
+* `chaos.controller.validation.failed` increments when a disruption fails to be validated from the admission webhook
+* `chaos.controller.validation.created` increments when a disruption is created
+* `chaos.controller.validation.updated` increments when a disruption is updated
+* `chaos.controller.validation.deleted` increments when a disruption is deleted
 
 ## Injector
 

--- a/metrics/datadog/datadog.go
+++ b/metrics/datadog/datadog.go
@@ -136,9 +136,24 @@ func (d *Sink) MetricRestart() error {
 	return d.metricWithStatus(metricPrefixController+"restart", []string{})
 }
 
-// MetricFailedValidation increments the failed validation metric
-func (d *Sink) MetricFailedValidation() error {
-	return d.metricWithStatus(metricPrefixController+"validation.failed", []string{})
+// MetricValidationFailed increments the failed validation metric
+func (d *Sink) MetricValidationFailed(tags []string) error {
+	return d.metricWithStatus(metricPrefixController+"validation.failed", tags)
+}
+
+// MetricValidationCreated increments the failed validation metric
+func (d *Sink) MetricValidationCreated(tags []string) error {
+	return d.metricWithStatus(metricPrefixController+"validation.created", tags)
+}
+
+// MetricValidationUpdated increments the failed validation metric
+func (d *Sink) MetricValidationUpdated(tags []string) error {
+	return d.metricWithStatus(metricPrefixController+"validation.updated", tags)
+}
+
+// MetricValidationDeleted increments the failed validation metric
+func (d *Sink) MetricValidationDeleted(tags []string) error {
+	return d.metricWithStatus(metricPrefixController+"validation.deleted", tags)
 }
 
 func boolToStatus(succeed bool) string {

--- a/metrics/datadog/datadog.go
+++ b/metrics/datadog/datadog.go
@@ -49,22 +49,6 @@ func (d *Sink) GetSinkName() string {
 	return string(types.SinkDriverDatadog)
 }
 
-// Flush forces the client to send the metrics in the current cache
-func (d *Sink) Flush() error {
-	return d.client.Flush()
-}
-
-// EventWithTags creates a new event with the given title, text and tags and send it
-func (d *Sink) EventWithTags(title, text string, tags []string) error {
-	e := &statsd.Event{
-		Title: title,
-		Text:  text,
-		Tags:  tags,
-	}
-
-	return d.client.Event(e)
-}
-
 // MetricInjected increments the injected metric
 func (d *Sink) MetricInjected(succeed bool, kind string, tags []string) error {
 	status := boolToStatus(succeed)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -18,8 +18,6 @@ import (
 // Sink describes a metric sink
 type Sink interface {
 	Close() error
-	EventWithTags(title, text string, tags []string) error
-	Flush() error
 	GetSinkName() string
 	MetricCleaned(succeed bool, kind string, tags []string) error
 	MetricCleanupDuration(duration time.Duration, tags []string) error

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -34,7 +34,10 @@ type Sink interface {
 	MetricDisruptionsCount(kind chaostypes.DisruptionKindName, tags []string) error
 	MetricPodsGauge(gauge float64) error
 	MetricRestart() error
-	MetricFailedValidation() error
+	MetricValidationFailed(tags []string) error
+	MetricValidationCreated(tags []string) error
+	MetricValidationUpdated(tags []string) error
+	MetricValidationDeleted(tags []string) error
 }
 
 // GetSink returns an initiated sink

--- a/metrics/noop/noop.go
+++ b/metrics/noop/noop.go
@@ -137,8 +137,26 @@ func (n *Sink) MetricRestart() error {
 	return nil
 }
 
-func (n *Sink) MetricFailedValidation() error {
-	fmt.Println("NOOP: MetricFailedValidation")
+func (n *Sink) MetricValidationFailed(tags []string) error {
+	fmt.Printf("NOOP: MetricValidationFailed %s\n", tags)
+
+	return nil
+}
+
+func (n *Sink) MetricValidationCreated(tags []string) error {
+	fmt.Printf("NOOP: MetricValidationCreated %s\n", tags)
+
+	return nil
+}
+
+func (n *Sink) MetricValidationUpdated(tags []string) error {
+	fmt.Printf("NOOP: MetricValidationUpdated %s\n", tags)
+
+	return nil
+}
+
+func (n *Sink) MetricValidationDeleted(tags []string) error {
+	fmt.Printf("NOOP: MetricValidationDeleted %s\n", tags)
 
 	return nil
 }

--- a/metrics/noop/noop.go
+++ b/metrics/noop/noop.go
@@ -32,18 +32,6 @@ func (n *Sink) GetSinkName() string {
 	return string(types.SinkDriverNoop)
 }
 
-// Flush returns nil
-func (n *Sink) Flush() error {
-	return nil
-}
-
-// EventWithTags creates a new event with the given title, text and tags and send it
-func (n *Sink) EventWithTags(title, text string, tags []string) error {
-	fmt.Printf("NOOP: Event %s\n", title)
-
-	return nil
-}
-
 // MetricInjected increments the injected metric
 func (n *Sink) MetricInjected(succeed bool, kind string, tags []string) error {
 	fmt.Printf("NOOP: MetricInjected %v\n", succeed)

--- a/webhook/user_info.go
+++ b/webhook/user_info.go
@@ -39,15 +39,14 @@ func (m *UserInfoMutator) Handle(ctx context.Context, req admission.Request) adm
 	}
 
 	// decode object
-	err := m.decoder.Decode(req, dis)
-	if err != nil {
+	if err := m.decoder.Decode(req, dis); err != nil {
 		m.Log.Errorw("error decoding disruption object", "error", err, "name", req.Name, "namespace", req.Namespace)
 
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
 	// retrieve user info
-	m.Log.Infow("storing user info in disrution", "name", dis.Name, "namespace", dis.Namespace)
+	m.Log.Infow("storing user info in disruption", "name", dis.Name, "namespace", dis.Namespace)
 
 	dis.Status.UserInfo = &req.UserInfo
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior: it sends more metrics from the validating webhook to track disruption creation, update and deletion and includes the resource owner username and groups gathered from user info to the metrics tags.

Motivation for change: have a better tracking of who uses disruptions.

## Code Quality

### Testing

- [ ] I used existing unit tests
- [x] I manually tested locally
- [x] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [ ] The documentation is up to date
- [x] My code is sufficiently commented
- [x] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
