### PR TITLE
Don't attempt re-injection after Disruption Duration has ended

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -114,8 +114,8 @@ func (dd DisruptionDuration) Duration() time.Duration {
 type DisruptionStatus struct {
 	IsStuckOnRemoval bool `json:"isStuckOnRemoval,omitempty"`
 	IsInjected       bool `json:"isInjected,omitempty"`
-	// +kubebuilder:validation:Enum=NotInjected;PartiallyInjected;Injected
-	// +ddmark:validation:Enum=NotInjected;PartiallyInjected;Injected
+	// +kubebuilder:validation:Enum=NotInjected;PartiallyInjected;Injected;PreviouslyInjected
+	// +ddmark:validation:Enum=NotInjected;PartiallyInjected;Injected;PreviouslyInjected
 	InjectionStatus chaostypes.DisruptionInjectionStatus `json:"injectionStatus,omitempty"`
 	// +nullable
 	Targets []string `json:"targets,omitempty"`

--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -334,6 +334,7 @@ spec:
               - NotInjected
               - PartiallyInjected
               - Injected
+              - PreviouslyInjected
               type: string
             isInjected:
               type: boolean

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -287,6 +287,20 @@ var _ = Describe("Disruption Controller", func() {
 			By("Waiting for the disruption to expire naturally")
 			Eventually(func() error { return expectChaosPod(disruption, 0) }, timeout*2).Should(Succeed())
 
+			By("Waiting for the disruption to reach PreviouslyInjected")
+			Eventually(func() error {
+				if err := k8sClient.Get(context.Background(), instanceKey, disruption); err != nil {
+					return err
+				}
+
+				// check disruption injection status
+				if disruption.Status.InjectionStatus != chaostypes.DisruptionInjectionStatusPreviouslyInjected {
+					return fmt.Errorf("disruptions is not injected, current status is %s", disruption.Status.InjectionStatus)
+				}
+
+				return nil
+			}, timeout*2).Should(Succeed())
+
 			By("Waiting for disruption to be removed")
 			Eventually(func() error { return k8sClient.Get(context.Background(), instanceKey, disruption) }, timeout).Should(MatchError("Disruption.chaos.datadoghq.com \"foo\" not found"))
 		})

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -295,7 +295,7 @@ var _ = Describe("Disruption Controller", func() {
 
 				// check disruption injection status
 				if disruption.Status.InjectionStatus != chaostypes.DisruptionInjectionStatusPreviouslyInjected {
-					return fmt.Errorf("disruptions is not injected, current status is %s", disruption.Status.InjectionStatus)
+					return fmt.Errorf("unexpected disruption status, current status is %s (expected PreviouslyInjected)", disruption.Status.InjectionStatus)
 				}
 
 				return nil


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Previously, after reaching the `Injected` status, we would set the requeue delay for long enough that we dont reconcile again until it's time to clean up the now finished chaos pods. This naively assumes that we will ever reach the Injected status, which can't be guaranteed. If that doesn't happen, we would actually try to continue to inject new pods after the duration has expired, but before we GC the disruption. Given that we failed to reach Injected the first time, it's likely that these new pods will fail too. Thus, we now stop injecting and immediately clean the disruption after the duration is over

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
