### PR TITLE
Catch len(Targets) = 0 for Safemode

### DIFF
--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -338,10 +338,18 @@ func safetyNetCountNotTooLarge(r Disruption) (bool, string, error) {
 		return false, "", fmt.Errorf("failed to get count: %w", err)
 	}
 
+	if targetCount == 0 {
+		return false, " ", nil
+	}
+
 	if isPercent {
 		userCountVal = float64(userCountInt) / 100.0 * float64(targetCount)
 	} else {
 		userCountVal = float64(userCountInt)
+	}
+
+	if userCountVal == 0 {
+		return false, " ", nil
 	}
 
 	// we check to see if the count represents > 80 percent of all pods in the existing namepsace

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -339,7 +339,7 @@ func safetyNetCountNotTooLarge(r Disruption) (bool, string, error) {
 	}
 
 	if targetCount == 0 {
-		return false, " ", nil
+		return false, "", nil
 	}
 
 	if isPercent {

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -348,10 +348,6 @@ func safetyNetCountNotTooLarge(r Disruption) (bool, string, error) {
 		userCountVal = float64(userCountInt)
 	}
 
-	if userCountVal == 0 {
-		return false, " ", nil
-	}
-
 	// we check to see if the count represents > 80 percent of all pods in the existing namepsace
 	// or if the count represents > 66 percent of all pods in the cluster
 	if r.Spec.Level != chaostypes.DisruptionLevelNode {


### PR DESCRIPTION
Catch when there are 0 targets to avoid bad math operations with 0

## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [X] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- There is the possibility that when a disruption is applied, the label for selecting target results in 0 targets which leads to some bad math (divide by 0) being down further down the line in safemode. So we should catch it before that weird math happens.

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [X] locally.
    - [ ] as a canary deployment to a cluster.
