### PR TITLE
Do not crash on disk pressure node level disruption if the specified …

### DIFF
--- a/cli/injector/disk_pressure.go
+++ b/cli/injector/disk_pressure.go
@@ -6,6 +6,9 @@
 package main
 
 import (
+	"errors"
+	"os"
+
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/injector"
 	"github.com/spf13/cobra"
@@ -43,7 +46,11 @@ var diskPressureCmd = &cobra.Command{
 		for _, config := range configs {
 			inj, err := injector.NewDiskPressureInjector(spec, injector.DiskPressureInjectorConfig{Config: config})
 			if err != nil {
-				log.Fatalw("error initializing the disk pressure injector", "error", err)
+				if errors.Is(errors.Unwrap(err), os.ErrNotExist) {
+					log.Errorw("error initializing the disk pressure injector because the given path does not exist", "error", err)
+				} else {
+					log.Fatalw("error initializing the disk pressure injector", "error", err)
+				}
 			}
 
 			if inj == nil {

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -275,7 +275,7 @@ func initExitSignalsHandler() {
 // for an exit signal to be sent
 func injectAndWait(cmd *cobra.Command, args []string) {
 	// early exit if an injector configuration failed to be generated during initialization
-	if !readyToInject {
+	if !readyToInject || len(injectors) == 0 {
 		log.Error("an injector could not be configured successfully during initialization, aborting the injection now")
 
 		return

--- a/disk/disk.go
+++ b/disk/disk.go
@@ -8,6 +8,7 @@ package disk
 import (
 	"bufio"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -27,6 +28,11 @@ type disk struct {
 
 // FromPath returns a disk informer from the given path
 func FromPath(path string) (Informer, error) {
+	// ensure the file exists before going further
+	if _, err := os.Stat(path); err != nil {
+		return nil, err
+	}
+
 	// get host path device
 	df := exec.Command("df", "--output=source", path)
 


### PR DESCRIPTION
…path does not exist

## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The injector does not crash anymore if the given path for a node level disk disruption does not exist and log it instead (like it is done at the container level when the given path does not exist)

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - apply the following disruption
```yaml
apiVersion: chaos.datadoghq.com/v1beta1
kind: Disruption
metadata:
  name: disk-pressure-read
  namespace: chaos-demo
spec:
  level: node
  selector:
    minikube.k8s.io/name: minikube
  count: 1
  diskPressure:
    path: /ferwfwefewf
    throttling:
      readBytesPerSec: 1024 # read throttling in bytes per sec
```

Before: the injector should crash on initialization, preventing the disruption to be removed while nothing has been injected yet.
After: the injector should log an error and complete, allowing a gentle disruption deletion without blocking it.