### PR TITLE
Remove Pre-Release & Release Slack Notifications

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -203,18 +203,6 @@ release-docker-hub-tag:
   variables:
     TAG: "${CI_COMMIT_TAG}"
 
-slack-notifier-pre-release.on-failure:
-  extends: .slack-notifier-base
-  variables:
-    CI_PIPELINE_NAME: "Pre-Release"
-  stage: pre-release
-
-slack-notifier-release.on-failure:
-  extends: .slack-notifier-base
-  variables:
-    CI_PIPELINE_NAME: "Release"
-  stage: release
-
 slack-notifier-build.on-failure:
   extends: .slack-notifier-base
   variables:


### PR DESCRIPTION
## What does this PR do?

Removes the gitlab ci configuration for slack notifications when pre-release and release fail. The jobs do not work as intended. The issues lie in the manual jobs. Because they are manual, notifying on them becomes difficult because the pipelines would continue until the manual job is finished (which we may not always want).

Because the build stage is not manual, we can keep the notification for when Build fails on the main and tags branches.

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [X] Fixes a bug
- [ ] Improves documentation or testing
