### PR TITLE
Add manual cleanup doc for all disruptions

### DIFF
--- a/docs/cpu_pressure.md
+++ b/docs/cpu_pressure.md
@@ -109,3 +109,32 @@ Threads fairness:
     events (avg/stddev):           1224.0000/0.00
     execution time (avg/stddev):   10.5927/0.00
 ```
+
+## Manual cleanup instructions
+
+:information_source: All those commands must be executed on the infected host (except for `kubectl`).
+
+* Identify the injector process PID
+
+```
+# ps ax | grep injector
+   4376 ?        Ssl    7:42 /app/cmd/cainjector/cainjector --v=2 --leader-election-namespace=kube-system
+1113879 ?        Ssl    0:00 /usr/local/bin/injector node-failure inject --metrics-sink noop --level pod --target-container-ids containerd://cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460,containerd://629c7da02cbcf77c6b7131a59f5be50579d9e374433a444210b6547186dd5f0d --target-pod-ip 10.244.0.8 --chaos-namespace chaos-engineering --log-context-disruption-name dry-run --log-context-disruption-namespace chaos-demo --log-context-target-name demo-curl-547bb9c686-57484 --log-context-target-node-name minikube --dry-run
+1117684 pts/0    R+     0:00 grep injector
+```
+
+* Kill the injector process
+
+```
+# kill 1113879
+```
+
+*You can SIGKILL the injector process if it is stuck but a standard kill is recommended.*
+
+* Ensure the injector process is gone
+
+```
+# ps ax | grep injector
+   4376 ?        Ssl    7:42 /app/cmd/cainjector/cainjector --v=2 --leader-election-namespace=kube-system
+1119071 pts/0    S+     0:00 grep injector
+```

--- a/docs/disk_pressure.md
+++ b/docs/disk_pressure.md
@@ -29,3 +29,53 @@ TL;DR: the limit will only applies on direct read and write operations (using th
 Most of the time, when writing a file to the disk, data are first written to kernel page cache (in memory) and then flushed to the disk. Because controllers are totally independent in cgroups v1, the limit will never be applied on page flush. So what does it mean? Most of the applications won't be throttled because they don't use direct read or write operations. We are currently working on a way to improve the behavior of the throttle until we can switch to cgroups v2.
 
 More information can be found on [this blog post](https://medium.com/some-tldrs/tldr-using-cgroups-to-limit-i-o-by-andr%C3%A9-carvalho-421bb1d855e) about this limitation.
+
+## Manual cleanup instructions
+
+:information_source: All those commands must be executed on the infected host (except for `kubectl`).
+
+---
+
+:warning: If the disruption is injected at the pod level, you must find the related cgroups path **for each container**.
+
+* Identify the container IDs of your pod
+
+```
+kubectl get -ojson pod demo-curl-547bb9c686-57484 | jq '.status.containerStatuses[].containerID'
+"containerd://cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460"
+"containerd://629c7da02cbcf77c6b7131a59f5be50579d9e374433a444210b6547186dd5f0d"
+```
+
+* Identify cgroups path
+
+```
+# crictl inspect cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460 | grep cgroupsPath
+        "cgroupsPath": "/kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460",
+```
+
+---
+
+* Identify blkio device to reset for read and write (depending on the applied disk pressure)
+
+```
+# cat /sys/fs/cgroup/blkio/kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460/blkio.throttle.read_bps_device
+8:0 1073741824
+# cat /sys/fs/cgroup/blkio/kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460/blkio.throttle.write_bps_device
+8:0 1073741824
+```
+
+*Throttle files are located directly in `/sys/fs/cgroup/blkio` if the disruption is applied at the node level.*
+
+* Reset throttle values for the found device
+
+```
+# echo "8:0 0" > /sys/fs/cgroup/blkio/kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460/blkio.throttle.read_bps_device
+# echo "8:0 0" > /sys/fs/cgroup/blkio/kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460/blkio.throttle.write_bps_device
+```
+
+* Ensure that the values are reset
+
+```
+# cat /sys/fs/cgroup/blkio/kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460/blkio.throttle.read_bps_device
+# cat /sys/fs/cgroup/blkio/kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460/blkio.throttle.write_bps_device
+```

--- a/docs/dns_disruption.md
+++ b/docs/dns_disruption.md
@@ -17,3 +17,87 @@ Second, in order for the target's DNS queries to end up at the injector's DNS re
 ## Forwarding non-matched requests
 
 Depending on your DNS setup you might need to override the DNS server and/or instruct the controller to forward requests to kube-dns. See the [advanced installation guide](installation.md#dns-resolution).
+
+## Manual cleanup instructions
+
+:information_source: All those commands must be executed on the infected host (except for `kubectl`).
+
+---
+
+:warning: If the disruption is injected at the pod level, you must enter the pod network namespace first.
+
+* Identify the container IDs of your pod
+
+```
+kubectl get -ojson pod demo-curl-547bb9c686-57484 | jq '.status.containerStatuses[].containerID'
+"containerd://cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460"
+"containerd://629c7da02cbcf77c6b7131a59f5be50579d9e374433a444210b6547186dd5f0d"
+```
+
+* Find one of the container PID
+
+```
+# crictl inspect cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460 | grep pid
+    "pid": 5607,
+            "pid": 1
+            "type": "pid"
+```
+
+* Enter the network namespace
+
+```
+# nsenter --net=/proc/5607/ns/net
+```
+
+---
+
+* Remove iptables rules jumping to the `CHAOS-DNS` chain
+
+```
+# iptables-save | grep -- '-j CHAOS-DNS'
+-A OUTPUT -p udp -m cgroup --cgroup 1048592 -m udp --dport 53 -j CHAOS-DNS
+# iptables -t nat -D OUTPUT -p udp -m cgroup --cgroup 1048592 -m udp --dport 53 -j CHAOS-DNS
+```
+
+* Remove iptables `CHAOS-DNS` chain
+
+```
+# iptables -t nat -F CHAOS-DNS
+# iptables -t nat -X CHAOS-DNS
+```
+
+---
+
+:warning: If the disruption is injected at the pod level, you must find the related cgroups path **for each container**.
+
+* Identify the container IDs of your pod
+
+```
+kubectl get -ojson pod demo-curl-547bb9c686-57484 | jq '.status.containerStatuses[].containerID'
+"containerd://cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460"
+"containerd://629c7da02cbcf77c6b7131a59f5be50579d9e374433a444210b6547186dd5f0d"
+```
+
+* Identify cgroups path
+
+```
+# crictl inspect cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460 | grep cgroupsPath
+        "cgroupsPath": "/kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460",
+```
+
+---
+
+* Reset the `net_cls` value for each container
+
+```
+# echo 0 > /sys/fs/cgroup/net_cls/kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460/net_cls.classid
+```
+
+* Kill dns resolver process if it is still running
+
+```
+# ps ax | grep dns_disruption_resolver
+1150251 ?        S      0:02 /usr/bin/python3 /usr/local/bin/dns_disruption_resolver.py -c /tmp/dns.conf --dns 8.8.8.8 --kube-dns off
+1167110 pts/0    S+     0:00 grep dns_disruption_resolver
+# kill 1150251
+```

--- a/docs/network_disruption.md
+++ b/docs/network_disruption.md
@@ -44,3 +44,88 @@ The injector needs some kernel modules to be enabled to be able to run:
 * `sch_netem` for the `tc` network emulator module used to apply packets loss, packets corruption and delay
 * `sch_tbf` for the `tc` bandwidth limitation used to apply bandwidth limitation
 * `sch_prio` for the `tc` `prio` qdisc creation used to apply disruptions to some part of the traffic only
+
+## Manual cleanup instructions
+
+:information_source: All those commands must be executed on the infected host (except for `kubectl`).
+
+---
+
+:warning: If the disruption is injected at the pod level, you must enter the pod network namespace first.
+
+* Identify the container IDs of your pod
+
+```
+kubectl get -ojson pod demo-curl-547bb9c686-57484 | jq '.status.containerStatuses[].containerID'
+"containerd://cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460"
+"containerd://629c7da02cbcf77c6b7131a59f5be50579d9e374433a444210b6547186dd5f0d"
+```
+
+* Find one of the container PID
+
+```
+# crictl inspect cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460 | grep pid
+    "pid": 5607,
+            "pid": 1
+            "type": "pid"
+```
+
+* Enter the network namespace
+
+```
+# nsenter --net=/proc/5607/ns/net
+```
+
+---
+
+* Identify impacted interfaces
+
+```
+# tc qdisc
+qdisc noqueue 0: dev lo root refcnt 2
+qdisc prio 1: dev eth0 root refcnt 2 bands 4 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
+qdisc prio 2: dev eth0 parent 1:4 bands 2 priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+qdisc netem 3: dev eth0 parent 2:2 limit 1000 loss 100%
+```
+*eth0 is affected because it has a netem qdisc (it could also have a tbf qdisc depending on the applied disruption)*
+
+* Clear qdisc for impacted interfaces
+
+```
+# tc qdisc del dev eth0 root
+```
+
+* Interface should now have its default qdisc configuration
+
+```
+# tc qdisc
+qdisc noqueue 0: dev lo root refcnt 2
+qdisc noqueue 0: dev eth0 root refcnt 2
+```
+
+---
+
+:warning: If the disruption is injected at the pod level, you must find the related cgroups path **for each container**.
+
+* Identify the container IDs of your pod
+
+```
+kubectl get -ojson pod demo-curl-547bb9c686-57484 | jq '.status.containerStatuses[].containerID'
+"containerd://cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460"
+"containerd://629c7da02cbcf77c6b7131a59f5be50579d9e374433a444210b6547186dd5f0d"
+```
+
+* Identify cgroups path
+
+```
+# crictl inspect cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460 | grep cgroupsPath
+        "cgroupsPath": "/kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460",
+```
+
+---
+
+* Reset the `net_cls` value for each container
+
+```
+# echo 0 > /sys/fs/cgroup/net_cls/kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460/net_cls.classid
+```


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [x] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Most disruptions now have a manual cleanup documentation that can be helpful for both debugging and emergency cleaning ([example](https://github.com/DataDog/chaos-controller/blob/manual_cleanup_doc/docs/network_disruption.md#manual-cleanup-instructions))

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).