### PR TITLE
CHAOS-245: Switch StaticTargeting default value to false

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -46,7 +46,7 @@ type DisruptionSpec struct {
 	DryRun           bool                              `json:"dryRun,omitempty"`           // enable dry-run mode
 	OnInit           bool                              `json:"onInit,omitempty"`           // enable disruption on init
 	Unsafemode       *UnsafemodeSpec                   `json:"unsafeMode,omitempty"`       // unsafemode spec used to turn off safemode safety nets
-	StaticTargeting  *bool                             `json:"staticTargeting,omitempty"`  // enable dynamic targeting and cluster observation
+	StaticTargeting  bool                              `json:"staticTargeting,omitempty"`  // enable dynamic targeting and cluster observation
 	// +nullable
 	Pulse    *DisruptionPulse   `json:"pulse,omitempty"`    // enable pulsing diruptions and specify the duration of the active state and the dormant state of the pulsing duration
 	Duration DisruptionDuration `json:"duration,omitempty"` // time from disruption creation until chaos pods are deleted and no more are created

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -283,11 +283,6 @@ func (in *DisruptionSpec) DeepCopyInto(out *DisruptionSpec) {
 		*out = new(UnsafemodeSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.StaticTargeting != nil {
-		in, out := &in.StaticTargeting, &out.StaticTargeting
-		*out = new(bool)
-		**out = **in
-	}
 	if in.Pulse != nil {
 		in, out := &in.Pulse, &out.Pulse
 		*out = new(DisruptionPulse)

--- a/cli/chaosli/cmd/create.go
+++ b/cli/chaosli/cmd/create.go
@@ -682,14 +682,14 @@ func getLevel() types.DisruptionLevel {
 	return types.DisruptionLevel(level)
 }
 
-func getStaticTargeting() *bool {
+func getStaticTargeting() bool {
 	staticTargetingExplanations := "StaticTargeting means the target selection will only happen once at disruption creation, and will never be run again. New targets will not be targeted. StaticTargeting is temporarily defaulting to true, and will eventually default to false"
 
 	fmt.Println(staticTargetingExplanations)
 
 	a := confirmOption("Would you like to enable StaticTargeting? Blocks new pods from being targeted after the initial injection.", staticTargetingExplanations)
 
-	return &a
+	return a
 }
 
 func getDryRun() bool {

--- a/cli/chaosli/cmd/explain.go
+++ b/cli/chaosli/cmd/explain.go
@@ -58,7 +58,7 @@ func explainMetaSpec(spec v1beta1.DisruptionSpec) {
 
 	fmt.Printf("\tℹ️  is going to target %s %s(s) (either described as a percentage of total %ss or actual number of them).\n", spec.Count, spec.Level, spec.Level)
 
-	if spec.StaticTargeting == nil || *spec.StaticTargeting {
+	if spec.StaticTargeting {
 		fmt.Printf("\tℹ️  has StaticTargeting activated, so new pods/nodes will be NOT be targeted \n")
 	} else {
 		fmt.Printf("\tℹ️  has StaticTargeting deactivated, so new pods/nodes will be targeted\n")

--- a/controllers/cache_handler.go
+++ b/controllers/cache_handler.go
@@ -449,12 +449,7 @@ func (h DisruptionTargetWatcherHandler) buildNodeEventsToSend(oldNode corev1.Nod
 func (r *DisruptionReconciler) manageInstanceSelectorCache(instance *chaosv1beta1.Disruption) error {
 	r.clearExpiredCacheContexts()
 
-	// remove check when StaticTargeting is defaulted to false
-	if instance.Spec.StaticTargeting == nil {
-		r.log.Debugw("StaticTargeting pointer is nil")
-	}
-
-	if instance.Spec.StaticTargeting == nil || *instance.Spec.StaticTargeting {
+	if instance.Spec.StaticTargeting {
 		return nil
 	}
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -744,12 +744,7 @@ func (r *DisruptionReconciler) handleChaosPodTermination(instance *chaosv1beta1.
 // the chosen targets names will be reflected in the instance status
 // subsequent calls to this function will always return the same targets as the first call
 func (r *DisruptionReconciler) selectTargets(instance *chaosv1beta1.Disruption) error {
-	// remove when StaticTargeting is defaulted to false
-	if instance.Spec.StaticTargeting == nil {
-		r.log.Debugw("StaticTargeting pointer is nil")
-	}
-
-	if len(instance.Status.Targets) != 0 && (instance.Spec.StaticTargeting == nil || *instance.Spec.StaticTargeting) {
+	if len(instance.Status.Targets) != 0 && instance.Spec.StaticTargeting {
 		return nil
 	}
 

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -388,7 +388,7 @@ var _ = Describe("Disruption Controller", func() {
 	Context("Dynamic targeting", func() {
 		BeforeEach(func() {
 			disruption.Spec = chaosv1beta1.DisruptionSpec{
-				StaticTargeting: func() *bool { b := false; return &b }(),
+				StaticTargeting: false,
 				DryRun:          true,
 				Count:           &intstr.IntOrString{Type: intstr.String, StrVal: "100%"},
 				Unsafemode: &chaosv1beta1.UnsafemodeSpec{
@@ -444,7 +444,7 @@ var _ = Describe("Disruption Controller", func() {
 	Context("Targets count", func() {
 		BeforeEach(func() {
 			disruption.Spec = chaosv1beta1.DisruptionSpec{
-				StaticTargeting: func() *bool { b := false; return &b }(),
+				StaticTargeting: false,
 				DryRun:          true,
 				Count:           &intstr.IntOrString{Type: intstr.String, StrVal: "3"},
 				Unsafemode: &chaosv1beta1.UnsafemodeSpec{

--- a/docs/features.md
+++ b/docs/features.md
@@ -52,18 +52,20 @@ If a `pulse` is not specified, then a disruption will not be pulsing.
 
 The `Disruption` resource uses [label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to target pods and nodes. The controller will retrieve all pods or nodes matching the given label selector and will randomly select a number (defined in the `count` field) of matching targets. It's possible to specify multiple label selectors, in which case the controller will select from targets that match all of them. Once applied, you can see the targeted pods/nodes by describing the `Disruption` resource.
 
+
 **NOTE:** If you are targeting pods, the disruption must be created in the same namespace as the targeted pods.
+
+### DynamicTargeting (default)
+By default, there is a constant re-targeting for disruptions. This means at any given time, any target within the selector's scope will be added to the target list and be disrupted.
+Although default, this is to use with care as a disruption gone wrong can quickly get out of control: per example, a disruption targeting 100% of an application's pod will affect all existing **and** future pods which can appear once the disruption started. As long as this 100% disruption exists, there will be no spared pod.
+
+`DynamicTargeting` behaviour design choices:
+- the controller will consider as a still-alive target any pod that exists - regardless of its state.
+- the controller will reconcile/update its targets list on any chaos or selector pod movement (create, update, delete)
 
 ### StaticTargeting
 
-When `StaticTargeting` is activated, targeting is limited to a single target selection at the disruption's creation. It allows for more controlled disruption impact and propagation, as the targets will never change and _can_ be compensated for in case they are made useless. Its major limit is not being able to follow targets through deployments/rollouts.
-By setting the `StaticTargeting` flag to `false` -or empty- in the [Disruption's yaml spec](../examples/static_targeting.yaml), there is a constant re-targeting for this disruption. This means at any given time, any target within the selector's scope will be added to the target list and be disrupted.
-This is a feature to use with care, as it can quickly get out of control: per example, a disruption targeting 100% of an application's pod will affect all existing **and** future pods which can appear once the disruption started. As long as this 100% disruption exists, there will be no spared pod.
-Even a 50%-set disruption, if the disruption gets targeted pods to die, will constantly re-target 50% of all selector-fitting pods and end up killing every pod unless they are recreated.
-
-`DynamicTargeting` behavior design choices:
-- the controller will consider as a still-alive target any pod that exists - regardless of its state.
-- the controller will reconcile/update its targets list on any chaos pod or selector movement (create, update, delete)
+Activate `StaticTargeting` to limit the disruption to a single target selection step at the disruption's creation. It allows for more controlled disruption impact and propagation, as the targets will never change and _can_ be compensated for in case they are made useless. Its major limit is not being able to follow targets through deployments/rollouts.
 
 ### Targeting safeguards
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -48,16 +48,16 @@ If a `pulse` is not specified, then a disruption will not be pulsing.
 
 ## Targeting
 
-**NEW:** StaticTargeting currently defaults to true. It will default to false after some transition time. [Read StaticTargeting](#StaticTargeting-(current-default-behaviour)).
+**NEW:** StaticTargeting currently defaults to false. Please mention explicitely if you wish to activate it. [Read StaticTargeting](#StaticTargeting-(current-default-behaviour)).
 
 The `Disruption` resource uses [label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to target pods and nodes. The controller will retrieve all pods or nodes matching the given label selector and will randomly select a number (defined in the `count` field) of matching targets. It's possible to specify multiple label selectors, in which case the controller will select from targets that match all of them. Once applied, you can see the targeted pods/nodes by describing the `Disruption` resource.
 
 **NOTE:** If you are targeting pods, the disruption must be created in the same namespace as the targeted pods.
 
-### StaticTargeting (current default behaviour)
+### StaticTargeting
 
 When `StaticTargeting` is activated, targeting is limited to a single target selection at the disruption's creation. It allows for more controlled disruption impact and propagation, as the targets will never change and _can_ be compensated for in case they are made useless. Its major limit is not being able to follow targets through deployments/rollouts.
-By setting the `StaticTargeting` flag to `false` in the [Disruption's yaml spec](../examples/static_targeting.yaml), you activate a constant re-targeting for this disruption. This means at any given time, any target within the selector's scope will be added to the target list and be disrupted.
+By setting the `StaticTargeting` flag to `false` -or empty- in the [Disruption's yaml spec](../examples/static_targeting.yaml), there is a constant re-targeting for this disruption. This means at any given time, any target within the selector's scope will be added to the target list and be disrupted.
 This is a feature to use with care, as it can quickly get out of control: per example, a disruption targeting 100% of an application's pod will affect all existing **and** future pods which can appear once the disruption started. As long as this 100% disruption exists, there will be no spared pod.
 Even a 50%-set disruption, if the disruption gets targeted pods to die, will constantly re-target 50% of all selector-fitting pods and end up killing every pod unless they are recreated.
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [X] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- StaticTargeting has been the default behaviour for the chaos-controller since it was created. After a month+ of beta testing, it's time to switch to default Dynamic Targeting. I expect this to go smoothly with some probable adjustments to come.

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [X] I manually tested the following steps:
    - Apply any disruption without `StaticTargeting` setting, and/or with Static Targeting set to false.
    - [X] locally.
    - [ ] as a canary deployment to a cluster.
