### PR TITLE
Add additional contextual tags to metrics sent from the admission

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -215,3 +215,19 @@ func (s *DisruptionSpec) DisruptionKindPicker(kind chaostypes.DisruptionKindName
 
 	return disruptionKind
 }
+
+// GetKindNames returns the non-nil disruption kind names for the given disruption
+func (s *DisruptionSpec) GetKindNames() []chaostypes.DisruptionKindName {
+	kinds := []chaostypes.DisruptionKindName{}
+
+	for _, kind := range chaostypes.DisruptionKindNames {
+		subspec := s.DisruptionKindPicker(kind)
+		if reflect.ValueOf(subspec).IsNil() {
+			continue
+		}
+
+		kinds = append(kinds, kind)
+	}
+
+	return kinds
+}

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -917,12 +917,7 @@ func (r *DisruptionReconciler) handleMetricSinkError(err error) {
 }
 
 func (r *DisruptionReconciler) emitKindCountMetrics(instance *chaosv1beta1.Disruption) {
-	for _, kind := range chaostypes.DisruptionKindNames {
-		subspec := instance.Spec.DisruptionKindPicker(kind)
-		if reflect.ValueOf(subspec).IsNil() {
-			continue
-		}
-
+	for _, kind := range instance.Spec.GetKindNames() {
 		r.handleMetricSinkError((r.MetricsSink.MetricDisruptionsCount(kind, []string{"name:" + instance.Name, "namespace:" + instance.Namespace})))
 	}
 }


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior: it adds more tags to the metrics sent from the admission webhook.

Motivation for change: have a better usage context in those metrics.

Example of sent tags:
```
NOOP: MetricValidationCreated [name:dry-run namespace:chaos-demo username:minikube-user group:system:masters group:system:authenticated selector:app:demo-curl kind:node-failure]
```

## Code Quality

### Testing

- [ ] I used existing unit tests
- [x] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [x] The documentation is up to date
- [x] My code is sufficiently commented
- [x] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
