### PR TITLE
[CHAOS-270]: Add StaticTargeting to `chaosli`

### DIFF
--- a/cli/chaosli/cmd/create.go
+++ b/cli/chaosli/cmd/create.go
@@ -687,7 +687,7 @@ func getStaticTargeting() *bool {
 
 	fmt.Println(staticTargetingExplanations)
 
-	a := confirmOption("Would you like to enable on StaticTargeting? Blocks new pods from being targeted.", staticTargetingExplanations)
+	a := confirmOption("Would you like to enable StaticTargeting? Blocks new pods from being targeted after the initial injection.", staticTargetingExplanations)
 
 	return &a
 }

--- a/cli/chaosli/cmd/create.go
+++ b/cli/chaosli/cmd/create.go
@@ -82,6 +82,7 @@ func createSpec() (v1beta1.DisruptionSpec, error) {
 
 	spec.Level = getLevel()
 	spec.Selector = getSelectors()
+	spec.StaticTargeting = getStaticTargeting()
 	spec.Count = getCount()
 
 	isPulsingCompatible := true
@@ -679,6 +680,16 @@ func getLevel() types.DisruptionLevel {
 	}
 
 	return types.DisruptionLevel(level)
+}
+
+func getStaticTargeting() *bool {
+	staticTargetingExplanations := "StaticTargeting means the target selection will only happen once at disruption creation, and will never be run again. New targets will not be targeted. StaticTargeting is temporarily defaulting to true, and will eventually default to false"
+
+	fmt.Println(staticTargetingExplanations)
+
+	a := confirmOption("Would you like to enable on StaticTargeting? Blocks new pods from being targeted.", staticTargetingExplanations)
+
+	return &a
 }
 
 func getDryRun() bool {

--- a/cli/chaosli/cmd/explain.go
+++ b/cli/chaosli/cmd/explain.go
@@ -57,6 +57,13 @@ func explainMetaSpec(spec v1beta1.DisruptionSpec) {
 	}
 
 	fmt.Printf("\tℹ️  is going to target %s %s(s) (either described as a percentage of total %ss or actual number of them).\n", spec.Count, spec.Level, spec.Level)
+
+	if spec.StaticTargeting == nil || *spec.StaticTargeting {
+		fmt.Printf("\tℹ️  has StaticTargeting activated, so new pods/nodes will be NOT be targeted \n")
+	} else {
+		fmt.Printf("\tℹ️  has StaticTargeting deactivated, so new pods/nodes will be targeted\n")
+	}
+
 	PrintSeparator()
 }
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [X] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Adds the last CRD modification to the chaosli: StaticTargeting

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [X] I manually tested the following steps:
    - `make chaosli`
    - `./bin/chaosli/chaosli_darwin_amd64 create --path=examples/disruption.yaml`
    - Exclude Static/Targeting
    - `./bin/chaosli/chaosli_darwin_amd64 explain --path=examples/disruption.yaml`
