### PR TITLE
Document local setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ disruption.yaml
 packer_cache/
 crash.log
 *.json-e
+
+# local certificates
+/local/certDir/*.crt
+/local/certDir/*.key

--- a/docs/development.md
+++ b/docs/development.md
@@ -57,6 +57,24 @@ A successful delete prints:
 If your pod gets stuck in terminating, it's possible that there was an issue with the disruption. Try manually removing the finalizer:
 * ```kubectl patch pod <pod> -p '{"metadata":{"finalizers":null}}'```
 
+## Debugging the controller locally
+You can run the controller locally (e.g. in your IDE) and point it to an existing cluster.
+
+Follow the steps below:
+
+1. Set your Kubernetes context to the required cluster:
+    ```
+    kubectl config use-context <context>
+    ```
+2. Create the local Certificate (e.g. `tls.crt`) and the private key (e.g. `tls.key`) files under [local/certDir](../local/certDir). These will be used for the webhook. You could generate these or get them from an existing deploy; you will find them in the `chaos-controller-webhook-secret` Secret, in base64 format.
+3. Set the config file in the program arguments:
+    ```
+    --config=local/config.yaml
+    ```
+5. Set the environment variable below. The value does not matter as the safeguards are disabled in the local setup:
+  ```CONTROLLER_NODE_NAME=local```
+6. Make sure to delete any resource related to the controller. If the controller is already installed, you can scale its replicas down to 0. You will also need to delete the controller's `ValidatingWebhookConfigurations` and `MutatingWebhookConfigurations` resources.
+
 ## Basic Troubleshooting
 
 See the existing disruptions (corresponding to `metadata.name`):

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,7 +66,7 @@ Follow the steps below:
     ```
     kubectl config use-context <context>
     ```
-2. Create the local Certificate (e.g. `tls.crt`) and the private key (e.g. `tls.key`) files under [local/certDir](../local/certDir). These will be used for the webhook. You could generate these or get them from an existing deploy; you will find them in the `chaos-controller-webhook-secret` Secret, in base64 format.
+2. Create a `certDir` folder under the existing [local](../local) directory. Inside `certDir` create the local Certificate (e.g. `tls.crt`) and the private key (e.g. `tls.key`) files. These will be used for the webhook. You could generate these or get them from an existing deploy; you will find them in the `chaos-controller-webhook-secret` Secret, in base64 format.
 3. Set the config file in the program arguments:
     ```
     --config=local/config.yaml

--- a/local/config.yaml
+++ b/local/config.yaml
@@ -1,3 +1,7 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
 controller:
   metricsBindAddr: "127.0.0.1:8080"
   leaderElection: false

--- a/local/config.yaml
+++ b/local/config.yaml
@@ -1,0 +1,32 @@
+controller:
+  metricsBindAddr: "127.0.0.1:8080"
+  leaderElection: false
+  metricsSink: "noop"
+  enableSafeguards: false
+  notifiers:
+    common:
+      clusterName: "minikube"
+    noop:
+      enabled: true
+    slack:
+      enabled: false
+      tokenFilepath: ""
+  deleteOnly: false
+  imagePullSecrets: ""
+  defaultDuration: 1h
+  expiredDisruptionGCDelay: 10m
+  webhook:
+    certDir: "local/certDir"
+    host: ""
+    port: 9443
+injector:
+  image: "docker.io/library/chaos-injector:latest"
+  serviceAccount: "chaos-injector"
+  chaosNamespace: "chaos-engineering"
+  dnsDisruption:
+    dnsServer: ""
+    kubeDns: "all"
+handler:
+  enabled: true
+  image: "docker.io/library/chaos-handler:latest"
+  timeout: "1m"


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [x] Improves documentation or testing

- Documents how to debug the controller locally. See #510.
- Introduces a sample `config.yaml` which can be used for debugging purposes.
- Adds an entry to gitignore to ensure the certificate and private key are never pushed to the upstream.

## Code Quality Checklist

- [x] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
