### PR TITLE
Let the server validating label selectors

### DIFF
--- a/cli/chaosli/cmd/context.go
+++ b/cli/chaosli/cmd/context.go
@@ -182,7 +182,7 @@ func getTargetSize(disruption v1beta1.Disruption) (int, error) {
 
 func getPods(disruption v1beta1.Disruption) (v1.PodList, error) {
 	options := metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(disruption.Spec.Selector).String(),
+		LabelSelector: labels.SelectorFromValidatedSet(disruption.Spec.Selector).String(),
 	}
 	pods, err := clientset.CoreV1().Pods(disruption.ObjectMeta.Namespace).List(context.TODO(), options)
 
@@ -195,7 +195,7 @@ func getPods(disruption v1beta1.Disruption) (v1.PodList, error) {
 
 func getNodes(disruption v1beta1.Disruption) (v1.NodeList, error) {
 	options := metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(disruption.Spec.Selector).String(),
+		LabelSelector: labels.SelectorFromValidatedSet(disruption.Spec.Selector).String(),
 	}
 	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), options)
 

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -375,7 +375,7 @@ func (i *networkDisruptionInjector) getServices() ([]networkDisruptionService, e
 
 		// retrieve endpoints from selector
 		endpoints, err := i.config.K8sClient.CoreV1().Pods(service.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: labels.SelectorFromSet(k8sService.Spec.Selector).String(),
+			LabelSelector: labels.SelectorFromValidatedSet(k8sService.Spec.Selector).String(),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("error getting the given kubernetes service (%s/%s) endpoints: %w", service.Namespace, service.Name, err)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- the behavior of the `labels.SelectorFromSet` we are using (in the version we are using) is to validate given labels before creating the selector
- if one of the given labels key or value is invalid, they an empty selector is returned with no errors, leading to some unexpected cases
- this PR switches to `labels.SelectorFromValidatedSet` which does not validate the given labels so the selector is validated by the server itself, which will throw an error if needed

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
