### PR TITLE
Custom cache watcher example

### DIFF
--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: disruptions.chaos.datadoghq.com
 spec:

--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: disruptions.chaos.datadoghq.com
 spec:

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -22,18 +22,15 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kubeinformers "k8s.io/client-go/informers"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -61,7 +58,6 @@ type DisruptionReconciler struct {
 	InjectorDNSDisruptionKubeDNS          string
 	InjectorNetworkDisruptionAllowedHosts []string
 	ExpiredDisruptionGCDelay              time.Duration
-	ChaosControllerInstance               controller.Controller
 }
 
 //+kubebuilder:rbac:groups=chaos.datadoghq.com,resources=disruptions,verbs=get;list;watch;create;update;patch;delete
@@ -116,41 +112,6 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		return ctrl.Result{}, err
 	}
-
-	watchClient, err := client.NewWithWatch(
-		&rest.Config{},
-		client.Options{
-			Mapper: meta.NewDefaultRESTMapper(nil),
-			Scheme: r.Scheme,
-		},
-	)
-
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	wat, err := watchClient.Watch(
-		context.Background(),
-		&chaosv1beta1.DisruptionList{},
-		&client.ListOptions{
-			LabelSelector: instance.Spec.Selector.AsSelector(),
-		},
-	)
-
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	watchEvent, ok := <-wat.ResultChan()
-
-	// r.ChaosControllerInstance.Watch(
-	// 	&source.Kind{Type: &corev1.Pod{}},
-	// 	handler.EnqueueRequestsFromMapFunc(
-	// 		func(o client.Object) []reconcile.Request {
-	// 			return nil
-	// 		},
-	// 	),
-	// )
 
 	// check whether the object is being deleted or not
 	if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -1161,7 +1122,7 @@ func (r *DisruptionReconciler) recordEventOnTarget(instance *chaosv1beta1.Disrup
 }
 
 // SetupWithManager setups the current reconciler with the given manager
-func (r *DisruptionReconciler) SetupWithManager(mgr ctrl.Manager, kubeInformerFactory kubeinformers.SharedInformerFactory) (controller.Controller, error) {
+func (r *DisruptionReconciler) SetupWithManager(mgr ctrl.Manager, kubeInformerFactory kubeinformers.SharedInformerFactory) error {
 	podToDisruption := func(c client.Object) []reconcile.Request {
 		// podtoDisruption is a function that maps pods to disruptions. it is meant to be used as an event handler on a pod informer
 		// this function should safely return an empty list of requests to reconcile if the object we receive is not actually a chaos pod
@@ -1190,8 +1151,7 @@ func (r *DisruptionReconciler) SetupWithManager(mgr ctrl.Manager, kubeInformerFa
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&chaosv1beta1.Disruption{}).
 		Watches(&source.Informer{Informer: informer}, handler.EnqueueRequestsFromMapFunc(podToDisruption)).
-		Build(r)
-	// Complete(r)
+		Complete(r)
 }
 
 // ReportMetrics reports some controller metrics every minute:

--- a/main.go
+++ b/main.go
@@ -332,6 +332,13 @@ func main() {
 		},
 	})
 
+	// erase/close caches contexts
+	defer func() {
+		for _, cFunc := range r.Caches {
+			cFunc()
+		}
+	}()
+
 	// +kubebuilder:scaffold:builder
 
 	logger.Infow("restarting chaos-controller")

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -291,7 +292,7 @@ func main() {
 		InjectorNetworkDisruptionAllowedHosts: cfg.Injector.NetworkDisruption.AllowedHosts,
 		ImagePullSecrets:                      cfg.Controller.ImagePullSecrets,
 		ExpiredDisruptionGCDelay:              cfg.Controller.ExpiredDisruptionGCDelay,
-		Caches:                                make(map[k8stypes.NamespacedName]chan error),
+		Caches:                                make(map[k8stypes.NamespacedName]context.CancelFunc),
 	}
 
 	informerClient := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())

--- a/main.go
+++ b/main.go
@@ -295,13 +295,15 @@ func main() {
 	informerClient := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(informerClient, time.Minute*5, kubeinformers.WithNamespace(cfg.Injector.ChaosNamespace))
 
-	if err := r.SetupWithManager(mgr, kubeInformerFactory); err != nil {
+	controller, err := r.SetupWithManager(mgr, kubeInformerFactory)
+	if err != nil {
 		logger.Errorw("unable to create controller", "controller", "Disruption", "error", err)
 		os.Exit(1) //nolint:gocritic
 	}
 
 	stopCh := make(chan struct{})
 	kubeInformerFactory.Start(stopCh)
+	r.ChaosControllerInstance = controller
 
 	go r.ReportMetrics()
 

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	chaosv1beta1 "github.com/DataDog/chaos-controller/api/v1beta1"
@@ -292,7 +291,7 @@ func main() {
 		InjectorNetworkDisruptionAllowedHosts: cfg.Injector.NetworkDisruption.AllowedHosts,
 		ImagePullSecrets:                      cfg.Controller.ImagePullSecrets,
 		ExpiredDisruptionGCDelay:              cfg.Controller.ExpiredDisruptionGCDelay,
-		Caches:                                make(map[k8stypes.NamespacedName]*cache.Cache),
+		Caches:                                make(map[k8stypes.NamespacedName]chan error),
 	}
 
 	informerClient := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())

--- a/main.go
+++ b/main.go
@@ -295,15 +295,13 @@ func main() {
 	informerClient := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(informerClient, time.Minute*5, kubeinformers.WithNamespace(cfg.Injector.ChaosNamespace))
 
-	controller, err := r.SetupWithManager(mgr, kubeInformerFactory)
-	if err != nil {
+	if err := r.SetupWithManager(mgr, kubeInformerFactory); err != nil {
 		logger.Errorw("unable to create controller", "controller", "Disruption", "error", err)
 		os.Exit(1) //nolint:gocritic
 	}
 
 	stopCh := make(chan struct{})
 	kubeInformerFactory.Start(stopCh)
-	r.ChaosControllerInstance = controller
 
 	go r.ReportMetrics()
 

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	chaosv1beta1 "github.com/DataDog/chaos-controller/api/v1beta1"
@@ -45,6 +46,7 @@ import (
 	"github.com/DataDog/chaos-controller/targetselector"
 	chaoswebhook "github.com/DataDog/chaos-controller/webhook"
 	"github.com/spf13/viper"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -290,6 +292,7 @@ func main() {
 		InjectorNetworkDisruptionAllowedHosts: cfg.Injector.NetworkDisruption.AllowedHosts,
 		ImagePullSecrets:                      cfg.Controller.ImagePullSecrets,
 		ExpiredDisruptionGCDelay:              cfg.Controller.ExpiredDisruptionGCDelay,
+		Caches:                                make(map[k8stypes.NamespacedName]*cache.Cache),
 	}
 
 	informerClient := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())

--- a/vendor/github.com/markbates/pkger/pkging/embed/embed.go
+++ b/vendor/github.com/markbates/pkger/pkging/embed/embed.go
@@ -1,0 +1,55 @@
+package embed
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/hex"
+	"io"
+
+	"github.com/markbates/pkger/here"
+)
+
+func Decode(src []byte) ([]byte, error) {
+	dst := make([]byte, hex.DecodedLen(len(src)))
+	_, err := hex.Decode(dst, src)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := gzip.NewReader(bytes.NewReader(dst))
+	if err != nil {
+		return nil, err
+	}
+
+	bb := &bytes.Buffer{}
+	if _, err := io.Copy(bb, r); err != nil {
+		return nil, err
+	}
+	return bb.Bytes(), nil
+}
+
+func Encode(b []byte) ([]byte, error) {
+	bb := &bytes.Buffer{}
+	gz := gzip.NewWriter(bb)
+
+	if _, err := gz.Write(b); err != nil {
+		return nil, err
+	}
+
+	if err := gz.Flush(); err != nil {
+		return nil, err
+	}
+
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+
+	s := hex.EncodeToString(bb.Bytes())
+	return []byte(s), nil
+}
+
+type Data struct {
+	Infos map[string]here.Info `json:"infos"`
+	Files map[string]File      `json:"files"`
+	Here  here.Info            `json:"here"`
+}

--- a/vendor/github.com/markbates/pkger/pkging/embed/file.go
+++ b/vendor/github.com/markbates/pkger/pkging/embed/file.go
@@ -1,0 +1,14 @@
+package embed
+
+import (
+	"github.com/markbates/pkger/here"
+	"github.com/markbates/pkger/pkging"
+)
+
+type File struct {
+	Info   *pkging.FileInfo `json:"info"`
+	Here   here.Info        `json:"her"`
+	Path   here.Path        `json:"path"`
+	Data   []byte           `json:"data"`
+	Parent here.Path        `json:"parent"`
+}

--- a/vendor/github.com/markbates/pkger/pkging/mem/add.go
+++ b/vendor/github.com/markbates/pkger/pkging/mem/add.go
@@ -1,0 +1,104 @@
+package mem
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/markbates/pkger/here"
+	"github.com/markbates/pkger/pkging"
+)
+
+var _ pkging.Adder = &Pkger{}
+
+// Add copies the pkging.File into the *Pkger
+func (fx *Pkger) Add(files ...*os.File) error {
+	for _, f := range files {
+		info, err := f.Stat()
+		if err != nil {
+			return err
+		}
+		pt, err := fx.Parse(f.Name())
+		if err != nil {
+			return err
+		}
+
+		dir := f.Name()
+		if !info.IsDir() {
+			dir = filepath.Dir(dir)
+		}
+
+		her, err := here.Dir(dir)
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			err = filepath.Walk(f.Name(), func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				f, err := os.Open(path)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+
+				pt, err := fx.Parse(path)
+				if err != nil {
+					return err
+				}
+
+				her, err := here.Package(pt.Pkg)
+				if err != nil {
+					return err
+				}
+
+				mf := &File{
+					Here:   her,
+					info:   pkging.NewFileInfo(info),
+					path:   pt,
+					pkging: fx,
+				}
+
+				if !info.IsDir() {
+					bb := &bytes.Buffer{}
+					_, err = io.Copy(bb, f)
+					if err != nil {
+						return err
+					}
+					mf.data = bb.Bytes()
+				}
+
+				fx.files.Store(mf.Path(), mf)
+
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		mf := &File{
+			Here:   her,
+			info:   pkging.NewFileInfo(info),
+			path:   pt,
+			pkging: fx,
+		}
+
+		if !info.IsDir() {
+			bb := &bytes.Buffer{}
+			_, err = io.Copy(bb, f)
+			if err != nil {
+				return err
+			}
+			mf.data = bb.Bytes()
+		}
+
+		fx.files.Store(mf.Path(), mf)
+	}
+
+	return nil
+}

--- a/vendor/github.com/markbates/pkger/pkging/mem/embed.go
+++ b/vendor/github.com/markbates/pkger/pkging/mem/embed.go
@@ -1,0 +1,92 @@
+package mem
+
+import (
+	"encoding/json"
+
+	"github.com/markbates/pkger/here"
+	"github.com/markbates/pkger/internal/maps"
+	"github.com/markbates/pkger/pkging"
+	"github.com/markbates/pkger/pkging/embed"
+)
+
+// MarshalJSON creates a fully re-hydratable JSON representation of *Pkger
+func (p *Pkger) MarshalJSON() ([]byte, error) {
+	files := map[string]embed.File{}
+
+	p.files.Range(func(key here.Path, file pkging.File) bool {
+		f, ok := file.(*File)
+		if !ok {
+			return true
+		}
+		ef := embed.File{
+			Info:   f.info,
+			Here:   f.Here,
+			Path:   f.path,
+			Parent: f.parent,
+			Data:   f.data,
+		}
+		files[key.String()] = ef
+		return true
+	})
+
+	infos := map[string]here.Info{}
+	p.infos.Range(func(key string, info here.Info) bool {
+		infos[key] = info
+		return true
+	})
+	ed := embed.Data{
+		Infos: infos,
+		Files: files,
+		Here:  p.Here,
+	}
+	return json.Marshal(ed)
+}
+
+// UnmarshalJSON re-hydrates the *Pkger
+func (p *Pkger) UnmarshalJSON(b []byte) error {
+	y := &embed.Data{
+		Infos: map[string]here.Info{},
+		Files: map[string]embed.File{},
+	}
+
+	if err := json.Unmarshal(b, &y); err != nil {
+		return err
+	}
+
+	p.Here = y.Here
+	p.infos = &maps.Infos{}
+	for k, v := range y.Infos {
+		p.infos.Store(k, v)
+	}
+
+	p.files = &maps.Files{}
+	for k, v := range y.Files {
+		pt, err := p.Parse(k)
+		if err != nil {
+			return err
+		}
+
+		f := &File{
+			Here:   v.Here,
+			info:   v.Info,
+			path:   v.Path,
+			data:   v.Data,
+			parent: v.Parent,
+		}
+		p.files.Store(pt, f)
+	}
+	return nil
+}
+
+func UnmarshalEmbed(in []byte) (*Pkger, error) {
+	b, err := embed.Decode(in)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &Pkger{}
+	if err := json.Unmarshal(b, p); err != nil {
+		return nil, err
+	}
+	return p, nil
+}

--- a/vendor/github.com/markbates/pkger/pkging/mem/file.go
+++ b/vendor/github.com/markbates/pkger/pkging/mem/file.go
@@ -1,0 +1,203 @@
+package mem
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/markbates/pkger/here"
+	"github.com/markbates/pkger/pkging"
+)
+
+const timeFmt = time.RFC3339Nano
+
+var _ pkging.File = &File{}
+
+type File struct {
+	Here   here.Info
+	info   *pkging.FileInfo
+	path   here.Path
+	data   []byte
+	parent here.Path
+	writer *bytes.Buffer
+	reader io.Reader
+	pkging pkging.Pkger
+}
+
+// Seek sets the offset for the next Read or Write on file to offset, interpreted according to whence: 0 means relative to the origin of the file, 1 means relative to the current offset, and 2 means relative to the end. It returns the new offset and an error, if any.
+func (f *File) Seek(ofpkginget int64, whence int) (int64, error) {
+	if len(f.data) > 0 && f.reader == nil {
+		f.reader = bytes.NewReader(f.data)
+	}
+
+	if sk, ok := f.reader.(io.Seeker); ok {
+		return sk.Seek(ofpkginget, whence)
+	}
+	return 0, nil
+}
+
+// Close closes the File, rendering it unusable for I/O.
+func (f *File) Close() error {
+	defer func() {
+		f.reader = nil
+		f.writer = nil
+	}()
+	if f.reader != nil {
+		if c, ok := f.reader.(io.Closer); ok {
+			if err := c.Close(); err != nil {
+				return err
+			}
+		}
+	}
+
+	if f.writer == nil {
+		return nil
+	}
+
+	f.data = f.writer.Bytes()
+
+	fi := f.info
+	fi.Details.Size = int64(len(f.data))
+	fi.Details.ModTime = pkging.ModTime(time.Now())
+	f.info = fi
+	return nil
+}
+
+// Read reads up to len(b) bytes from the File. It returns the number of bytes read and any error encountered. At end of file, Read returns 0, io.EOF.
+func (f *File) Read(p []byte) (int, error) {
+	if len(f.data) > 0 && f.reader == nil {
+		f.reader = bytes.NewReader(f.data)
+	}
+
+	if f.reader != nil {
+		return f.reader.Read(p)
+	}
+
+	return 0, fmt.Errorf("unable to read %s", f.Name())
+}
+
+// Write writes len(b) bytes to the File. It returns the number of bytes written and an error, if any. Write returns a non-nil error when n != len(b).
+func (f *File) Write(b []byte) (int, error) {
+	if f.writer == nil {
+		f.writer = &bytes.Buffer{}
+	}
+	i, err := f.writer.Write(b)
+	return i, err
+}
+
+// Info returns the here.Info of the file
+func (f File) Info() here.Info {
+	return f.Here
+}
+
+// Stat returns the FileInfo structure describing file. If there is an error, it will be of type *PathError.
+func (f File) Stat() (os.FileInfo, error) {
+	if f.info == nil {
+		return nil, os.ErrNotExist
+	}
+	return f.info, nil
+}
+
+// Name retuns the name of the file in pkger format
+func (f File) Name() string {
+	return f.path.String()
+}
+
+// Path returns the here.Path of the file
+func (f File) Path() here.Path {
+	return f.path
+}
+
+func (f File) String() string {
+	return f.Path().String()
+}
+
+// Readdir reads the contents of the directory associated with file and returns a slice of up to n FileInfo values, as would be returned by Lstat, in directory order. Subsequent calls on the same file will yield further FileInfos.
+//
+// If n > 0, Readdir returns at most n FileInfo structures. In this case, if Readdir returns an empty slice, it will return a non-nil error explaining why. At the end of a directory, the error is io.EOF.
+//
+// If n <= 0, Readdir returns all the FileInfo from the directory in a single slice. In this case, if Readdir succeeds (reads all the way to the end of the directory), it returns the slice and a nil error. If it encounters an error before the end of the directory, Readdir returns the FileInfo read until that point and a non-nil error.
+func (f *File) Readdir(count int) ([]os.FileInfo, error) {
+	var infos []os.FileInfo
+	root := f.Path().String()
+	err := f.pkging.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if count > 0 && len(infos) == count {
+			return io.EOF
+		}
+
+		if root == path {
+			return nil
+		}
+
+		pt, err := f.pkging.Parse(path)
+		if err != nil {
+			return err
+		}
+		if pt.Name == f.parent.Name {
+			return nil
+		}
+
+		infos = append(infos, info)
+		if info.IsDir() && path != root {
+			return filepath.SkipDir
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		if _, ok := err.(*os.PathError); ok {
+			return infos, nil
+		}
+		if err != io.EOF {
+			return nil, err
+		}
+	}
+	return infos, nil
+
+}
+
+// Open implements the http.FileSystem interface. A FileSystem implements access to a collection of named files. The elements in a file path are separated by slash ('/', U+002F) characters, regardless of host operating system convention.
+func (f *File) Open(name string) (http.File, error) {
+	pt, err := f.Here.Parse(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if pt == f.path {
+		return f, nil
+	}
+
+	pt.Name = path.Join(f.Path().Name, pt.Name)
+
+	di, err := f.pkging.Open(pt.String())
+	if err != nil {
+		return nil, err
+	}
+
+	fi, err := di.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	if fi.IsDir() {
+		d2 := &File{
+			info:   pkging.NewFileInfo(fi),
+			Here:   di.Info(),
+			path:   pt,
+			parent: f.path,
+			pkging: f.pkging,
+		}
+		di = d2
+	}
+	return di, nil
+}

--- a/vendor/github.com/markbates/pkger/pkging/mem/mem.go
+++ b/vendor/github.com/markbates/pkger/pkging/mem/mem.go
@@ -1,0 +1,252 @@
+package mem
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/markbates/pkger/here"
+	"github.com/markbates/pkger/internal/maps"
+	"github.com/markbates/pkger/pkging"
+)
+
+var _ pkging.Pkger = &Pkger{}
+
+// New returns *Pkger for the provided here.Info
+func New(info here.Info) (*Pkger, error) {
+	f := &Pkger{
+		infos: &maps.Infos{},
+		files: &maps.Files{},
+		Here:  info,
+	}
+	f.infos.Store(info.ImportPath, info)
+	return f, nil
+}
+
+type Pkger struct {
+	Here  here.Info
+	infos *maps.Infos
+	files *maps.Files
+}
+
+// Current returns the here.Info representing the current Pkger implementation.
+func (f *Pkger) Current() (here.Info, error) {
+	return f.Here, nil
+}
+
+// Info returns the here.Info of the here.Path
+func (f *Pkger) Info(p string) (here.Info, error) {
+	info, ok := f.infos.Load(p)
+	if !ok {
+		return info, fmt.Errorf("no such package %q", p)
+	}
+
+	return info, nil
+}
+
+// Parse the string in here.Path format.
+func (f *Pkger) Parse(p string) (here.Path, error) {
+	return f.Here.Parse(p)
+}
+
+// Remove removes the named file or (empty) directory.
+func (fx *Pkger) Remove(name string) error {
+	pt, err := fx.Parse(name)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := fx.files.Load(pt); !ok {
+		return &os.PathError{"remove", pt.String(), fmt.Errorf("no such file or directory")}
+	}
+
+	fx.files.Delete(pt)
+	return nil
+}
+
+// RemoveAll removes path and any children it contains. It removes everything it can but returns the first error it encounters. If the path does not exist, RemoveAll returns nil (no error).
+func (fx *Pkger) RemoveAll(name string) error {
+	pt, err := fx.Parse(name)
+	if err != nil {
+		return err
+	}
+
+	fx.files.Range(func(key here.Path, file pkging.File) bool {
+		if strings.HasPrefix(key.Name, pt.Name) {
+			fx.files.Delete(key)
+		}
+		return true
+	})
+
+	return nil
+}
+
+// Create creates the named file with mode 0666 (before umask) - It's actually 0644, truncating it if it already exists. If successful, methods on the returned File can be used for I/O; the associated file descriptor has mode O_RDWR.
+func (fx *Pkger) Create(name string) (pkging.File, error) {
+	fx.MkdirAll("/", 0755)
+	pt, err := fx.Parse(name)
+	if err != nil {
+		return nil, err
+	}
+
+	her, err := fx.Info(pt.Pkg)
+	if err != nil {
+		return nil, err
+	}
+
+	dir := filepath.Dir(pt.Name)
+	if dir != "/" {
+		if _, err := fx.Stat(dir); err != nil {
+			return nil, err
+		}
+	}
+
+	f := &File{
+		Here: her,
+		path: pt,
+		info: &pkging.FileInfo{
+			Details: pkging.Details{
+				Name:    filepath.Base(name),
+				Mode:    0644,
+				ModTime: pkging.ModTime(time.Now()),
+			},
+		},
+		pkging: fx,
+	}
+
+	fx.files.Store(pt, f)
+
+	return f, nil
+}
+
+// MkdirAll creates a directory named path, along with any necessary parents, and returns nil, or else returns an error. The permission bits perm (before umask) are used for all directories that MkdirAll creates. If path is already a directory, MkdirAll does nothing and returns nil.
+func (fx *Pkger) MkdirAll(p string, perm os.FileMode) error {
+	pt, err := fx.Parse(p)
+	if err != nil {
+		return err
+	}
+	dir, name := path.Split(pt.Name)
+
+	if dir != "/" {
+		if err := fx.MkdirAll(dir, perm); err != nil {
+			return err
+		}
+	}
+
+	if dir == "/" && name == "" {
+		dir = filepath.Base(fx.Here.Dir)
+	}
+
+	f := &File{
+		Here:   fx.Here,
+		pkging: fx,
+		path:   pt,
+		info: &pkging.FileInfo{
+			Details: pkging.Details{
+				IsDir:   true,
+				Name:    name,
+				Mode:    perm,
+				ModTime: pkging.ModTime(time.Now()),
+			},
+		},
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	fx.files.Store(pt, f)
+	return nil
+
+}
+
+// Open opens the named file for reading. If successful, methods on the returned file can be used for reading; the associated file descriptor has mode O_RDONLY.
+func (fx *Pkger) Open(name string) (pkging.File, error) {
+	pt, err := fx.Parse(name)
+	if err != nil {
+		return nil, &os.PathError{
+			Op:   "open",
+			Path: name,
+			Err:  err,
+		}
+	}
+
+	fl, ok := fx.files.Load(pt)
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	f, ok := fl.(*File)
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	nf := &File{
+		pkging: fx,
+		info:   pkging.NewFileInfo(f.info),
+		path:   f.path,
+		data:   f.data,
+		Here:   f.Here,
+	}
+
+	return nf, nil
+}
+
+// Stat returns a FileInfo describing the named file.
+func (fx *Pkger) Stat(name string) (os.FileInfo, error) {
+	pt, err := fx.Parse(name)
+	if err != nil {
+		return nil, err
+	}
+	f, ok := fx.files.Load(pt)
+	if ok {
+		return f.Stat()
+	}
+	return nil, fmt.Errorf("could not stat %s", pt)
+}
+
+// Walk walks the file tree rooted at root, calling walkFn for each file or directory in the tree, including root. All errors that arise visiting files and directories are filtered by walkFn. The files are walked in lexical order, which makes the output deterministic but means that for very large directories Walk can be inefficient. Walk does not follow symbolic links. - That is from the standard library. I know. Their grammar teachers can not be happy with them right now.
+func (f *Pkger) Walk(p string, wf filepath.WalkFunc) error {
+	keys := f.files.Keys()
+
+	pt, err := f.Parse(p)
+	if err != nil {
+		return err
+	}
+
+	skip := "!"
+	for _, k := range keys {
+		if k.Pkg != pt.Pkg {
+			continue
+		}
+		if !strings.HasPrefix(k.Name, pt.Name) {
+			continue
+		}
+		if strings.HasPrefix(k.Name, skip) {
+			continue
+		}
+
+		fl, ok := f.files.Load(k)
+		if !ok {
+			return os.ErrNotExist
+		}
+
+		fi, err := fl.Stat()
+		if err != nil {
+			return err
+		}
+
+		fi = pkging.NewFileInfo(fi)
+
+		err = wf(k.String(), fi, nil)
+		if err == filepath.SkipDir {
+
+			skip = k.Name
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,6 +249,8 @@ github.com/markbates/pkger
 github.com/markbates/pkger/here
 github.com/markbates/pkger/internal/maps
 github.com/markbates/pkger/pkging
+github.com/markbates/pkger/pkging/embed
+github.com/markbates/pkger/pkging/mem
 github.com/markbates/pkger/pkging/stdos
 # github.com/mattn/go-colorable v0.1.8
 github.com/mattn/go-colorable


### PR DESCRIPTION
## What does this PR do?

- [X] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Ongoing work for the live target retargeting
- Live selector-based cache system per disruption, only drops a log for now
- Lifecycle: for each disruption, the cache is created if it doesn't exist, and is deleted on disruption deletion and/or on controller shutdown
- Next step/ongoing work: enqueue a reconcile loop trigger from the cache function

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
