### PR TITLE
[CHAOS-241] Fix on init bug with dns disruptions

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -217,6 +217,10 @@ func (s *DisruptionSpec) validateGlobalDisruptionScope() (retErr error) {
 			retErr = multierror.Append(retErr, errors.New("OnInit is only compatible with network and dns disruptions"))
 		}
 
+		if s.DNS != nil && len(s.Containers) > 0 {
+			retErr = multierror.Append(retErr, errors.New("OnInit is only compatible on dns disruptions with no subset of targeted containers"))
+		}
+
 		if s.Level != chaostypes.DisruptionLevelPod && s.Level != chaostypes.DisruptionLevelUnspecified {
 			retErr = multierror.Append(retErr, errors.New("OnInit is only compatible with pod level disruptions"))
 		}

--- a/cli/chaosli/cmd/create.go
+++ b/cli/chaosli/cmd/create.go
@@ -101,6 +101,10 @@ func createSpec() (v1beta1.DisruptionSpec, error) {
 		spec.Containers = getContainers()
 	}
 
+	if spec.ContainerFailure == nil && spec.CPUPressure == nil && spec.DiskPressure == nil && spec.NodeFailure == nil && spec.GRPC == nil && spec.Level == types.DisruptionLevelPod && len(spec.Containers) == 0 {
+		spec.OnInit = getOnInit()
+	}
+
 	spec.DryRun = getDryRun()
 
 	return spec, nil
@@ -572,6 +576,14 @@ func getCount() *intstr.IntOrString {
 	wrappedResult := intstr.FromString(result)
 
 	return &wrappedResult
+}
+
+func getOnInit() bool {
+	onInitExplanations := "An OnInit disruption is a disruption which will be launched on the initialization of your targeted pod(s), enabling the disruption to be working directly at the start of the disrupted pod(s).\nTo make it work, you need to add \"chaos.datadoghq.com/disrupt-on-init: \"true\"\" to the labels of your targeted pod(s) and redeploy them."
+
+	fmt.Println(onInitExplanations)
+
+	return confirmOption("Do you want to enable on initialization disruptions?", "OnInit is disabled by default")
 }
 
 func getPulse() *v1beta1.DisruptionPulse {

--- a/cli/chaosli/cmd/explain.go
+++ b/cli/chaosli/cmd/explain.go
@@ -52,6 +52,10 @@ func explainMetaSpec(spec v1beta1.DisruptionSpec) {
 		fmt.Printf("\tℹ️  has the pulse mode activated meaning the disruptions will alternate between an active injected state with a duration of %s, and an inactive dormant state with a duration of %s.\n", spec.Pulse.ActiveDuration.Duration().String(), spec.Pulse.DormantDuration.Duration().String())
 	}
 
+	if spec.OnInit {
+		fmt.Printf("\tℹ️  has the onInit mode activated meaning the disruptions will be launched at the initialization of the targeted pods.\n")
+	}
+
 	fmt.Printf("\tℹ️  is going to target %s %s(s) (either described as a percentage of total %ss or actual number of them).\n", spec.Count, spec.Level, spec.Level)
 	PrintSeparator()
 }

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -448,6 +448,14 @@ func cleanAndExit(cmd *cobra.Command, args []string) {
 }
 
 func cleanFinalizer() error {
+	if len(configs) == 0 {
+		err := fmt.Errorf("no configuration available for this disruption")
+
+		log.Warnw("couldn't GET this pod in order to remove its finalizer", "pod", os.Getenv(env.InjectorPodName), "err", err)
+
+		return err
+	}
+
 	pod, err := configs[0].K8sClient.CoreV1().Pods(chaosNamespace).Get(context.Background(), os.Getenv(env.InjectorPodName), metav1.GetOptions{})
 	if err != nil {
 		log.Warnw("couldn't GET this pod in order to remove its finalizer", "pod", os.Getenv(env.InjectorPodName), "err", err)

--- a/docs/dns_disruption.md
+++ b/docs/dns_disruption.md
@@ -12,7 +12,9 @@ In order to ensure the target receives the configured records from DNS queries, 
 
 First, it sets up and runs a man-in-the-middle DNS resolver on the chaos pod, which you can find at `./bin/injector/dns_disruption_resolver.py`. This resolver intercepts DNS queries, checks the queried hostname against a local config file, and returns any present record overrides. If the resolver has no matching record for the hostname, it proxies the DNS query to the normal DNS resolver configured for the chaos pod.
 
-Second, in order for the target's DNS queries to end up at the injector's DNS resolver instead of the intended resolver, we use `iptables` nat rules. All port 53 udp traffic is redirected to the chaos pod, rather than the intended destination.
+Second, in order for the target's DNS queries to end up at the injector's DNS resolver instead of the intended resolver, we use `iptables` nat rules.
+With the OnInit parameter, we target all port 53 udp traffic, which is then redirected to the chaos pod, rather than the intended destination. (**It is not possible to isolate containers**)
+Without the OnInit parameter, we target all port 53 udp traffic **of each container targeted in the pod**, which is then redirected to the chaos pod, rather than the intended destination.
 
 ## Forwarding non-matched requests
 

--- a/injector/dns_disruption.go
+++ b/injector/dns_disruption.go
@@ -112,22 +112,22 @@ func (i DNSDisruptionInjector) Inject() error {
 		return fmt.Errorf("unable to create new iptables rule: %w", err)
 	}
 
-	if i.config.Level == chaostypes.DisruptionLevelPod && !i.config.OnInit {
-		// write classid to container net_cls cgroup - for iptable filtering
-		if err := i.config.Cgroup.Write("net_cls", "net_cls.classid", InjectorDNSCgroupClassID); err != nil {
-			return fmt.Errorf("error writing classid to pod net_cls cgroup: %w", err)
-		}
+	if i.config.Level == chaostypes.DisruptionLevelPod {
+		if !i.config.OnInit {
+			// write classid to container net_cls cgroup - for iptable filtering
+			if err := i.config.Cgroup.Write("net_cls", "net_cls.classid", InjectorDNSCgroupClassID); err != nil {
+				return fmt.Errorf("error writing classid to pod net_cls cgroup: %w", err)
+			}
 
-		// Redirect traffic marked by targeted InjectorDNSCgroupClassID to CHAOS-DNS
-		if err := i.config.Iptables.AddCgroupFilterRule("OUTPUT", InjectorDNSCgroupClassID, "udp", "53", "CHAOS-DNS"); err != nil {
-			return fmt.Errorf("unable to create new iptables rule: %w", err)
-		}
-	}
-
-	if i.config.OnInit {
-		// Redirect all dns related traffic in the pod to CHAOS-DNS
-		if err := i.config.Iptables.AddWideFilterRule("OUTPUT", "udp", "53", "CHAOS-DNS"); err != nil {
-			return fmt.Errorf("unable to create new iptables rule: %w", err)
+			// Redirect traffic marked by targeted InjectorDNSCgroupClassID to CHAOS-DNS
+			if err := i.config.Iptables.AddCgroupFilterRule("OUTPUT", InjectorDNSCgroupClassID, "udp", "53", "CHAOS-DNS"); err != nil {
+				return fmt.Errorf("unable to create new iptables rule: %w", err)
+			}
+		} else {
+			// Redirect all dns related traffic in the pod to CHAOS-DNS
+			if err := i.config.Iptables.AddWideFilterRule("OUTPUT", "udp", "53", "CHAOS-DNS"); err != nil {
+				return fmt.Errorf("unable to create new iptables rule: %w", err)
+			}
 		}
 	}
 

--- a/injector/dns_disruption_test.go
+++ b/injector/dns_disruption_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Failure", func() {
 		iptables.On("CreateChain", mock.Anything).Return(nil)
 		iptables.On("ClearAndDeleteChain", mock.Anything).Return(nil)
 		iptables.On("AddRuleWithIP", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		iptables.On("AddWideFilterRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		iptables.On("AddCgroupFilterRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		iptables.On("PrependRule", mock.Anything, mock.Anything).Return(nil)
 		iptables.On("DeleteRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/network/iptables.go
+++ b/network/iptables.go
@@ -106,7 +106,6 @@ func (i iptables) AddWideFilterRule(chain string, protocol string, port string, 
 	i.log.Infow("creating new iptables rule", "chain name", chain, "protocol", protocol, "port", port, "jump target", jump)
 
 	return i.ip.AppendUnique("nat", chain, "-p", protocol, "--dport", port, "-j", jump)
-
 }
 
 func (i iptables) DeleteRule(chain string, protocol string, port string, jump string) error {

--- a/network/iptables.go
+++ b/network/iptables.go
@@ -17,6 +17,7 @@ type Iptables interface {
 	CreateChain(name string) error
 	ClearAndDeleteChain(name string) error
 	AddRuleWithIP(chain string, protocol string, port string, jump string, destinationIP string) error
+	AddWideFilterRule(chain string, protocol string, port string, jump string) error
 	AddCgroupFilterRule(chain string, cgroupid string, protocol string, port string, jump string) error
 	PrependRule(chain string, rulespec ...string) error
 	DeleteRule(chain string, protocol string, port string, jump string) error
@@ -95,6 +96,17 @@ func (i iptables) AddCgroupFilterRule(chain string, cgroupid string, protocol st
 		"protocol", protocol, "port", port, "jump target", jump)
 
 	return i.ip.AppendUnique("nat", chain, "-m", "cgroup", "--cgroup", cgroupid, "-p", protocol, "--dport", port, "-j", jump)
+}
+
+func (i iptables) AddWideFilterRule(chain string, protocol string, port string, jump string) error {
+	if i.dryRun {
+		return nil
+	}
+
+	i.log.Infow("creating new iptables rule", "chain name", chain, "protocol", protocol, "port", port, "jump target", jump)
+
+	return i.ip.AppendUnique("nat", chain, "-p", protocol, "--dport", port, "-j", jump)
+
 }
 
 func (i iptables) DeleteRule(chain string, protocol string, port string, jump string) error {

--- a/network/iptables_mock.go
+++ b/network/iptables_mock.go
@@ -48,6 +48,13 @@ func (f *IptablesMock) DeleteRule(chain string, protocol string, port string, ju
 }
 
 //nolint:golint
+func (f *IptablesMock) AddWideFilterRule(chain string, protocol string, port string, jump string) error {
+	args := f.Called(chain, protocol, port, jump)
+
+	return args.Error(0)
+}
+
+//nolint:golint
 func (f *IptablesMock) AddCgroupFilterRule(chain string, cgroupid string, protocol string, port string, jump string) error {
 	args := f.Called(chain, cgroupid, protocol, port, jump)
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- *OnInit*: The containers of the targeted pods are in a Waiting state when  we use onInit parameter.
Because we wait for the injection to be launched before resuming the initialisation of the containers, we can't get any process ID associated with those containers, except the chaos-handler pid.
- *dns Injector*: When injecting the dns disruption, an iptable rule per targeted pid is created to redirect the udp 53 traffic to our man-in-the-middle dns resolver, changing the dns record to the value we want.
- *root cause*: as we can't target the non initialized containers (no pid), no iptable rule is created for the container we want to target: the disruption doesn't succeed

- When onInit parameter is set, we create an iptable rule targeting traffic on whole pod instead of the container.
- We can't use the containers parameter with onInit anymore.
- Adding onInit parameter to the chaosli

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `onInit dns disruption`
    - [x] locally.
    - [x] on staging
    - [ ] as a canary deployment to a cluster.
