### PR TITLE
Chaosli: goreleaser build fix

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,8 +30,6 @@ builds:
     goos:
       - linux
       - darwin
-    env:
-      - CGO_ENABLED=0
     ldflags:
       - -X github.com/DataDog/chaos-controller/cli/chaosli/cmd.Version={{ .Tag }}
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,8 @@
 before:
   hooks:
     - go mod download
+    - pkger -o /cli/chaosli/cmd
+
 builds:
   - id: controller
     binary: manager
@@ -28,6 +30,10 @@ builds:
     goos:
       - linux
       - darwin
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -X github.com/DataDog/chaos-controller/cli/chaosli/cmd.Version={{ .Tag }}
 archives:
   - id: controller
     builds:

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ handler:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/handler/handler ./cli/handler/
 
 # Build chaosli
+# - please make sure to execute this command from the full path, with no alias in `pwd`. 
+#   pkger will not work properly otherwise
 chaosli:
 	pkger -o cli/chaosli/cmd
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-X github.com/DataDog/chaos-controller/cli/chaosli/cmd.Version=$(VERSION)" -o bin/chaosli/chaosli_darwin_amd64 ./cli/chaosli/


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [X] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Up to now, the `goreleaser` build for the `chaosli` was not functionnal, as the focus was mainly on the homebrew version build.
- 

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [X] I manually tested the following steps:
    - go to the chaos-controller project *using the full path* (eg. `~/go/src/github.com/DataDog/chaos-controller`)
    - `make chaosli VERSION=customtest`
    - `./bin/chaosli/chaosli_darwin_amd64 version` ⇒ check for `chaosli customtest`
    - `./bin/chaosli/chaosli_darwin_amd64 validate --path examples/dns.yaml` ⇒ check for errorless `file is valid` result
    - `./bin/chaosli/chaosli_darwin_amd64 validate --path examples/complete.yaml` ⇒ check for valid errors list
    - `tree $GOPATH/src/chaosli-api-lib` ⇒ directory should contain `v1beta1/customtest/...`
