### PR TITLE
CHAOS-31: Support durationSeconds in disruption spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,12 @@ jobs:
             sudo chown circleci:circleci /go /usr/local/bin /usr/local/kubebuilder
       - go_restore_cache
       - run:
+          name: Edit controller chart
+          <<: *working_directory
+          command: |
+            sudo snap install yq
+            yq e '.controller.expiredDisruptionGCDelay = "3s"' -i chart/values.yaml
+      - run:
           name: Configure Minikube
           command: |
             curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ spec:
   selector: # a label selector used to target resources
     app: demo-curl
   count: 1 # the number of resources to target
+  durationSeconds: 3600 # the amount of time before your disruption automatically terminates itself
   nodeFailure:
     shutdown: false # trigger a kernel panic on the target node
 ```

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 
 	chaosapi "github.com/DataDog/chaos-controller/api"
 	chaostypes "github.com/DataDog/chaos-controller/types"
@@ -49,7 +50,7 @@ type DisruptionSpec struct {
 	AdvancedSelector []metav1.LabelSelectorRequirement `json:"advancedSelector,omitempty"` // advanced label selector
 	DryRun           bool                              `json:"dryRun,omitempty"`           // enable dry-run mode
 	OnInit           bool                              `json:"onInit,omitempty"`           // enable disruption on init
-	DurationSeconds  int64                             `json:"durationSeconds"`            // time from disruption creation until chaos pods are deleted and no more are created
+	Duration         time.Duration                     `json:"duration,omitempty"`         // time from disruption creation until chaos pods are deleted and no more are created
 	// +kubebuilder:validation:Enum=pod;node;""
 	// +ddmark:validation:Enum=pod;node;""
 	Level      chaostypes.DisruptionLevel `json:"level,omitempty"`
@@ -158,11 +159,6 @@ func (s *DisruptionSpec) validateGlobalDisruptionScope() error {
 	if s.ContainerFailure != nil && s.Level == chaostypes.DisruptionLevelNode {
 		return errors.New("cannot execute a container failure because the level configuration is set to node")
 	}
-
-	// Rule: must have a durationSeconds // Can't implement until we are a v1 CRD because you can't default in v1beta1
-	// if s.DurationSeconds == 0 {
-	//	 return errors.New("must have durationSeconds set in your disruption spec")
-	// }
 
 	// Rule: at least one disruption field
 	if s.DNS == nil &&

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -49,6 +49,7 @@ type DisruptionSpec struct {
 	AdvancedSelector []metav1.LabelSelectorRequirement `json:"advancedSelector,omitempty"` // advanced label selector
 	DryRun           bool                              `json:"dryRun,omitempty"`           // enable dry-run mode
 	OnInit           bool                              `json:"onInit,omitempty"`           // enable disruption on init
+	DurationSeconds  int64                             `json:"durationSeconds"`            // time from disruption creation until chaos pods are deleted and no more are created
 	// +kubebuilder:validation:Enum=pod;node;""
 	// +ddmark:validation:Enum=pod;node;""
 	Level      chaostypes.DisruptionLevel `json:"level,omitempty"`
@@ -157,6 +158,11 @@ func (s *DisruptionSpec) validateGlobalDisruptionScope() error {
 	if s.ContainerFailure != nil && s.Level == chaostypes.DisruptionLevelNode {
 		return errors.New("cannot execute a container failure because the level configuration is set to node")
 	}
+
+	// Rule: must have a durationSeconds // Cant implement until we are a v1 CRD because you cant default in v1beta1
+	//if s.DurationSeconds == 0 {
+	//	return errors.New("must have durationSeconds set in your disruption spec")
+	//}
 
 	// Rule: at least one disruption field
 	if s.DNS == nil &&

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -159,10 +159,10 @@ func (s *DisruptionSpec) validateGlobalDisruptionScope() error {
 		return errors.New("cannot execute a container failure because the level configuration is set to node")
 	}
 
-	// Rule: must have a durationSeconds // Cant implement until we are a v1 CRD because you cant default in v1beta1
-	//if s.DurationSeconds == 0 {
-	//	return errors.New("must have durationSeconds set in your disruption spec")
-	//}
+	// Rule: must have a durationSeconds // Can't implement until we are a v1 CRD because you can't default in v1beta1
+	// if s.DurationSeconds == 0 {
+	//	 return errors.New("must have durationSeconds set in your disruption spec")
+	// }
 
 	// Rule: at least one disruption field
 	if s.DNS == nil &&

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"time"
 
 	chaosapi "github.com/DataDog/chaos-controller/api"
 	chaostypes "github.com/DataDog/chaos-controller/types"
@@ -50,7 +49,7 @@ type DisruptionSpec struct {
 	AdvancedSelector []metav1.LabelSelectorRequirement `json:"advancedSelector,omitempty"` // advanced label selector
 	DryRun           bool                              `json:"dryRun,omitempty"`           // enable dry-run mode
 	OnInit           bool                              `json:"onInit,omitempty"`           // enable disruption on init
-	Duration         time.Duration                     `json:"duration,omitempty"`         // time from disruption creation until chaos pods are deleted and no more are created
+	DurationSeconds  int64                             `json:"durationSeconds,omitempty"`  // seconds from disruption creation until chaos pods are deleted and no more are created
 	// +kubebuilder:validation:Enum=pod;node;""
 	// +ddmark:validation:Enum=pod;node;""
 	Level      chaostypes.DisruptionLevel `json:"level,omitempty"`

--- a/chart/install.yaml
+++ b/chart/install.yaml
@@ -772,6 +772,32 @@ webhooks:
 ---
 # Source: chaos-controller/templates/webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: chaos-engineering/chaos-controller-serving-cert
+  name: chaos-controller-disruption-spec-defaults
+webhooks:
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: chaos-controller-webhook-service
+        namespace: chaos-engineering
+        path: /mutate-chaos-datadoghq-com-v1beta1-disruption-spec-defaults
+    failurePolicy: Fail
+    name: chaos-controller-admission-webhook.chaos-engineering.svc
+    rules:
+      - apiGroups:
+          - "chaos.datadoghq.com"
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+        resources:
+          - disruptions
+---
+# Source: chaos-controller/templates/webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -16,6 +16,8 @@ data:
       metricsSink: {{ .Values.controller.metricsSink | quote }}
       deleteOnly: {{ .Values.controller.deleteOnly }}
       imagePullSecrets: {{ .Values.images.pullSecrets }}
+      defaultDuration: {{ .Values.controller.defaultDuration }}
+      expiredDisruptionGCDelay: {{ .Values.controller.expiredDisruptionGCDelay }}
       webhook:
         {{- if .Values.controller.webhook.generateCert }}
         certDir: /tmp/k8s-webhook-server/serving-certs

--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -129,6 +129,9 @@ spec:
               type: array
             dryRun:
               type: boolean
+            durationSeconds:
+              format: int64
+              type: integer
             level:
               description: DisruptionLevel represents which level the disruption should
                 be injected at
@@ -241,6 +244,7 @@ spec:
               type: object
           required:
           - count
+          - durationSeconds
           type: object
         status:
           description: DisruptionStatus defines the observed state of Disruption

--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -129,7 +129,10 @@ spec:
               type: array
             dryRun:
               type: boolean
-            durationSeconds:
+            duration:
+              description: A Duration represents the elapsed time between two instants
+                as an int64 nanosecond count. The representation limits the largest
+                representable duration to approximately 290 years.
               format: int64
               type: integer
             level:
@@ -244,7 +247,6 @@ spec:
               type: object
           required:
           - count
-          - durationSeconds
           type: object
         status:
           description: DisruptionStatus defines the observed state of Disruption

--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -129,10 +129,7 @@ spec:
               type: array
             dryRun:
               type: boolean
-            duration:
-              description: A Duration represents the elapsed time between two instants
-                as an int64 nanosecond count. The representation limits the largest
-                representable duration to approximately 290 years.
+            durationSeconds:
               format: int64
               type: integer
             level:

--- a/chart/templates/webhook.yaml
+++ b/chart/templates/webhook.yaml
@@ -107,6 +107,37 @@ webhooks:
     resources:
     - disruptions
 ---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+  {{- if not .Values.controller.webhook.generateCert }}
+    cert-manager.io/inject-ca-from: chaos-engineering/chaos-controller-serving-cert
+  {{- end }}
+  name: chaos-controller-disruption-spec-defaults
+webhooks:
+  - clientConfig:
+    {{- if not .Values.controller.webhook.generateCert }}
+      caBundle: Cg==
+    {{- else }}
+      caBundle: {{ b64enc $ca.Cert }}
+    {{- end }}
+      service:
+        name: chaos-controller-webhook-service
+        namespace: chaos-engineering
+        path: /mutate-chaos-datadoghq-com-v1beta1-disruption-spec-defaults
+    failurePolicy: Fail
+    name: chaos-controller-admission-webhook.chaos-engineering.svc
+    rules:
+      - apiGroups:
+          - "chaos.datadoghq.com"
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+        resources:
+          - disruptions
+---
 {{- if not .Values.controller.webhook.generateCert }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,6 +13,8 @@ images: # images and tag to pull for each component of the stack
 controller:
   deleteOnly: false # enable delete-only mode
   metricsSink: noop # metrics driver (noop or datadog)
+  defaultDuration: 1h # default spec.duration for a disruption with none specified
+  expiredDisruptionGCDelay: 15m # time after a disruption expires before deleting it
   webhook: # admission webhook configuration
     generateCert: false # if you want Helm to generate certificates (e.g. in case the cert-manager is not installed in the cluster) set this to true
     certDir: "" # certificate directory (must contain tls.crt and tls.key files)

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -172,7 +172,7 @@ func (r *DisruptionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		controllerutil.AddFinalizer(instance, disruptionFinalizer)
 
 		if calculateRemainingDurationSeconds(*instance) <= (-1 * int64(r.ExpiredDisruptionGCDelay)) {
-			r.log.Infow("disruption has lived for more than its duration, it will now be deleted.", "durationSeconds", instance.Spec.DurationSeconds)
+			r.log.Infow("disruption has lived for more than its duration, it will now be deleted.", "duration", instance.Spec.Duration)
 			r.Recorder.Event(instance, "Normal", "DurationOver", fmt.Sprintf("The disruption has lived %d seconds longer than its specified duration, and will now be deleted.", r.ExpiredDisruptionGCDelay))
 
 			var err error

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -52,8 +52,7 @@ import (
 )
 
 const (
-	finalizerPrefix          = "finalizer.chaos.datadoghq.com"
-	ExpiredDisruptionGCDelay = -900 // 15 minutes, measured in seconds
+	finalizerPrefix = "finalizer.chaos.datadoghq.com"
 )
 
 var (
@@ -78,6 +77,7 @@ type DisruptionReconciler struct {
 	InjectorDNSDisruptionDNSServer        string
 	InjectorDNSDisruptionKubeDNS          string
 	InjectorNetworkDisruptionAllowedHosts []string
+	ExpiredDisruptionGCDelay              int64
 }
 
 // +kubebuilder:rbac:groups=chaos.datadoghq.com,resources=disruptions,verbs=get;list;watch;create;update;patch;delete
@@ -171,9 +171,9 @@ func (r *DisruptionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		// the injection is being created or modified, apply needed actions
 		controllerutil.AddFinalizer(instance, disruptionFinalizer)
 
-		if calculateRemainingDurationSeconds(*instance) <= ExpiredDisruptionGCDelay {
+		if calculateRemainingDurationSeconds(*instance) <= r.ExpiredDisruptionGCDelay {
 			r.log.Infow("disruption has lived for more than its duration, it will now be deleted.", "durationSeconds", instance.Spec.DurationSeconds)
-			r.Recorder.Event(instance, "Normal", "DurationOver", fmt.Sprintf("The disruption has lived %d seconds longer than its specified duration, and will now be deleted.", ExpiredDisruptionGCDelay))
+			r.Recorder.Event(instance, "Normal", "DurationOver", fmt.Sprintf("The disruption has lived %d seconds longer than its specified duration, and will now be deleted.", r.ExpiredDisruptionGCDelay))
 
 			var err error
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -173,7 +173,7 @@ func (r *DisruptionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 
 		if calculateRemainingDurationSeconds(*instance) <= ExpiredDisruptionGCDelay {
 			r.log.Infow("disruption has lived for more than its duration, it will now be deleted.", "durationSeconds", instance.Spec.DurationSeconds)
-			r.Recorder.Event(instance, "Normal", "DurationOver", "The disruption has lived longer than its specified duration, and will be deleted.")
+			r.Recorder.Event(instance, "Normal", "DurationOver", fmt.Sprintf("The disruption has lived %d seconds longer than its specified duration, and will now be deleted.", ExpiredDisruptionGCDelay))
 
 			var err error
 
@@ -493,6 +493,7 @@ func (r *DisruptionReconciler) handleChaosPodsTermination(instance *chaosv1beta1
 				removeFinalizer = true
 			}
 
+			// if the pod died only because it exceeded its activeDeadlineSeconds, we can remove the finalizer
 			if chaosPod.Status.Reason == "DeadlineExceeded" {
 				removeFinalizer = true
 			}

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -77,7 +77,7 @@ type DisruptionReconciler struct {
 	InjectorDNSDisruptionDNSServer        string
 	InjectorDNSDisruptionKubeDNS          string
 	InjectorNetworkDisruptionAllowedHosts []string
-	ExpiredDisruptionGCDelay              int
+	ExpiredDisruptionGCDelay              time.Duration
 }
 
 // +kubebuilder:rbac:groups=chaos.datadoghq.com,resources=disruptions,verbs=get;list;watch;create;update;patch;delete
@@ -171,9 +171,9 @@ func (r *DisruptionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		// the injection is being created or modified, apply needed actions
 		controllerutil.AddFinalizer(instance, disruptionFinalizer)
 
-		if calculateRemainingDurationSeconds(*instance) <= (-1 * int64(r.ExpiredDisruptionGCDelay)) {
+		if calculateRemainingDurationSeconds(*instance) <= (-1 * int64(r.ExpiredDisruptionGCDelay.Seconds())) {
 			r.log.Infow("disruption has lived for more than its duration, it will now be deleted.", "duration", instance.Spec.Duration)
-			r.Recorder.Event(instance, "Normal", "DurationOver", fmt.Sprintf("The disruption has lived %d seconds longer than its specified duration, and will now be deleted.", r.ExpiredDisruptionGCDelay))
+			r.Recorder.Event(instance, "Normal", "DurationOver", fmt.Sprintf("The disruption has lived %s longer than its specified duration, and will now be deleted.", r.ExpiredDisruptionGCDelay))
 
 			var err error
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -487,6 +487,10 @@ func (r *DisruptionReconciler) handleChaosPodsTermination(instance *chaosv1beta1
 				removeFinalizer = true
 			}
 
+			if chaosPod.Status.Reason == "DeadlineExceeded" {
+				removeFinalizer = true
+			}
+
 			// check if the container was able to start or not
 			// if not, we can safely delete the pod since the disruption was not injected
 			for _, cs := range chaosPod.Status.ContainerStatuses {
@@ -559,6 +563,7 @@ func (r *DisruptionReconciler) ignoreTarget(instance *chaosv1beta1.Disruption, t
 // the chosen targets names will be reflected in the intance status
 // subsequent calls to this function will always return the same targets as the first call
 func (r *DisruptionReconciler) selectTargets(instance *chaosv1beta1.Disruption) error {
+	//TODO fimd completed pods
 	matchingTargets := []string{}
 
 	// exit early if we already have targets selected for the given instance

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -726,12 +726,15 @@ func (r *DisruptionReconciler) generatePod(instance *chaosv1beta1.Disruption, ta
 	// ensures that whether a chaos pod is deleted directly or by deleting a disruption, it will have time to finish cleaning up after itself.
 	terminationGracePeriod := int64(60)
 
+	activeDeadlineSeconds := calculateDeadlineSeconds(instance.Spec.DurationSeconds, instance.ObjectMeta.CreationTimestamp.Time)
+
 	podSpec := corev1.PodSpec{
 		HostPID:                       true,                      // enable host pid
 		RestartPolicy:                 corev1.RestartPolicyNever, // do not restart the pod on fail or completion
 		NodeName:                      targetNodeName,            // specify node name to schedule the pod
 		ServiceAccountName:            r.InjectorServiceAccount,  // service account to use
 		TerminationGracePeriodSeconds: &terminationGracePeriod,
+		ActiveDeadlineSeconds:         &activeDeadlineSeconds,
 		Containers: []corev1.Container{
 			{
 				Name:            "injector",              // container name

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -52,7 +52,8 @@ import (
 )
 
 const (
-	finalizerPrefix = "finalizer.chaos.datadoghq.com"
+	finalizerPrefix          = "finalizer.chaos.datadoghq.com"
+	ExpiredDisruptionGCDelay = -900 // 15 minutes, measured in seconds
 )
 
 var (
@@ -170,7 +171,7 @@ func (r *DisruptionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		// the injection is being created or modified, apply needed actions
 		controllerutil.AddFinalizer(instance, disruptionFinalizer)
 
-		if calculateRemainingDurationSeconds(*instance) <= -180 {
+		if calculateRemainingDurationSeconds(*instance) <= ExpiredDisruptionGCDelay {
 			r.log.Infow("disruption has lived for more than its duration, it will now be deleted.", "durationSeconds", instance.Spec.DurationSeconds)
 			r.Recorder.Event(instance, "Normal", "DurationOver", "The disruption has lived longer than its specified duration, and will be deleted.")
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -144,6 +144,7 @@ func (r *DisruptionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 				requeueAfter := time.Duration(rand.Intn(5)+5) * time.Second //nolint:gosec
 
 				r.log.Infow(fmt.Sprintf("disruption has not been fully cleaned yet, re-queuing in %v", requeueAfter))
+
 				return ctrl.Result{
 					Requeue:      true,
 					RequeueAfter: requeueAfter,
@@ -167,7 +168,6 @@ func (r *DisruptionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 			return ctrl.Result{}, nil
 		}
 	} else {
-
 		// the injection is being created or modified, apply needed actions
 		controllerutil.AddFinalizer(instance, disruptionFinalizer)
 

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -247,7 +247,7 @@ var _ = Describe("Disruption Controller", func() {
 	Context("disruption expires naturally", func() {
 		BeforeEach(func() {
 			disruption.Spec.Count = &intstr.IntOrString{Type: intstr.String, StrVal: "100%"}
-			disruption.Spec.DurationSeconds = 5
+			disruption.Spec.DurationSeconds = int64(timeout.Seconds() + 5)
 		})
 
 		It("should target all the selected pods", func() {

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -139,10 +139,11 @@ var _ = Describe("Disruption Controller", func() {
 				Namespace: "default",
 			},
 			Spec: chaosv1beta1.DisruptionSpec{
-				DryRun:     true,
-				Count:      &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
-				Selector:   map[string]string{"foo": "bar"},
-				Containers: []string{"ctn1"},
+				DryRun:          true,
+				Count:           &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				Selector:        map[string]string{"foo": "bar"},
+				Containers:      []string{"ctn1"},
+				DurationSeconds: 3600,
 				NodeFailure: &chaosv1beta1.NodeFailureSpec{
 					Shutdown: false,
 				},

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -23,6 +23,7 @@ package controllers
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -139,11 +140,11 @@ var _ = Describe("Disruption Controller", func() {
 				Namespace: "default",
 			},
 			Spec: chaosv1beta1.DisruptionSpec{
-				DryRun:          true,
-				Count:           &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
-				Selector:        map[string]string{"foo": "bar"},
-				Containers:      []string{"ctn1"},
-				DurationSeconds: 3600,
+				DryRun:     true,
+				Count:      &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				Selector:   map[string]string{"foo": "bar"},
+				Containers: []string{"ctn1"},
+				Duration:   time.Hour,
 				NodeFailure: &chaosv1beta1.NodeFailureSpec{
 					Shutdown: false,
 				},
@@ -247,7 +248,7 @@ var _ = Describe("Disruption Controller", func() {
 	Context("disruption expires naturally", func() {
 		BeforeEach(func() {
 			disruption.Spec.Count = &intstr.IntOrString{Type: intstr.String, StrVal: "100%"}
-			disruption.Spec.DurationSeconds = int64(timeout.Seconds() + 5)
+			disruption.Spec.Duration = time.Second * 5
 		})
 
 		It("should target all the selected pods", func() {

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -97,13 +97,13 @@ func getScaledValueFromIntOrPercent(intOrPercent *intstr.IntOrString, total int,
 }
 
 func calculateRemainingDurationSeconds(instance v1beta1.Disruption) int64 {
-	return calculateDeadlineSeconds(instance.Spec.DurationSeconds, instance.ObjectMeta.CreationTimestamp.Time)
+	return calculateDeadlineSeconds(instance.Spec.Duration, instance.ObjectMeta.CreationTimestamp.Time)
 }
 
 // returned value can be negative if deadline is in the past
-func calculateDeadlineSeconds(durationSeconds int64, creationTime time.Time) int64 {
+func calculateDeadlineSeconds(duration time.Duration, creationTime time.Time) int64 {
 	// first we must calculate the timout from when the disruption was created, not from now
-	timeout := creationTime.Add(time.Second * time.Duration(durationSeconds))
+	timeout := creationTime.Add(duration)
 	now := time.Now() // rather not take the risk that the time changes by a second during this function
 
 	// return the number of seconds between now and the deadline

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"time"
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -93,6 +94,20 @@ func getScaledValueFromIntOrPercent(intOrPercent *intstr.IntOrString, total int,
 	}
 
 	return value, nil
+}
+
+func calculateDeadlineSeconds(durationSeconds int64, creationTime time.Time) int64 {
+	// first we must calculate the timout from when the disruption was created, not from now
+	timeout := creationTime.Add(time.Second * time.Duration(durationSeconds))
+	now := time.Now() // rather not take the risk that the time changes by a second during this function
+
+	// if we missed it, return a 0 second deadline
+	if timeout.Before(now) {
+		return 0
+	}
+
+	// otherwise return the number of seconds between now and the deadline
+	return int64(timeout.Sub(now).Seconds())
 }
 
 // assert label selector matches valid grammar, avoids CORE-414

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -96,17 +96,16 @@ func getScaledValueFromIntOrPercent(intOrPercent *intstr.IntOrString, total int,
 	return value, nil
 }
 
+func calculateRemainingDurationSeconds(instance v1beta1.Disruption) int64 {
+	return calculateDeadlineSeconds(instance.Spec.DurationSeconds, instance.ObjectMeta.CreationTimestamp.Time)
+}
+
 func calculateDeadlineSeconds(durationSeconds int64, creationTime time.Time) int64 {
 	// first we must calculate the timout from when the disruption was created, not from now
 	timeout := creationTime.Add(time.Second * time.Duration(durationSeconds))
 	now := time.Now() // rather not take the risk that the time changes by a second during this function
 
-	// if we missed it, return a 0 second deadline
-	if timeout.Before(now) {
-		return 0
-	}
-
-	// otherwise return the number of seconds between now and the deadline
+	// return the number of seconds between now and the deadline
 	return int64(timeout.Sub(now).Seconds())
 }
 

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -97,7 +97,10 @@ func getScaledValueFromIntOrPercent(intOrPercent *intstr.IntOrString, total int,
 }
 
 func calculateRemainingDurationSeconds(instance v1beta1.Disruption) int64 {
-	return calculateDeadlineSeconds(instance.Spec.Duration, instance.ObjectMeta.CreationTimestamp.Time)
+	return calculateDeadlineSeconds(
+		time.Duration(instance.Spec.DurationSeconds)*time.Second,
+		instance.ObjectMeta.CreationTimestamp.Time,
+	)
 }
 
 // returned value can be negative if deadline is in the past

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -100,6 +100,7 @@ func calculateRemainingDurationSeconds(instance v1beta1.Disruption) int64 {
 	return calculateDeadlineSeconds(instance.Spec.DurationSeconds, instance.ObjectMeta.CreationTimestamp.Time)
 }
 
+// returned value can be negative if deadline is in the past
 func calculateDeadlineSeconds(durationSeconds int64, creationTime time.Time) int64 {
 	// first we must calculate the timout from when the disruption was created, not from now
 	timeout := creationTime.Add(time.Second * time.Duration(durationSeconds))

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,6 +18,17 @@ Let's imagine a node with two pods running: `foo` and `bar` and a disruption dro
 * Applying this disruption at the `pod` level and with a selector targeting the `foo` pod will result with the `foo` pod not being able to send any packets, but the `bar` pod will still be able to send packets, as well as other processes on the node.
 * Applying this disruption at the `node` level and with a selector targeting the node itself, both `foo` and `bar` pods won't be able to send network packets anymore, as well as all the other processes running on the node.
 
+## Duration
+
+The `Disruption` spec takes a `durationSeconds` field. This field represents the number of seconds after the disruption's creation before 
+all chaos pods automatically terminate and the disruption stops injecting new ones.
+
+If a `durationSeconds` is not specified, then a disruption will receive the default duration, which is configured at the controller level by setting 
+`controller.defaultDuration` in the controller's config map, and this value defaults to 1 hour.
+
+After a disruption's duration expires, the disruption resource will live in k8s for a default of 15 minutes. This can be configured by altering 
+`controller.expiredDisruptionGCDelay` in the controller's config map.
+
 ## Targeting
 
 The `Disruption` resource uses [label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to target pods and nodes. The controller will retrieve all pods or nodes matching the given label selector and will randomly select a number (defined in the `count` field) of matching targets. It's possible to specify multiple label selectors, in which case the controller will select from targets that match all of them. Once applied, you can see the targeted pods/nodes by describing the `Disruption` resource.

--- a/examples/complete.yaml
+++ b/examples/complete.yaml
@@ -31,6 +31,7 @@ spec:
     - demo
     - demo2
   count: 1 # number of pods to target or a percentage (1% - 100%)
+  durationSeconds: 2700 # the number of seconds before the disruption terminates itself
   nodeFailure: # node kernel panic or shutdown
     shutdown: true # optional, shutdown the host instead of triggering a stack dump (defaults to false)
   containerFailure: # terminating a pod's containers gracefully or non-gracefully

--- a/examples/timed_disruption.yaml
+++ b/examples/timed_disruption.yaml
@@ -1,0 +1,18 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+apiVersion: chaos.datadoghq.com/v1beta1
+kind: Disruption
+metadata:
+  name: network-drop
+  namespace: chaos-demo
+spec:
+  level: pod
+  selector:
+    app: demo-curl
+  count: 1
+  durationSeconds: 1800 # Disruption will time out after 1800s (30m)
+  network:
+    delay: 300

--- a/main.go
+++ b/main.go
@@ -245,6 +245,7 @@ func main() {
 		InjectorDNSDisruptionKubeDNS:          cfg.Injector.DNSDisruption.KubeDNS,
 		InjectorNetworkDisruptionAllowedHosts: cfg.Injector.NetworkDisruption.AllowedHosts,
 		ImagePullSecrets:                      cfg.Controller.ImagePullSecrets,
+		ExpiredDisruptionGCDelay:              -900, // 15 minutes, measured in seconds
 	}
 
 	if err := r.SetupWithManager(mgr); err != nil {

--- a/main.go
+++ b/main.go
@@ -278,6 +278,14 @@ func main() {
 		},
 	})
 
+	// register spec default mutating webhook
+	mgr.GetWebhookServer().Register("/mutate-chaos-datadoghq-com-v1beta1-disruption-spec-defaults", &webhook.Admission{
+		Handler: &chaoswebhook.DefaultMutator{
+			Client: mgr.GetClient(),
+			Log:    logger,
+		},
+	})
+
 	// +kubebuilder:scaffold:builder
 
 	logger.Infow("restarting chaos-controller")

--- a/types/types.go
+++ b/types/types.go
@@ -48,6 +48,8 @@ const (
 	DisruptionInjectionStatusPartiallyInjected DisruptionInjectionStatus = "PartiallyInjected"
 	// DisruptionInjectionStatusInjected is the value of the injection status of a fully injected disruption
 	DisruptionInjectionStatusInjected DisruptionInjectionStatus = "Injected"
+	// DisruptionInjectionStatusPreviouslyInjected is the value of the injection status after the duration has expired
+	DisruptionInjectionStatusPreviouslyInjected DisruptionInjectionStatus = "PreviouslyInjected"
 
 	// DisruptionNameLabel is the label used to identify the disruption name for a chaos pod. This is used to determine pod ownership.
 	DisruptionNameLabel = "chaos.datadoghq.com/disruption-name"

--- a/webhook/defaults.go
+++ b/webhook/defaults.go
@@ -19,9 +19,10 @@ import (
 )
 
 type DefaultMutator struct {
-	Client  client.Client
-	Log     *zap.SugaredLogger
-	decoder *admission.Decoder
+	Client          client.Client
+	Log             *zap.SugaredLogger
+	decoder         *admission.Decoder
+	DefaultDuration time.Duration
 }
 
 func (m *DefaultMutator) InjectDecoder(d *admission.Decoder) error {
@@ -48,9 +49,8 @@ func (m *DefaultMutator) Handle(ctx context.Context, req admission.Request) admi
 	}
 
 	if dis.Spec.Duration == 0 {
-		defaultDuration := time.Hour
-		m.Log.Infow(fmt.Sprintf("setting default duration of %s in disruption", defaultDuration), "name", dis.Name, "namespace", dis.Namespace)
-		dis.Spec.Duration = defaultDuration
+		m.Log.Infow(fmt.Sprintf("setting default duration of %s in disruption", m.DefaultDuration), "name", dis.Name, "namespace", dis.Namespace)
+		dis.Spec.Duration = m.DefaultDuration
 	}
 
 	marshaled, err := json.Marshal(dis)

--- a/webhook/defaults.go
+++ b/webhook/defaults.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/chaos-controller/api/v1beta1"
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type DefaultMutator struct {
+	Client  client.Client
+	Log     *zap.SugaredLogger
+	decoder *admission.Decoder
+}
+
+func (m *DefaultMutator) InjectDecoder(d *admission.Decoder) error {
+	m.decoder = d
+
+	return nil
+}
+
+func (m *DefaultMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	dis := &v1beta1.Disruption{}
+
+	// ensure decoder is set
+	if m.decoder == nil {
+		m.Log.Errorw("webhook decoder seems to be nil while it should not, aborting")
+
+		return admission.Errored(http.StatusInternalServerError, nil)
+	}
+
+	// decode object
+	if err := m.decoder.Decode(req, dis); err != nil {
+		m.Log.Errorw("error decoding disruption object", "error", err, "name", req.Name, "namespace", req.Namespace)
+
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if dis.Spec.DurationSeconds == 0 {
+		defaultDuration := int64(3600)
+		m.Log.Infow(fmt.Sprintf("setting default duration of %d seconds in disruption", defaultDuration), "name", dis.Name, "namespace", dis.Namespace)
+		dis.Spec.DurationSeconds = defaultDuration
+	}
+
+	marshaled, err := json.Marshal(dis)
+	if err != nil {
+		m.Log.Errorw("error encoding modified disruption object", "error", err, "name", dis.Name, "namespace", dis.Namespace)
+
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
+}

--- a/webhook/defaults.go
+++ b/webhook/defaults.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"go.uber.org/zap"
@@ -46,10 +47,10 @@ func (m *DefaultMutator) Handle(ctx context.Context, req admission.Request) admi
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if dis.Spec.DurationSeconds == 0 {
-		defaultDuration := int64(3600)
-		m.Log.Infow(fmt.Sprintf("setting default duration of %d seconds in disruption", defaultDuration), "name", dis.Name, "namespace", dis.Namespace)
-		dis.Spec.DurationSeconds = defaultDuration
+	if dis.Spec.Duration == 0 {
+		defaultDuration := time.Hour
+		m.Log.Infow(fmt.Sprintf("setting default duration of %s in disruption", defaultDuration), "name", dis.Name, "namespace", dis.Namespace)
+		dis.Spec.Duration = defaultDuration
 	}
 
 	marshaled, err := json.Marshal(dis)

--- a/webhook/defaults.go
+++ b/webhook/defaults.go
@@ -48,9 +48,9 @@ func (m *DefaultMutator) Handle(ctx context.Context, req admission.Request) admi
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if dis.Spec.Duration == 0 {
+	if dis.Spec.DurationSeconds == 0 {
 		m.Log.Infow(fmt.Sprintf("setting default duration of %s in disruption", m.DefaultDuration), "name", dis.Name, "namespace", dis.Namespace)
-		dis.Spec.Duration = m.DefaultDuration
+		dis.Spec.DurationSeconds = int64(m.DefaultDuration.Seconds())
 	}
 
 	marshaled, err := json.Marshal(dis)


### PR DESCRIPTION
## What does this PR do?

- [x] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior:

- Adds a new field to the disruption spec: `durationSeconds`
- Adds a new mutatingadmissionwebhook for setting spec defaults
- Adds a new controller configuration option: `expired-disruption-gc-delay`
- Adds a new disruption injection status: `PreviouslyInjected`
- Rolls back the minikube kubernetes version to 1.19.latest

Disruptions now have a `spec.durationSeconds` value, that defaults to `3600` (one hour). When chaos pods are created, their `activeDeadlineSeconds` is set so that they expire `spec.durationSeconds` after the disruption was first created (not the chaos pod). After a disruption's duration has expired, at least`expired-disruption-gc-delay` seconds later, the disruption will be deleted and all of the chaos pods removed.

Motivation for change:
https://github.com/DataDog/chaos-controller/discussions/379

## Code Quality

### Testing

- [ ] I used existing unit tests
- [ ] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [ ] The documentation is up to date
- [ ] My code is sufficiently commented
- [ ] I have tested to the best of my ability
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))

My documentation is not up to date, but I wanted to get feedback before I finished the PR