### PR TITLE
Fix expected config key to match chart

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 	pflag.StringVar(&configPath, "config", "", "Configuration file path")
 
 	pflag.StringVar(&cfg.Controller.MetricsBindAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	handleFatalError(viper.BindPFlag("controller.metrics.addr", pflag.Lookup("metrics-bind-address")))
+	handleFatalError(viper.BindPFlag("controller.metricsBindAddr", pflag.Lookup("metrics-bind-address")))
 
 	pflag.BoolVar(&cfg.Controller.LeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	handleFatalError(viper.BindPFlag("controller.leaderElection", pflag.Lookup("leader-elect")))


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- We noticed we used `metricsBindAddr` in the configMap, but we were still expecting `metrics.bind.addr`.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
