### PR TITLE
Let chaos pods terminate themselves, rather than rely on activeDeadlineSeconds

### DIFF
--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -386,6 +386,7 @@ func injectAndWait(cmd *cobra.Command, args []string) {
 	deadline, err := time.Parse(time.RFC3339, deadlineRaw)
 	if err != nil {
 		deadline = time.Now().Add(time.Hour)
+
 		log.Errorw("unable to determine disruption deadline, will self-terminate in one hour instead", "err", err)
 	}
 
@@ -430,7 +431,6 @@ func injectAndWait(cmd *cobra.Command, args []string) {
 	case <-time.After(getDuration(deadline)):
 		log.Infow("duration has expired")
 	}
-
 }
 
 // cleanAndExit cleans the disruption with the configured injector and exits nicely
@@ -482,5 +482,5 @@ func retryNotifyHandler(err error, delay time.Duration) {
 // getDuration returns the time between time.Now() and when the disruption is due to expire
 // This gives the chaos pod plenty of time to clean up before it hits activeDeadlineSeconds and becomes Failed
 func getDuration(deadline time.Time) time.Duration {
-	return deadline.Sub(time.Now())
+	return time.Until(deadline)
 }

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -383,7 +383,7 @@ func injectAndWait(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	deadline, err := time.Parse(time.Layout, deadlineRaw)
+	deadline, err := time.Parse(time.RFC3339, deadlineRaw)
 	if err != nil {
 		deadline = time.Now().Add(time.Hour)
 		log.Errorw("unable to determine disruption deadline, will self-terminate in one hour instead", "err", err)

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -479,8 +479,8 @@ func retryNotifyHandler(err error, delay time.Duration) {
 	log.Infof("retrying cleanup in %s", delay.String())
 }
 
-// getDuration returns 30 seconds less than duration between time.Now() and when the disruption is due to expire
+// getDuration returns the time between time.Now() and when the disruption is due to expire
 // This gives the chaos pod plenty of time to clean up before it hits activeDeadlineSeconds and becomes Failed
 func getDuration(deadline time.Time) time.Duration {
-	return deadline.Sub(time.Now()) - (time.Second * 30)
+	return deadline.Sub(time.Now())
 }

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -847,6 +847,8 @@ func (r *DisruptionReconciler) generatePod(instance *chaosv1beta1.Disruption, ta
 	// ensures that whether a chaos pod is deleted directly or by deleting a disruption, it will have time to finish cleaning up after itself.
 	terminationGracePeriod := int64(60)
 	activeDeadlineSeconds := int64(calculateRemainingDuration(*instance).Seconds()) + 1
+	args = append(args,
+		"--deadline", time.Now().Add(calculateRemainingDuration(*instance)).Format(time.Layout))
 
 	if activeDeadlineSeconds < 1 {
 		return nil

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -846,7 +846,9 @@ func (r *DisruptionReconciler) generatePod(instance *chaosv1beta1.Disruption, ta
 	// the signal sent to a pod becomes SIGKILL, which will interrupt any in-progress cleaning. By double this to 1 minute in the pod spec itself,
 	// ensures that whether a chaos pod is deleted directly or by deleting a disruption, it will have time to finish cleaning up after itself.
 	terminationGracePeriod := int64(60)
-	activeDeadlineSeconds := int64(calculateRemainingDuration(*instance).Seconds()) + 1
+	// Chaos pods will clean themselves automatically when duration expires, so we set activeDeadlineSeconds to ten seconds after that
+	// to give time for cleaning
+	activeDeadlineSeconds := int64(calculateRemainingDuration(*instance).Seconds()) + 10
 	args = append(args,
 		"--deadline", time.Now().Add(calculateRemainingDuration(*instance)).Format(time.Layout))
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -850,7 +850,7 @@ func (r *DisruptionReconciler) generatePod(instance *chaosv1beta1.Disruption, ta
 	// to give time for cleaning
 	activeDeadlineSeconds := int64(calculateRemainingDuration(*instance).Seconds()) + 10
 	args = append(args,
-		"--deadline", time.Now().Add(calculateRemainingDuration(*instance)).Format(time.Layout))
+		"--deadline", time.Now().Add(calculateRemainingDuration(*instance)).Format(time.RFC3339))
 
 	if activeDeadlineSeconds < 1 {
 		return nil


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Some versions of kubernetes consider a pod that hits activeDeadlineSeconds to be `Failed`. This can be problematic. Rather than relying on this functionality to trigger chaos pod termination, they should know their own duration and attempt to self-clean.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
