### PR TITLE
CHAOS-142: Fix cgroup fetching during node level disruptions

### DIFF
--- a/cgroup/cgroup.go
+++ b/cgroup/cgroup.go
@@ -89,8 +89,14 @@ func (m manager) write(path, data string) error {
 
 // generatePath generates a path within the cgroup like /<mount>/<kind>/<path (kubepods)>
 func (m manager) generatePath(kind string) string {
+	var foundPath string
+
 	generatedPath := fmt.Sprintf("%s%s/%s", m.mount, kind, m.path)
-	foundPath := fmt.Sprintf("%s%s/%s", m.mount, kind, m.cgroup.Paths[kind])
+	if m.cgroup != nil {
+		foundPath = fmt.Sprintf("%s%s/%s", m.mount, kind, m.cgroup.Paths[kind])
+	} else {
+		foundPath = fmt.Sprintf("%s%s/", m.mount, kind)
+	}
 
 	if generatedPath != foundPath {
 		m.log.Infow("container runtime generated path does not match found cgroup path",

--- a/cgroup/cgroup.go
+++ b/cgroup/cgroup.go
@@ -92,6 +92,7 @@ func (m manager) generatePath(kind string) string {
 	var foundPath string
 
 	generatedPath := fmt.Sprintf("%s%s/%s", m.mount, kind, m.path)
+
 	if m.cgroup != nil {
 		foundPath = fmt.Sprintf("%s%s/%s", m.mount, kind, m.cgroup.Paths[kind])
 	} else {

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -197,13 +197,19 @@ func initConfig() {
 
 	// create cgroup managers
 	for i, cgroupPath := range cgroupPaths {
-		rawContainerID := strings.Split(containerIDs[i], "://") // This is "guaranteed" to work because it was already validated when we called container.New(containerID) earlier
-		foundCgroup, ok := cgroups[rawContainerID[1]]
+		var foundCgroup *cgroup.ContainerCgroup // We want to pass nil for a node level disruption, as we arent targeting a container
 
-		if !ok {
-			log.Errorf("could not find cgroup paths for containerID %s", containerIDs[i])
+		if level == chaostypes.DisruptionLevelPod {
+			var ok bool
 
-			return
+			rawContainerID := strings.Split(containerIDs[i], "://") // This is "guaranteed" to work because it was already validated when we called container.New(containerID) earlier
+			foundCgroup, ok = cgroups[rawContainerID[1]]
+
+			if !ok {
+				log.Errorf("could not find cgroup paths for containerID %s", containerIDs[i])
+
+				return
+			}
 		}
 
 		log.Infow("creating a new cgroup manager", "cgroupPath", cgroupPath)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior:

Fixes https://github.com/DataDog/chaos-controller/issues/409

Motivation for change:

## Code Quality

### Testing

- [ ] I used existing unit tests
- [x] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [ ] The documentation is up to date
- [ ] My code is sufficiently commented
- [ ] I have tested to the best of my ability
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
