### PR TITLE
Specify overwrite=true for minikube image load

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ This document explains how to install and run the project on a local minikube cl
 To get started, we need to have the following software installed:
 
 * [docker](https://docs.docker.com/get-docker/)
-* [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) (1: Installation)
+* [minikube >=1.21](https://kubernetes.io/docs/tasks/tools/install-minikube/) (1: Installation)
 * [golangci-lint](https://github.com/golangci/golangci-lint)
 * [Kubebuilder Prerequisites](https://book.kubebuilder.io/quick-start.html#prerequisites) (go, docker, kubectl, kubebuilder, controller-gen)
 * [helm](https://helm.sh/docs/intro/quickstart/)

--- a/Makefile
+++ b/Makefile
@@ -73,15 +73,15 @@ generate: controller-gen
 # Build the docker images
 minikube-build-manager: manager
 	docker build -t ${MANAGER_IMAGE} -f bin/manager/Dockerfile ./bin/manager/
-	minikube image load ${MANAGER_IMAGE}
+	minikube image load --daemon=false --overwrite=true ${MANAGER_IMAGE}
 
 minikube-build-injector: injector
 	docker build -t ${INJECTOR_IMAGE} -f bin/injector/Dockerfile ./bin/injector/
-	minikube image load ${INJECTOR_IMAGE}
+	minikube image load --daemon=false --overwrite=true ${INJECTOR_IMAGE}
 
 minikube-build-handler: handler
 	docker build -t ${HANDLER_IMAGE} -f bin/handler/Dockerfile ./bin/handler/
-	minikube image load ${HANDLER_IMAGE}
+	minikube image load --daemon=false --overwrite=true ${HANDLER_IMAGE}
 
 minikube-build: minikube-build-manager minikube-build-injector minikube-build-handler
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves Documentation

A brief description of changes to implementation or controller behavior:
Specifically always overwrite an image when rebuilding the controller and uploading to minikube

Motivation for change:
Making sure local developers have https://github.com/kubernetes/minikube/pull/11366 in their minikube (as caught by @Azoam)

## Code Quality

### Testing

- [ ] I used existing unit tests
- [ ] I manually tested locally
- [ ] I will manually test in a canary deployment

Please list your manual testing steps (sample `yaml` file, commands, important checks):

### Checklist

- [ ] The documentation is up to date
- [ ] My code is sufficiently commented
- [ ] I have tested to the best of my ability
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md))
