### PR TITLE
Ignore target immediately after creating the chaos pod

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -330,7 +330,10 @@ func (r *DisruptionReconciler) startInjection(instance *chaosv1beta1.Disruption)
 		r.log.Infow("starting targets injection", "targets", instance.Status.Targets)
 	}
 
-	for _, target := range instance.Status.Targets {
+	targetList := make([]string, len(instance.Status.Targets))
+	copy(targetList, instance.Status.Targets)
+
+	for _, target := range targetList {
 		targetNodeName := ""
 		targetContainerIDs := []string{}
 		targetPodIP := ""

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -395,6 +395,10 @@ func (r *DisruptionReconciler) startInjection(instance *chaosv1beta1.Disruption)
 					continue
 				}
 
+				if err := r.ignoreTarget(instance, target); err != nil {
+					r.log.Errorw("error ignoring chaos pod target", "err", err, "target", target, "chaosPod", chaosPod.Name)
+				}
+
 				// send metrics and events
 				r.Recorder.Event(instance, corev1.EventTypeNormal, "Created", fmt.Sprintf("Created disruption injection pod for \"%s\"", instance.Name))
 				r.recordEventOnTarget(instance, target, corev1.EventTypeWarning, "Disrupted", fmt.Sprintf("Pod %s from disruption %s targeted this resource for injection", chaosPod.Name, instance.Name))


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
I have yet to test this, but what do you think of the idea? Ignoring targets immediately after we confirm the chaos pod on them has been created. We don't ever want to create multiple chaos pods for a target after the initial injection anyway? Will this affect @nathantournant's design for dynamic count resolution?

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
