### PR TITLE
Give more time for natural expiration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
           <<: *working_directory
           command: |
             sudo snap install yq
-            yq e '.controller.expiredDisruptionGCDelay = "3s"' -i chart/values.yaml
+            yq e '.controller.expiredDisruptionGCDelay = "10s"' -i chart/values.yaml
       - run:
           name: Wait for Docker Daemon to be up and running
           command: |


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- I noticed that `disruption expires naturally` has been flaky recently and went to investigate why. We're always failing when waiting for the disruption to reach PreviouslyInjected. We are only giving 3 seconds for this condition to possibly be true, and if there isn't a reconciliation in that window, we will fail. So I've increased it to 10s to reduce flakiness

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
