### PR TITLE
Modify ddmark ExclusiveFields to allow for specifying a one-to-many relationship

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -37,6 +37,8 @@ import (
 
 // DisruptionSpec defines the desired state of Disruption
 // +ddmark:validation:ExclusiveFields={Network,DNS}
+// +ddmark:validation:ExclusiveFields={ContainerFailure,CPUPressure,DiskPressure,NodeFailure,Network,DNS}
+// +ddmark:validation:ExclusiveFields={NodeFailure,CPUPressure,DiskPressure,ContainerFailure,Network,DNS}
 type DisruptionSpec struct {
 	// +kubebuilder:validation:Required
 	// +ddmark:validation:Required=true

--- a/ddmark/README.md
+++ b/ddmark/README.md
@@ -30,7 +30,7 @@ It also allows us to define custom rules to apply to our structures, and focus t
 - ExclusiveFields:
   - `// +ddmark:validation:ExclusiveFields={<fieldName1>,<fieldName2>,...}`
   - Applies to: `<struct>` type
-  - Asserts only one of the given fieldnames isn’t `nil`
+  - Asserts that if `<fieldname1>` can only be non-nil iff all of the other fields are `nil`
 - Maximum:
   - `// +ddmark:validation:Maximum=<int/uint>`
   - Applies to: `int/uint` field

--- a/ddmark/validation_integration_test.go
+++ b/ddmark/validation_integration_test.go
@@ -154,6 +154,15 @@ exclusivefieldstest:
 			errorList := validateString(exclusivefieldsValidYaml)
 			Expect(errorList).To(HaveLen(0))
 		})
+		It("allows latter fields to be set freely", func() {
+			var exclusivefieldsValidYaml = `
+exclusivefieldstest:
+  bfield: 1
+  cfield: 1
+`
+			errorList := validateString(exclusivefieldsValidYaml)
+			Expect(errorList).To(HaveLen(0))
+		})
 	})
 })
 

--- a/ddmark/validation_teststruct.go
+++ b/ddmark/validation_teststruct.go
@@ -15,12 +15,15 @@ type Teststruct struct {
 }
 
 // +ddmark:validation:ExclusiveFields={PIntField,PStrField}
+// +ddmark:validation:ExclusiveFields={PIntField,BField,CField}
 // +ddmark:validation:ExclusiveFields={IntField,StrField}
 type ExclusiveFieldsTestStruct struct {
 	IntField  int
 	PIntField *int
 	StrField  string
 	PStrField *string
+	BField    int
+	CField    int
 }
 
 type MinMaxTestStruct struct {

--- a/ddmark/validation_unit_test.go
+++ b/ddmark/validation_unit_test.go
@@ -173,5 +173,10 @@ var _ = Describe("Validation Rules Cases", func() {
 			fakeObj.Field3 = 0
 			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(BeNil())
 		})
+
+		It("accepts object with all fields but first set", func() {
+			fakeObj.Field1 = ""
+			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+		})
 	})
 })


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- In order to specify that neither `NodeFailure` nor `ContainerFailure` are appropriate to set alongside other disruption kinds, I wanted to use ddmark's `ExclusiveField` feature. However, because this has previously only been used to handle pairs of fields, assumed a many-to-many relationship: if any specified field is set, none of the others can. I needed a one-to-many relationship, if the first field is set, the rest cannot, but the rest don't necessarily have an interdependent relationship. This change enables that, without breaking any of the existing uses (at least ours)

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
