### PR TITLE
Extract namespace into a Helm property.

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chaos-controller-config
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}
 data:
   config.yaml: |
     controller:
@@ -44,7 +44,7 @@ data:
         {{- end }}
       {{- end }}
       serviceAccount: {{ .Values.injector.serviceAccount | quote }}
-      chaosNamespace: {{ .Values.injector.chaosNamespace | quote }}
+      chaosNamespace: {{ .Values.chaosNamespace | quote }}
       dnsDisruption:
         dnsServer: {{ .Values.injector.dnsDisruption.dnsServer | quote }}
         kubeDns: {{ .Values.injector.dnsDisruption.kubeDns | quote }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -6,7 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: chaos-controller
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}
 spec:
   replicas: 1
   selector:

--- a/chart/templates/role_binding.yaml
+++ b/chart/templates/role_binding.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: chaos-controller-leader-election-rolebinding
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -14,7 +14,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: chaos-controller
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -27,7 +27,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: chaos-injector
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -40,7 +40,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: chaos-controller
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -53,4 +53,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: chaos-controller
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: chaos-controller-metrics-service
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}
 spec:
   ports:
   - name: https
@@ -19,7 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: chaos-controller-webhook-service
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}
 spec:
   ports:
   - port: 443

--- a/chart/templates/service_account.yaml
+++ b/chart/templates/service_account.yaml
@@ -6,10 +6,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: chaos-controller
-  namespace: chaos-engineering
+  namespace: {{ .Values.global.namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.injector.serviceAccount }}
-  namespace: {{ .Values.injector.chaosNamespace }}
+  namespace: {{ .Values.chaosNamespace }}

--- a/chart/templates/service_account.yaml
+++ b/chart/templates/service_account.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: chaos-controller
-  namespace: {{ .Values.global.namespace }}
+  namespace: {{ .Values.chaosNamespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/chart/templates/webhook.yaml
+++ b/chart/templates/webhook.yaml
@@ -4,8 +4,8 @@
 # Copyright 2021 Datadog, Inc.
 {{- $ca := genCA "chaos-controller-webhook-service-ca" 3650 }}
 {{- $cn := "chaos-controller-webhook-service" }}
-{{- $altName1 := "chaos-controller-webhook-service.chaos-engineering.svc" }}
-{{- $altName2 := "chaos-controller-webhook-service.chaos-engineering.svc.cluster.local" }}
+{{- $altName1 := printf "chaos-controller-webhook-service.%s.svc" .Values.chaosNamespace }}
+{{- $altName2 := printf "chaos-controller-webhook-service.%s.svc.cluster.local" .Values.chaosNamespace }}
 {{- $cert := genSignedCert $cn nil (list $altName1 $altName2) 3650 $ca }}
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -13,7 +13,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
   {{- if not .Values.controller.webhook.generateCert }}
-    cert-manager.io/inject-ca-from: chaos-engineering/chaos-controller-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Values.chaosNamespace }}/chaos-controller-serving-cert
   {{- end }}
   name: chaos-controller
 webhooks:
@@ -25,10 +25,10 @@ webhooks:
   {{- end }}
     service:
       name: chaos-controller-webhook-service
-      namespace: chaos-engineering
+      namespace: {{ .Values.chaosNamespace }}
       path: /validate-chaos-datadoghq-com-v1beta1-disruption
   failurePolicy: Fail
-  name: chaos-controller-webhook-service.chaos-engineering.svc
+  name: chaos-controller-webhook-service.{{ .Values.chaosNamespace }}.svc
   rules:
   - apiGroups:
     - chaos.datadoghq.com
@@ -46,7 +46,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
   {{- if not .Values.controller.webhook.generateCert }}
-    cert-manager.io/inject-ca-from: chaos-engineering/chaos-controller-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Values.chaosNamespace }}/chaos-controller-serving-cert
   {{- end }}
   name: chaos-controller
 webhooks:
@@ -58,10 +58,10 @@ webhooks:
   {{- end }}
     service:
       name: chaos-controller-webhook-service
-      namespace: chaos-engineering
+      namespace: {{ .Values.chaosNamespace }}
       path: /mutate-chaos-datadoghq-com-v1beta1-disruption
   failurePolicy: Fail
-  name: chaos-controller-webhook-service.chaos-engineering.svc
+  name: chaos-controller-webhook-service.{{ .Values.chaosNamespace }}.svc
   rules:
   - apiGroups:
       - chaos.datadoghq.com
@@ -77,7 +77,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
   {{- if not .Values.controller.webhook.generateCert }}
-    cert-manager.io/inject-ca-from: chaos-engineering/chaos-controller-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Values.chaosNamespace }}/chaos-controller-serving-cert
   {{- end }}
   name: chaos-controller-pod-chaos-handler
 webhooks:
@@ -89,10 +89,10 @@ webhooks:
   {{- end }}
     service:
       name: chaos-controller-webhook-service
-      namespace: chaos-engineering
+      namespace: {{ .Values.chaosNamespace }}
       path: /mutate-v1-pod-chaos-handler-init-container
   failurePolicy: Ignore
-  name: chaos-controller-admission-webhook.chaos-engineering.svc
+  name: chaos-controller-admission-webhook.{{ .Values.chaosNamespace }}.svc
   objectSelector:
     matchExpressions:
       - key: "chaos.datadoghq.com/disrupt-on-init"
@@ -112,7 +112,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
   {{- if not .Values.controller.webhook.generateCert }}
-    cert-manager.io/inject-ca-from: chaos-engineering/chaos-controller-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Values.chaosNamespace }}/chaos-controller-serving-cert
   {{- end }}
   name: chaos-controller-disruption-user-info
 webhooks:
@@ -124,10 +124,10 @@ webhooks:
   {{- end }}
     service:
       name: chaos-controller-webhook-service
-      namespace: chaos-engineering
+      namespace: {{ .Values.chaosNamespace }}
       path: /mutate-chaos-datadoghq-com-v1beta1-disruption-user-info
   failurePolicy: Fail
-  name: chaos-controller-admission-webhook.chaos-engineering.svc
+  name: chaos-controller-admission-webhook.{{ .Values.chaosNamespace }}.svc
   rules:
   - apiGroups:
     - "chaos.datadoghq.com"
@@ -145,11 +145,11 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: chaos-controller-serving-cert
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}
 spec:
   dnsNames:
-    - chaos-controller-webhook-service.chaos-engineering.svc
-    - chaos-controller-webhook-service.chaos-engineering.svc.cluster.local
+    - chaos-controller-webhook-service.{{ .Values.chaosNamespace }}.svc
+    - chaos-controller-webhook-service.{{ .Values.chaosNamespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: chaos-controller-selfsigned-issuer
@@ -159,7 +159,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: chaos-controller-selfsigned-issuer
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}
 spec:
   selfSigned: {}
 {{- else }}
@@ -169,7 +169,7 @@ kind: Secret
 type: kubernetes.io/tls
 metadata:
   name: chaos-controller-webhook-secret
-  namespace: chaos-engineering
+  namespace: {{ .Values.chaosNamespace }}
   labels:
     app: chaos-controller
 data:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,6 +2,7 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
+chaosNamespace: chaos-engineering # namespace where any resources get created.
 
 images: # images and tag to pull for each component of the stack
   controller: docker.io/library/chaos-controller:latest
@@ -33,7 +34,6 @@ controller:
 injector:
   annotations: {} # extra annotations passed to the chaos injector pods
   serviceAccount: chaos-injector # service account to use for the chaos injector pods
-  chaosNamespace: chaos-engineering # namespace where the service account can be found (NOTE: changing this will change the namespace in which the chaos pods are created)
   dnsDisruption: # dns disruption configuration
     dnsServer: "8.8.8.8" # IP address of the upstream dns server
     kubeDns: "off" # whether to use kube-dns for DNS resolution (off, internal, all)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,7 +3,7 @@
 ## Where can I find the chaos pods for my disruption?
 
 In order to ensure that chaos pods have access to the ClusterRole they need, all chaos pods are created in the same namespace as the `chaos-injector`
- service account. This is configured with the `--chaos-namespace` flag when starting the chaos-controller, or by setting `injector.chaosNamespace` in the controller's config map. By default, this is the "chaos-engineering" namespace.
+ service account. This is configured with the `--chaos-namespace` flag when starting the chaos-controller, or by setting `chaosNamespace` in the controller's config map. By default, this is the "chaos-engineering" namespace.
 
 ## Is there any specific tooling that can help me create/understand my disruptions?
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [X] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Right now the namespace is either hardcoded or set as an [injector property for the Service Account](https://github.com/DataDog/chaos-controller/blob/1fb906c7e5cc6149a329bff4ba753f8465563702/chart/values.yaml#L36).

It would be good to consolidate and set this in a single place.
This will also allow users to install the resources in a different namespace - we have to do that for certain reasons internally.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
