### PR TITLE
Add error logging everywhere we return an error from Reconcile

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -113,6 +113,8 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if controllerutil.ContainsFinalizer(instance, chaostypes.DisruptionFinalizer) {
 			isCleaned, err := r.cleanDisruption(instance)
 			if err != nil {
+				r.log.Errorw("error cleaning disruption", "error", err)
+
 				return ctrl.Result{}, err
 			}
 
@@ -135,6 +137,8 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			controllerutil.RemoveFinalizer(instance, chaostypes.DisruptionFinalizer)
 
 			if err := r.Update(context.Background(), instance); err != nil {
+				r.log.Errorw("error removing disruption finalizer", "error", err)
+
 				return ctrl.Result{}, err
 			}
 
@@ -190,6 +194,8 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// requeue the request if the disruption is not fully injected yet
 		injected, err := r.updateInjectionStatus(instance)
 		if err != nil {
+			r.log.Errorw("error updating injection status", "error", err)
+
 			return ctrl.Result{}, fmt.Errorf("error updating disruption injection status: %w", err)
 		} else if !injected {
 			// requeue after 5-10 seconds, as default 1m is too quick here

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -198,7 +198,7 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 			return ctrl.Result{}, fmt.Errorf("error updating disruption injection status: %w", err)
 		} else if !injected {
-			// requeue after 5-10 seconds, as default 1m is too quick here
+			// requeue after 5-10 seconds, as default 1ms is too quick here
 			requeueAfter := time.Duration(rand.Intn(5)+5) * time.Second //nolint:gosec
 			r.log.Infow("disruption is not fully injected yet, requeuing", "injectionStatus", instance.Status.InjectionStatus)
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -295,7 +295,9 @@ func (r *DisruptionReconciler) updateInjectionStatus(instance *chaosv1beta1.Disr
 func (r *DisruptionReconciler) startInjection(instance *chaosv1beta1.Disruption) error {
 	var err error
 
-	r.log.Infow("starting targets injection", "targets", instance.Status.Targets)
+	if len(instance.Status.Targets) > 0 {
+		r.log.Infow("starting targets injection", "targets", instance.Status.Targets)
+	}
 
 	for _, target := range instance.Status.Targets {
 		targetNodeName := ""


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- These returned errors aren't actually ever logged for us in DataDog, and I have one of them happening, but I dont know why. I figured I'd log them all at this time.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
