### PR TITLE
Demo namespace has been removed from the demo manifest for some reason

### DIFF
--- a/examples/demo.yaml
+++ b/examples/demo.yaml
@@ -3,6 +3,14 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chaos-demo
+  labels:
+    name: chaos-demo
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Re-add the demo namespace in the demo manifest
