### PR TITLE
Wait for docker daemon to be ready before starting minikube

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,19 @@ jobs:
             sudo chown circleci:circleci /go /usr/local/bin /usr/local/kubebuilder
       - go_restore_cache
       - run:
+          name: Wait for Docker Daemon to be up and running
+          command: |
+            for i in 0..9; do
+              docker version
+
+              ret=$?
+              if [ $ret -eq 0 ]; then
+                exit 0
+              fi
+
+              sleep 5
+            done
+      - run:
           name: Configure Minikube
           command: |
             curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- add a step to e2e test setup to wait for docker daemon to be up and running before trying to start minikube to avoid a race condition where minikube fails to start because the job starts before the docker daemon is healthy

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.