### PR TITLE
CI dep check should check all deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,8 +215,8 @@ jobs:
   third-party-licenses:
     executor: python
     steps:
-      - checkout
       - alpine_install_git
+      - checkout
       - python_install_requirements
       - run:
           name: Ensure 3rd-party licenses are up-to-date
@@ -226,8 +226,8 @@ jobs:
   license-header:
     executor: python
     steps:
-      - checkout
       - alpine_install_git
+      - checkout
       - python_install_requirements
       - run:
           name: Ensure license header is present

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ jobs:
           name: Ensure dependencies are up-to-date
           command: |
             go mod tidy
+            go mod vendor
             git diff --exit-code
   # this will fail if changes in packages are checked into git but the updated manifests are not
   manifests:

--- a/cli/chaosli/cmd/root.go
+++ b/cli/chaosli/cmd/root.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/markbates/pkger"
+	_ "github.com/markbates/pkger/pkging/mem" //nolint:revive
 	goyaml "sigs.k8s.io/yaml"
 
 	"github.com/spf13/cobra"


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Without `pkged.go` checked in, then `go mod vendor` wont pick up our need for `mem` or `embed`. But if they aren't in `vendor/`, then our `pkger` script wont work. So my bad solution was to check in `pkged.go`. I would love a better solution?

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
