### PR TITLE
Remove CHANGELOG from goreleaser archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,6 @@ archives:
     - LICENSE
     - LICENSE-3rdparty.csv
     - NOTICE
-    - CHANGELOG.md
     - README.md
     - docs/*
   - id: chaosli


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- removes the CHANGELOG.md file from goreleaser archives now that we do not use this file anymore

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
