### PR TITLE
e2e test: 30s timeout -> 45s timeout

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -47,7 +47,7 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 const (
-	timeout = time.Second * 30
+	timeout = time.Second * 45
 )
 
 var (


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior:

e2e test times out at 30s fairly often in CircleCI, this requires us to run it again and each run takes ~ 12 minutes which slows down development. 45s has much higher success rate, so let's change it!

## Code Quality

### Testing

- [x] I used existing unit tests
- [ ] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [x] The documentation is up to date
- [x] My code is sufficiently commented
- [x] I have tested to the best of my ability
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
