### PR TITLE
Fix unspecified port parsing in allowed hosts

### DIFF
--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -174,7 +174,7 @@ func NetworkDisruptionHostSpecFromString(hosts []string) ([]NetworkDisruptionHos
 		parsedHost := strings.SplitN(host, ";", 4)
 
 		// cast port to int if specified
-		if len(parsedHost) > 1 {
+		if len(parsedHost) > 1 && parsedHost[1] != "" {
 			port, err = strconv.Atoi(parsedHost[1])
 			if err != nil {
 				return nil, fmt.Errorf("unexpected port parameter in %s: %v", host, err)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- when an allowed host was specified with no port but a protocol or a flow, port parsing was failing

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).
