### PR TITLE
Extract proxy image. Doc fixes.

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
         host: {{ .Values.controller.webhook.host | quote }}
         port: {{ .Values.controller.webhook.port }}
     injector:
-      image: {{ printf "%s:%s" .Values.images.injector .Values.images.tag | quote }}
+      image: {{ .Values.images.injector | quote }}
       {{- if .Values.injector.annotations }}
       annotations:
         {{- range $key, $val := .Values.injector.annotations }}
@@ -49,5 +49,5 @@ data:
       {{- end }}
     handler:
       enabled: {{ .Values.handler.enabled }}
-      image: {{ printf "%s:%s" .Values.images.handler .Values.images.tag | quote }}
+      image: {{ .Values.images.handler | quote }}
       timeout: {{ .Values.handler.timeout | quote }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccount: chaos-controller
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: {{ .Values.images.proxy }}
         imagePullPolicy: IfNotPresent
         args:
         - --secure-listen-address=0.0.0.0:8443
@@ -31,7 +31,7 @@ spec:
         - containerPort: 8443
           name: https
       - name: manager
-        image: {{ .Values.images.controller }}:{{ .Values.images.tag }}
+        image: {{ .Values.images.controller }}
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/manager

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,10 +4,10 @@
 # Copyright 2021 Datadog, Inc.
 
 images: # images and tag to pull for each component of the stack
-  controller: docker.io/library/chaos-controller
-  injector: docker.io/library/chaos-injector
-  handler: docker.io/library/chaos-handler
-  tag: latest
+  controller: docker.io/library/chaos-controller:latest
+  injector: docker.io/library/chaos-injector:latest
+  handler: docker.io/library/chaos-handler:latest
+  proxy: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
   pullSecrets: false # name of the secret object to use when pulling images
 
 controller:
@@ -25,9 +25,9 @@ injector:
   annotations: {} # extra annotations passed to the chaos injector pods
   serviceAccount: chaos-injector # service account to use for the chaos injector pods
   serviceAccountNamespace: chaos-engineering # namespace where the service account can be found (NOTE: changing this will change the namespace in which the chaos pods are created)
-  dnsDisruption:
-    dnsServer: "8.8.8.8"
-    kubeDns: "off"
+  dnsDisruption: # dns disruption configuration
+    dnsServer: "8.8.8.8" # IP address of the upstream dns server
+    kubeDns: "off" # whether to use kube-dns for DNS resolution (off, internal, all)
   networkDisruption: # network disruption general configuration
     allowedHosts: [] # list of always allowed hosts (even if explicitly blocked by a network disruption)
     # (here's the expected format, all fields are optional)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -97,6 +97,7 @@ Internal error occurred: failed calling webhook "chaos-controller-webhook-servic
 You can try disabling the Istio injection on the chaos controller pods. This can be done by adding the following annotation to the Deployment:
 ```
 sidecar.istio.io/inject: "false"
+```
 
 ### Handler
 

--- a/tasks/release.sh
+++ b/tasks/release.sh
@@ -26,7 +26,7 @@ if [ ! -z "$(git fetch --dry-run)" ]; then
 fi
 
 echo "Generating install manifest..."
-helm template ./chart/ --set images.tag=${VERSION} --set images.controller=datadog/chaos-controller --set images.injector=datadog/chaos-injector --set images.handler=datadog/chaos-handler > ./chart/install.yaml
+helm template ./chart/ --set images.controller=datadog/chaos-controller:${VERSION} --set images.injector=datadog/chaos-injector:${VERSION} --set images.handler=datadog/chaos-handler:${VERSION} > ./chart/install.yaml
 git add ./chart/install.yaml
 git commit -m "Generate install manifest for version ${VERSION}"
 echo "Creating git tag..."


### PR DESCRIPTION
## What does this PR do?

- [x] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [x] Improves documentation or testing

Currently the charts allow someone to use custom images for the controller, injector, and handler, but not for the kube-rbac-proxy.
This will not work for everyone as many users might only be allowed to use images from private registries. This PR adds support for that. It also makes small changes/fixes to docs.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `make minikube-start`
    - `make minikube-build`
    - `make install`
