### PR TITLE
Use config to gate mutating hooks

### DIFF
--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -137,12 +137,15 @@ func (r *Disruption) getMetricsTags() []string {
 	tags := []string{
 		"name:" + r.Name,
 		"namespace:" + r.Namespace,
-		"username:" + r.Status.UserInfo.Username,
 	}
 
-	// add groups
-	for _, group := range r.Status.UserInfo.Groups {
-		tags = append(tags, "group:"+group)
+	if r.Status.UserInfo != nil {
+		tags = append(tags, "username:"+r.Status.UserInfo.Username)
+
+		// add groups
+		for _, group := range r.Status.UserInfo.Groups {
+			tags = append(tags, "group:"+group)
+		}
 	}
 
 	// add selectors

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -27,6 +27,7 @@ data:
       imagePullSecrets: {{ .Values.images.pullSecrets }}
       defaultDuration: {{ .Values.controller.defaultDuration }}
       expiredDisruptionGCDelay: {{ .Values.controller.expiredDisruptionGCDelay }}
+      userInfoHook: {{ .Values.controller.userInfoHook }}
       webhook:
         {{- if .Values.controller.webhook.generateCert }}
         certDir: /tmp/k8s-webhook-server/serving-certs

--- a/chart/templates/webhook.yaml
+++ b/chart/templates/webhook.yaml
@@ -72,6 +72,7 @@ webhooks:
     resources:
       - disruptions
 ---
+{{- if .Values.handler.enabled }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -106,7 +107,9 @@ webhooks:
     - CREATE
     resources:
     - pods
+{{- end }}
 ---
+{{- if .Values.controller.userInfoHook }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -139,6 +142,7 @@ webhooks:
     resources:
     - disruptions
     - disruptions/status
+{{- end }}
 ---
 {{- if not .Values.controller.webhook.generateCert }}
 apiVersion: cert-manager.io/v1alpha2

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,6 +25,7 @@ controller:
       tokenFilepath: ""
   defaultDuration: 1h # default spec.duration for a disruption with none specified
   expiredDisruptionGCDelay: 10m # time after a disruption expires before deleting it
+  userInfoHook: true
   webhook: # admission webhook configuration
     generateCert: false # if you want Helm to generate certificates (e.g. in case the cert-manager is not installed in the cluster) set this to true
     certDir: "" # certificate directory (must contain tls.crt and tls.key files)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,6 +95,16 @@ If you use Helm you can set the `controller.webhook.generateCert` parameter to `
 helm install -f values.yaml chaos-controller ./
 ```
 
+### User Info Webhook
+
+The chaos controller can [grab the authentication metadata](../webhook/user_info.go) from the user applying a disruption, and store it in the Disruption's status.
+To enable this, start the controller with the following option:
+```
+--user-info-hook
+```
+
+If you use Helm, you can set the `controller.webhook.userInfoHook` parameter to `true` in the [values.yaml](../chart/values.yaml).
+
 ### Setup in a cluster with Istio Service Mesh
 
 If you use a service mesh like Istio and the Istio sidecar is installed in application pods by default you may get the following error message:

--- a/main.go
+++ b/main.go
@@ -215,6 +215,10 @@ func main() {
 		logger.Fatal("missing required CONTROLLER_NODE_NAME environment variable")
 	}
 
+	if !cfg.Controller.UserInfoHook && cfg.Controller.Notifiers.Slack.Enabled {
+		logger.Fatal("cannot enable slack notifier without enabling the user info webhook")
+	}
+
 	// load configuration file if present
 	if configPath != "" {
 		logger.Infow("loading configuration file", "config", configPath)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Dont initialize the handler webhook if the handler is disabled
- Require a config option to initialize the user info webhook

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
