### PR TITLE
Make the duration docs more clear about the fields purpose

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -22,7 +22,9 @@ Let's imagine a node with two pods running: `foo` and `bar` and a disruption dro
 
 The `Disruption` spec takes a `duration` field. This field represents amount of time after the disruption's creation before 
 all chaos pods automatically terminate and the disruption stops injecting new ones. This field takes a string, which is meant to conform to 
-golang's time.Duration's [string format, e.g., "45s", "15m30s", "4h30m".](https://pkg.go.dev/time#ParseDuration)
+golang's time.Duration's [string format, e.g., "45s", "15m30s", "4h30m".](https://pkg.go.dev/time#ParseDuration) This time is measured from the moment 
+that the Disruption resource is created, not from when the injection of the actual failure occurs. It functions as a strict maximum for the lifetime of the Disruption, 
+not a guarantee of how long the failure will persist for.
 
 If a `duration` is not specified, then a disruption will receive the default duration, which is configured at the controller level by setting 
 `controller.defaultDuration` in the controller's config map, and this value defaults to 1 hour.

--- a/docs/features.md
+++ b/docs/features.md
@@ -23,8 +23,7 @@ Let's imagine a node with two pods running: `foo` and `bar` and a disruption dro
 The `Disruption` spec takes a `duration` field. This field represents amount of time after the disruption's creation before 
 all chaos pods automatically terminate and the disruption stops injecting new ones. This field takes a string, which is meant to conform to 
 golang's time.Duration's [string format, e.g., "45s", "15m30s", "4h30m".](https://pkg.go.dev/time#ParseDuration) This time is measured from the moment 
-that the Disruption resource is created, not from when the injection of the actual failure occurs. It functions as a strict maximum for the lifetime of the Disruption, 
-not a guarantee of how long the failure will persist for.
+that the Disruption resource is created, not from when the injection of the actual failure occurs. It functions as a strict maximum for the lifetime of the Disruption, not a guarantee of how long the failure will persist for.
 
 If a `duration` is not specified, then a disruption will receive the default duration, which is configured at the controller level by setting 
 `controller.defaultDuration` in the controller's config map, and this value defaults to 1 hour.


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [x] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- `x`

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
