### PR TITLE
[Chaos-20] Notify on Gitlab Job Failures Correctly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ stages:
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - 'MESSAGE_TEXT=":siren: | A Job in the $CI_PIPELINE_NAME Pipeline Failed | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
-    - postmessage "#test-chaosnotifier2" "$MESSAGE_TEXT"
+    - postmessage "#chaos-ops" "$MESSAGE_TEXT"
 
 # CI image
 .docker-runner: &docker-runner
@@ -71,10 +71,9 @@ build:make:
     - "runner:docker"
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-push:v2875076-79d562c-1.4.0
   before_script:
-    - exit -1
-    #- echo "Logging into the Docker Hub"
-    #- DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.chaos-engineering.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
-    #- aws ssm get-parameter --region us-east-1 --name ci.chaos-engineering.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
+    - echo "Logging into the Docker Hub"
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.chaos-engineering.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.chaos-engineering.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
 
 # pre-release
 # build the target from the local Dockerfile and push it to
@@ -84,10 +83,9 @@ build:make:
   stage: pre-release
   allow_failure: false
   script:
-    - exit -1
-    #- release.sh --build-from=./bin/manager/Dockerfile --build-context=./bin/manager/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${CONTROLLER_IMAGE_NAME} ${TAG}
-    #- release.sh --build-from=./bin/injector/Dockerfile --build-context=./bin/injector/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${INJECTOR_IMAGE_NAME} ${TAG}
-    #- release.sh --build-from=./bin/handler/Dockerfile --build-context=./bin/handler/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${HANDLER_IMAGE_NAME} ${TAG}
+    - release.sh --build-from=./bin/manager/Dockerfile --build-context=./bin/manager/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${CONTROLLER_IMAGE_NAME} ${TAG}
+    - release.sh --build-from=./bin/injector/Dockerfile --build-context=./bin/injector/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${INJECTOR_IMAGE_NAME} ${TAG}
+    - release.sh --build-from=./bin/handler/Dockerfile --build-context=./bin/handler/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${HANDLER_IMAGE_NAME} ${TAG}
   dependencies:
     - build:make
 
@@ -240,6 +238,6 @@ slack-notifier-build.on-failure:
   variables:
     CI_PIPELINE_NAME: "Build"
   needs: ["build:make"]
-  #only:
-  #  - main
-  #  - tags
+  only:
+    - main
+    - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ stages:
   when: on_failure
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
-    - 'MESSAGE_TEXT=":siren: | The $CI_JOB_STAGE Job Failed in the Pipeline CI_PIPELINE_NAME Failed | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
+    - 'MESSAGE_TEXT=":siren: | The $CI_JOB_NAME Job Failed in the Pipeline $CI_PIPELINE_NAME Failed | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
     - postmessage "#test-chaosnotifier2" "$MESSAGE_TEXT"
 
 # CI image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ stages:
   when: on_failure
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
-    - 'MESSAGE_TEXT=":siren: | The $CI_JOB_NAME Job Failed in the Pipeline $CI_PIPELINE_NAME Failed | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
+    - 'MESSAGE_TEXT=":siren: | A Job in the $CI_PIPELINE_NAME Pipeline Failed | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
     - postmessage "#test-chaosnotifier2" "$MESSAGE_TEXT"
 
 # CI image
@@ -56,8 +56,7 @@ build:make:
   stage: build
   when: always
   script:
-    - exit -1
-    #- make
+    - make
   artifacts:
     paths:
       - bin/injector/injector

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,7 @@ build:make:
   <<: *meta-release
   stage: pre-release
   script:
+    - exit -1
     #- release.sh --build-from=./bin/manager/Dockerfile --build-context=./bin/manager/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${CONTROLLER_IMAGE_NAME} ${TAG}
     #- release.sh --build-from=./bin/injector/Dockerfile --build-context=./bin/injector/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${INJECTOR_IMAGE_NAME} ${TAG}
     #- release.sh --build-from=./bin/handler/Dockerfile --build-context=./bin/handler/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${HANDLER_IMAGE_NAME} ${TAG}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ build:make:
   stage: build
   when: always
   script:
-     - make
+    - make
   artifacts:
     paths:
       - bin/injector/injector

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,11 +20,11 @@ stages:
 
 # Slack Notify Base
 .slack-notifier-base:
+  stage: notify
   tags: [ "runner:main", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/slack-notifier:latest
   allow_failure: true
   when: on_failure
-  stage: notify
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - 'MESSAGE_TEXT=":siren: | The $CI_JOB_STAGE Job Failed in the Pipeline CI_PIPELINE_NAME Failed | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
@@ -239,6 +239,6 @@ slack-notifier-build.on-failure:
   variables:
     CI_PIPELINE_NAME: "Build"
   needs: ["build:make"]
-  only:
-    - main
-    - tags
+  #only:
+  #  - main
+  #  - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,8 @@ build:make:
   stage: build
   when: always
   script:
-    - make
+    - exit -1
+    #- make
   artifacts:
     paths:
       - bin/injector/injector
@@ -71,9 +72,10 @@ build:make:
     - "runner:docker"
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-push:v2875076-79d562c-1.4.0
   before_script:
-    - echo "Logging into the Docker Hub"
-    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.chaos-engineering.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.chaos-engineering.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
+    - exit -1
+    #- echo "Logging into the Docker Hub"
+    #- DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.chaos-engineering.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
+    #- aws ssm get-parameter --region us-east-1 --name ci.chaos-engineering.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
 
 # pre-release
 # build the target from the local Dockerfile and push it to
@@ -82,9 +84,9 @@ build:make:
   <<: *meta-release
   stage: pre-release
   script:
-    - release.sh --build-from=./bin/manager/Dockerfile --build-context=./bin/manager/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${CONTROLLER_IMAGE_NAME} ${TAG}
-    - release.sh --build-from=./bin/injector/Dockerfile --build-context=./bin/injector/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${INJECTOR_IMAGE_NAME} ${TAG}
-    - release.sh --build-from=./bin/handler/Dockerfile --build-context=./bin/handler/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${HANDLER_IMAGE_NAME} ${TAG}
+    #- release.sh --build-from=./bin/manager/Dockerfile --build-context=./bin/manager/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${CONTROLLER_IMAGE_NAME} ${TAG}
+    #- release.sh --build-from=./bin/injector/Dockerfile --build-context=./bin/injector/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${INJECTOR_IMAGE_NAME} ${TAG}
+    #- release.sh --build-from=./bin/handler/Dockerfile --build-context=./bin/handler/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${HANDLER_IMAGE_NAME} ${TAG}
   dependencies:
     - build:make
 
@@ -204,12 +206,14 @@ release-docker-hub-tag:
   variables:
     TAG: "${CI_COMMIT_TAG}"
 
+# notify slack when the pre-release job fails
 slack-notifier-pre-release.on-failure:
   extends: .slack-notifier-base
   variables:
     CI_PIPELINE_NAME: "Pre-Release"
   needs: ["pre-release-ref"]
 
+# notify slack when the release related jobs fail
 slack-notifier-release-controller.on-failure:
   extends: .slack-notifier-base
   variables:
@@ -228,6 +232,7 @@ slack-notifier-release-injector.on-failure:
     CI_PIPELINE_NAME: "Release"
   needs: ["release-injector-ref"]
 
+# notify slack when the build job fails ONLY on the main and tags branches
 slack-notifier-build.on-failure:
   extends: .slack-notifier-base
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,21 +13,21 @@ variables:
 stages:
   - ci-image
   - build
-  - notify-build-fail
   - pre-release
-  - notify-pre-release-fail
   - release
-  - notify-release-fail
   - release-public
+  - notify
 
 # Slack Notify Base
 .slack-notifier-base:
   tags: [ "runner:main", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/slack-notifier:latest
   allow_failure: true
+  when: on_failure
+  stage: notify
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
-    - 'MESSAGE_TEXT=":siren: | $CI_PIPELINE_NAME Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
+    - 'MESSAGE_TEXT=":siren: | The $CI_JOB_STAGE Job Failed in the Pipeline CI_PIPELINE_NAME Failed | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
     - postmessage "#test-chaosnotifier2" "$MESSAGE_TEXT"
 
 # CI image
@@ -208,24 +208,30 @@ slack-notifier-pre-release.on-failure:
   extends: .slack-notifier-base
   variables:
     CI_PIPELINE_NAME: "Pre-Release"
-  needs: ["pre-release"]
-  when: on_failure
-  stage: notify-pre-release-fail
+  needs: ["pre-release-ref"]
 
-slack-notifier-release.on-failure:
+slack-notifier-release-controller.on-failure:
   extends: .slack-notifier-base
   variables:
     CI_PIPELINE_NAME: "Release"
-  needs: ["release"]
-  when: on_failure
-  stage: notify-relase-fail
+  needs: ["release-controller-ref"]
+
+slack-notifier-release-handler.on-failure:
+  extends: .slack-notifier-base
+  variables:
+    CI_PIPELINE_NAME: "Release"
+  needs: ["release-handler-ref"]
+
+slack-notifier-release-injector.on-failure:
+  extends: .slack-notifier-base
+  variables:
+    CI_PIPELINE_NAME: "Release"
+  needs: ["release-injector-ref"]
 
 slack-notifier-build.on-failure:
   extends: .slack-notifier-base
   variables:
     CI_PIPELINE_NAME: "Build"
-  stage: notify-build-fail
-  when: on_success
   needs: ["build:make"]
   only:
     - main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,9 +54,11 @@ ci-image:
 build:make:
   <<: *common
   stage: build
+  allow_failure: true
   when: always
   script:
-    - make
+    - exit 1
+    #- make
   artifacts:
     paths:
       - bin/injector/injector

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,21 +13,22 @@ variables:
 stages:
   - ci-image
   - build
+  - notify-build-fail
   - pre-release
+  - notify-pre-release-fail
   - release
+  - notify-release-fail
   - release-public
-  - notify
 
 # Slack Notify Base
 .slack-notifier-base:
   tags: [ "runner:main", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/slack-notifier:latest
   allow_failure: true
-  when: on_failure
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - 'MESSAGE_TEXT=":siren: | $CI_PIPELINE_NAME Pipeline Failure | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ] [ <$BUILD_URL|$CI_PIPELINE_ID> ]   :siren:"'
-    - postmessage "#chaos-ops" "$MESSAGE_TEXT"
+    - postmessage "#test-chaosnotifier2" "$MESSAGE_TEXT"
 
 # CI image
 .docker-runner: &docker-runner
@@ -207,19 +208,25 @@ slack-notifier-pre-release.on-failure:
   extends: .slack-notifier-base
   variables:
     CI_PIPELINE_NAME: "Pre-Release"
-  stage: pre-release
+  needs: ["pre-release"]
+  when: on_failure
+  stage: notify-pre-release-fail
 
 slack-notifier-release.on-failure:
   extends: .slack-notifier-base
   variables:
     CI_PIPELINE_NAME: "Release"
-  stage: release
+  needs: ["release"]
+  when: on_failure
+  stage: notify-relase-fail
 
 slack-notifier-build.on-failure:
   extends: .slack-notifier-base
   variables:
     CI_PIPELINE_NAME: "Build"
-  stage: build
+  stage: notify-build-fail
+  when: on_success
+  needs: ["build:make"]
   only:
     - main
     - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,11 +54,9 @@ ci-image:
 build:make:
   <<: *common
   stage: build
-  allow_failure: true
   when: always
   script:
-    - exit 1
-    #- make
+     - make
   artifacts:
     paths:
       - bin/injector/injector
@@ -84,6 +82,7 @@ build:make:
 .pre-release: &pre-release
   <<: *meta-release
   stage: pre-release
+  allow_failure: false
   script:
     - exit -1
     #- release.sh --build-from=./bin/manager/Dockerfile --build-context=./bin/manager/ 727006795293.dkr.ecr.us-east-1.amazonaws.com/${CONTROLLER_IMAGE_NAME} ${TAG}
@@ -117,6 +116,7 @@ pre-release-tag:
 .release: &release
   <<: *meta-release
   stage: release
+  allow_failure: false
   script:
     - release.sh --pull-from=727006795293.dkr.ecr.us-east-1.amazonaws.com/${IMAGE}:${TAG} eu.gcr.io/datadog-staging/${IMAGE} ${TAG}
     - release.sh --pull-from=727006795293.dkr.ecr.us-east-1.amazonaws.com/${IMAGE}:${TAG} eu.gcr.io/datadog-prod/${IMAGE} ${TAG}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [X] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:

We added a way to notify on certain job failures in our gitlab ci. Turns out `on_failure` is not stage specific, but means "on_failure of ANY previous stage" not the current stage and previously believed. Therefore the bug occurring was when the build stage would fail (which often times happens with new branches), the pre-release and release notifiers would go off because build is a previous stage to them. Pre-release and Release notifier were requested to go off no matter what branch they were run in, therefore all build jobs would be notified which is not intended.

The solution here is to create 5 notifiers in their own notify stage towards the end of the pipeline. Each notifier corresponds to a specific job under the big three umbrellas Build, Pre-Release, and Release. Release contains 3 jobs of importance therefore we have 5 jobs if you include 1 job for both Build and Pre-Release. The strategy we are using here which will hopefully solve this issue is using the `needs` keyword. This keyword should make it so that notifiers will ONLY go off if their specified job fails. Once that specified job fails, the notifier in next on the list to run. If the job never runs, neither does the notifier.

We are also adding that all manual jobs do NOT ignore failure. When ignoring failures with `allow_failures` it makes it difficult to notify on those failures. This should be fine as the manual jobs (pre-release, release)  make sense to fail the pipeline if one of them fails. If pre-release fails, then release shouldn't be run on that pipeline without fixing whatever caused pre-release to fail.

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

I tested manually by commiting a few test changes to the branch to see the changes were correct. Please check the corresponding gitlab pipelines for each testing commit to see how this would work in practice.
