### PR TITLE
[CHAOS-20] Alert on Build. Pre-Release, and Release failure pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,10 +18,16 @@ stages:
   - release-public
   - notify
 
-# Slack Notify Image
+# Slack Notify Base
 .slack-notifier-base:
   tags: [ "runner:main", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/slack-notifier:latest
+  allow_failure: true
+  when: on_failure
+  script:
+    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
+    - 'MESSAGE_TEXT=":siren: | $CI_PIPELINE_NAME Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
+    - postmessage "#chaos-ops" "$MESSAGE_TEXT"
 
 # CI image
 .docker-runner: &docker-runner
@@ -197,39 +203,23 @@ release-docker-hub-tag:
   variables:
     TAG: "${CI_COMMIT_TAG}"
 
-.slack-notifier-script: &slack-notifier-script
-  script:
-    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
-    - 'MESSAGE_TEXT=":siren: | $CI_PIPELINE_NAME Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
-    - postmessage "#chaos-ops" "$MESSAGE_TEXT"
-
-
 slack-notifier-pre-release.on-failure:
   extends: .slack-notifier-base
   variables:
     CI_PIPELINE_NAME: "Pre-Release"
-  when: on_failure
   stage: pre-release
-  allow_failure: true
-  <<: *slack-notifier-script
 
 slack-notifier-release.on-failure:
   extends: .slack-notifier-base
   variables:
     CI_PIPELINE_NAME: "Release"
-  when: on_failure
   stage: release
-  allow_failure: true
-  <<: *slack-notifier-script
 
 slack-notifier-build.on-failure:
   extends: .slack-notifier-base
   variables:
     CI_PIPELINE_NAME: "Build"
-  when: on_failure
   stage: build
-  allow_failure: true
   only:
     - main
     - tags
-  <<: *slack-notifier-script

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -228,7 +228,7 @@ slack-notifier-build.on-failure:
   extends: .slack-notifier-base
   variables:
     CI_PIPELINE_NAME: "Build"
-  when: on_success
+  when: on_failure
   stage: build
   allow_failure: true
   #only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,28 +201,26 @@ release-docker-hub-tag:
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - 'MESSAGE_TEXT=":siren: | $CI_PIPELINE_NAME Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
-    - postmessage "#test-chaosnotifier" "$MESSAGE_TEXT"
+    - postmessage "#chaos-ops" "$MESSAGE_TEXT"
 
 
 slack-notifier-pre-release.on-failure:
   extends: .slack-notifier-base
+  variables:
+    CI_PIPELINE_NAME: "Pre-Release"
   when: on_failure
   stage: pre-release
   allow_failure: true
-  script:
-    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
-    - 'MESSAGE_TEXT=":siren:   | Pre-Release Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
-    - postmessage "#chaos-ops" "$MESSAGE_TEXT"
+  <<: *slack-notifier-script
 
 slack-notifier-release.on-failure:
   extends: .slack-notifier-base
+  variables:
+    CI_PIPELINE_NAME: "Release"
   when: on_failure
   stage: release
   allow_failure: true
-  script:
-    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
-    - 'MESSAGE_TEXT=":siren:   | Release Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
-    - postmessage "#chaos-ops" "$MESSAGE_TEXT"
+  <<: *slack-notifier-script
 
 slack-notifier-build.on-failure:
   extends: .slack-notifier-base
@@ -231,11 +229,7 @@ slack-notifier-build.on-failure:
   when: on_failure
   stage: build
   allow_failure: true
-  #only:
-  #  - main
-  #  - tags
+  only:
+    - main
+    - tags
   <<: *slack-notifier-script
-  #script:
-  #  - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
-  #  - 'MESSAGE_TEXT=":siren:   | Build Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
-  #  - postmessage "#chaos-ops" "$MESSAGE_TEXT"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -205,7 +205,7 @@ slack-notifier-pre-release.on-failure:
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - 'MESSAGE_TEXT=":siren:   | Pre-Release Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
-    - postmessage "#test-chaosnotifier" "$MESSAGE_TEXT"
+    - postmessage "#chaos-ops" "$MESSAGE_TEXT"
 
 slack-notifier-release.on-failure:
   extends: .slack-notifier-base
@@ -215,7 +215,7 @@ slack-notifier-release.on-failure:
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - 'MESSAGE_TEXT=":siren:   | Release Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
-    - postmessage "#test-chaosnotifier" "$MESSAGE_TEXT"
+    - postmessage "#chaos-ops" "$MESSAGE_TEXT"
 
 slack-notifier-build.on-failure:
   extends: .slack-notifier-base
@@ -228,4 +228,4 @@ slack-notifier-build.on-failure:
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - 'MESSAGE_TEXT=":siren:   | Build Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
-    - postmessage "#test-chaosnotifier" "$MESSAGE_TEXT"
+    - postmessage "#chaos-ops" "$MESSAGE_TEXT"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,12 @@ stages:
   - pre-release
   - release
   - release-public
+  - notify
+
+# Slack Notify Image
+.slack-notifier-base:
+  tags: [ "runner:main", "size:large" ]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/slack-notifier:latest
 
 # CI image
 .docker-runner: &docker-runner
@@ -190,3 +196,36 @@ release-docker-hub-tag:
     - tags
   variables:
     TAG: "${CI_COMMIT_TAG}"
+
+slack-notifier-pre-release.on-failure:
+  extends: .slack-notifier-base
+  when: on_failure
+  stage: pre-release
+  allow_failure: true
+  script:
+    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
+    - 'MESSAGE_TEXT=":siren:   | Pre-Release Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
+    - postmessage "#test-chaosnotifier" "$MESSAGE_TEXT"
+
+slack-notifier-release.on-failure:
+  extends: .slack-notifier-base
+  when: on_failure
+  stage: release
+  allow_failure: true
+  script:
+    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
+    - 'MESSAGE_TEXT=":siren:   | Release Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
+    - postmessage "#test-chaosnotifier" "$MESSAGE_TEXT"
+
+slack-notifier-build.on-failure:
+  extends: .slack-notifier-base
+  when: on_failure
+  stage: build
+  allow_failure: true
+  only:
+    - main
+    - tags
+  script:
+    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
+    - 'MESSAGE_TEXT=":siren:   | Build Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
+    - postmessage "#test-chaosnotifier" "$MESSAGE_TEXT"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,6 +197,13 @@ release-docker-hub-tag:
   variables:
     TAG: "${CI_COMMIT_TAG}"
 
+.slack-notifier-script: &slack-notifier-script
+  script:
+    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
+    - 'MESSAGE_TEXT=":siren: | $CI_PIPELINE_NAME Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
+    - postmessage "#test-chaosnotifier" "$MESSAGE_TEXT"
+
+
 slack-notifier-pre-release.on-failure:
   extends: .slack-notifier-base
   when: on_failure
@@ -219,13 +226,16 @@ slack-notifier-release.on-failure:
 
 slack-notifier-build.on-failure:
   extends: .slack-notifier-base
-  when: on_failure
+  variables:
+    CI_PIPELINE_NAME: "Build"
+  when: on_success
   stage: build
   allow_failure: true
-  only:
-    - main
-    - tags
-  script:
-    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
-    - 'MESSAGE_TEXT=":siren:   | Build Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
-    - postmessage "#chaos-ops" "$MESSAGE_TEXT"
+  #only:
+  #  - main
+  #  - tags
+  <<: *slack-notifier-script
+  #script:
+  #  - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
+  #  - 'MESSAGE_TEXT=":siren:   | Build Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
+  #  - postmessage "#chaos-ops" "$MESSAGE_TEXT"


### PR DESCRIPTION
## What does this PR do?

- [X] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior:

When a release/pre-release pipeline from any branch fails, a slack message will be sent to #chaos-ops.
When a build pipeline fails on main or tags branches, a slack message will be sent to #chaos-ops

Motivation for change:

We had some release pipelines failing for various reasons without seeing it, leading to errors or unexpected behaviors later, often discovered by users.

### Testing

- [ ] I used existing unit tests
- [X] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

There is a channel (I will delete once this PR is approved) called #test-chaosnotifier) which contains some example messages. These were sent implicitly when a build pipeline succeeds to emulate a failure (failure during a build is harder to emulate than succeed, so the message is simulating what a failure message would look like, but the trigger came from a successful build pipeline).

### Checklist

- [ ] The documentation is up to date
- [ ] My code is sufficiently commented
- [X] I have tested to the best of my ability
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
