### PR TITLE
Consider a disruption partiallyinjected as soon as chaos pods exist

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -244,17 +244,17 @@ func (r *DisruptionReconciler) updateInjectionStatus(instance *chaosv1beta1.Disr
 
 	// consider a disruption not injected if no chaos pods are existing
 	if status == chaostypes.DisruptionInjectionStatusNotInjected && len(chaosPods) > 0 {
+		// consider the disruption "partially injected" if we found at least one ready pod
+		status = chaostypes.DisruptionInjectionStatusPartiallyInjected
 		// check the chaos pods conditions looking for the ready condition
 		for _, chaosPod := range chaosPods {
 			podReady := false
 
 			// search for the "Ready" condition in the pod conditions
-			// consider the disruption "partially injected" if we found at least one ready pod
 			for _, cond := range chaosPod.Status.Conditions {
 				if cond.Type == corev1.PodReady {
 					if cond.Status == corev1.ConditionTrue {
 						podReady = true
-						status = chaostypes.DisruptionInjectionStatusPartiallyInjected
 
 						break
 					}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Consider a disruption partiallyinjected as soon as chaos pods exist

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
