### PR TITLE
Review network disruption safeguards

### DIFF
--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -153,24 +153,36 @@ func (s *NetworkDisruptionSpec) GenerateArgs() []string {
 // NetworkDisruptionHostSpecFromString parses the given hosts to host specs
 // The expected format for hosts is <host>;<port>;<protocol>
 func NetworkDisruptionHostSpecFromString(hosts []string) ([]NetworkDisruptionHostSpec, error) {
+	var err error
+
 	parsedHosts := []NetworkDisruptionHostSpec{}
 
 	// parse given hosts
 	for _, host := range hosts {
+		port := 0
+		protocol := ""
+
 		// parse host with format <host>;<port>;<protocol>
 		parsedHost := strings.SplitN(host, ";", 3)
 
-		// cast port to int
-		port, err := strconv.Atoi(parsedHost[1])
-		if err != nil {
-			return nil, fmt.Errorf("unexpected port parameter in %s: %v", host, err)
+		// cast port to int if specified
+		if len(parsedHost) > 1 {
+			port, err = strconv.Atoi(parsedHost[1])
+			if err != nil {
+				return nil, fmt.Errorf("unexpected port parameter in %s: %v", host, err)
+			}
+		}
+
+		// get protocol if specified
+		if len(parsedHost) > 2 {
+			protocol = parsedHost[2]
 		}
 
 		// generate host spec
 		parsedHosts = append(parsedHosts, NetworkDisruptionHostSpec{
 			Host:     parsedHost[0],
 			Port:     port,
-			Protocol: parsedHost[2],
+			Protocol: protocol,
 		})
 	}
 

--- a/docs/network_disruption/hosts.md
+++ b/docs/network_disruption/hosts.md
@@ -52,6 +52,21 @@ You can pass a flag to the controller to specify hosts which would be excluded f
 
 It can be configured easily [in the chart values.yaml file](../../chart/values.yaml).
 
+## Q: What are the default excluded hosts?
+
+### Pod level network disruptions
+
+Both of the following safeguards are used to allow the node to communicate with the pod for things like liveness probes.
+
+* to default routes gateways
+* to node IP
+
+### Node level network disruptions
+
+* ARP packets (for cloud providers health checks)
+* SSH packets
+* metadata service (packets going to `169.254.169.154`)
+
 ## Notation
 
 Although the `hosts` field is handled in the same way for both pod and node level disruptions, different network interfaces may be targeted based node configurations. For example, pods that have their own networking interface work differently than pods that use their hosts' networking directly:

--- a/injector/network_disruption_test.go
+++ b/injector/network_disruption_test.go
@@ -306,8 +306,8 @@ var _ = Describe("Failure", func() {
 				tc.AssertCalled(GinkgoT(), "AddFilter", []string{"lo", "eth0", "eth1"}, "1:0", mock.Anything, "nil", "nil", 0, 0, "arp", "1:1")
 			})
 
-			It("should add a filter to apiserver traffic on a non-disrupted band", func() {
-				tc.AssertCalled(GinkgoT(), "AddFilter", []string{"lo", "eth0", "eth1"}, "1:0", mock.Anything, "nil", "192.168.0.254/32", 0, 0, "", "1:1")
+			It("should add a filter to redirect metadata service traffic on a non-disrupted band", func() {
+				tc.AssertCalled(GinkgoT(), "AddFilter", []string{"lo", "eth0", "eth1"}, "1:0", mock.Anything, "nil", "169.254.169.254/32", 0, 0, "", "1:1")
 			})
 		})
 

--- a/network/dns.go
+++ b/network/dns.go
@@ -33,12 +33,30 @@ func NewDNSClient() DNSClient {
 func (c dnsClient) Resolve(host string) ([]net.IP, error) {
 	ips := []net.IP{}
 
-	// read resolv conf file to get search domain
+	// NOTE: we read both the pod and the node DNS configurations here
+	// in case some of the given hosts are not resolvable from a pod
+
+	// read the pod resolv conf file to get search domain
 	// and other dns configurations
-	dnsConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	podDNSConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
 	if err != nil {
 		return nil, fmt.Errorf("can't read resolve.conf file: %w", err)
 	}
+
+	// also read the node resolv conf file to get search domain
+	// and other dns configurations
+	nodeDNSConfig, err := dns.ClientConfigFromFile("/mnt/host/etc/resolv.conf")
+	if err != nil {
+		return nil, fmt.Errorf("can't read resolve.conf file: %w", err)
+	}
+
+	// compute resolvers list
+	resolvers := append([]string{}, podDNSConfig.Servers...)
+	resolvers = append(resolvers, nodeDNSConfig.Servers...)
+
+	// compute possible names to resolve
+	names := append([]string{}, podDNSConfig.NameList(host)...)
+	names = append([]string{}, nodeDNSConfig.NameList(host)...)
 
 	// do the request on the first configured dns resolver
 	dnsClient := dns.Client{}
@@ -46,11 +64,11 @@ func (c dnsClient) Resolve(host string) ([]net.IP, error) {
 
 	err = retry.Do(func() error {
 		// query possible resolvers and fqdn based on servers and search domains specified in the dns configuration
-		for _, name := range dnsConfig.NameList(host) {
+		for _, name := range names {
 			dnsMessage := dns.Msg{}
 			dnsMessage.SetQuestion(name, dns.TypeA)
 
-			for _, server := range dnsConfig.Servers {
+			for _, server := range resolvers {
 				response, _, err = dnsClient.Exchange(&dnsMessage, fmt.Sprintf("%s:53", server))
 				if response != nil && len(response.Answer) > 0 {
 					return nil


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- improve network disruptions safeguards to avoid breaking things that should not be broken (like kubelet to apiserver communication to avoid the node to be not ready, or loopback communications like 2 pods on the same node) to make it more realistic

Concrete changes:
- do not disrupt packets going to the metadata service
- impact interfaces according to the standard linux naming (ens, eth, etc.) and not the other ones (like veth, bridges, etc.)
- use both pod and node resolver configs to try to resolve given hostnames (because it does not make sense to use the pod one at the node level)

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
