### PR TITLE
Allow combined Network/DNS Disruption

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -29,7 +29,6 @@ import (
 )
 
 // DisruptionSpec defines the desired state of Disruption
-// +ddmark:validation:ExclusiveFields={Network,DNS}
 // +ddmark:validation:ExclusiveFields={ContainerFailure,CPUPressure,DiskPressure,NodeFailure,Network,DNS}
 // +ddmark:validation:ExclusiveFields={NodeFailure,CPUPressure,DiskPressure,ContainerFailure,Network,DNS}
 // +ddmark:validation:AtLeastOneOf={DNS,CPUPressure,Network,NodeFailure,ContainerFailure,DiskPressure,GRPC}

--- a/injector/dns_disruption.go
+++ b/injector/dns_disruption.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/env"
 	"github.com/DataDog/chaos-controller/network"
+	"github.com/DataDog/chaos-controller/types"
 	chaostypes "github.com/DataDog/chaos-controller/types"
 )
 
@@ -29,8 +30,6 @@ type DNSDisruptionInjectorConfig struct {
 	FileWriter   FileWriter
 	PythonRunner PythonRunner
 }
-
-const InjectorDNSCgroupClassID = "0x00100010"
 
 // NewDNSDisruptionInjector creates a DNSDisruptionInjector object with the given config,
 // missing fields are initialized with the defaults
@@ -115,12 +114,12 @@ func (i DNSDisruptionInjector) Inject() error {
 	if i.config.Level == chaostypes.DisruptionLevelPod {
 		if !i.config.OnInit {
 			// write classid to container net_cls cgroup - for iptable filtering
-			if err := i.config.Cgroup.Write("net_cls", "net_cls.classid", InjectorDNSCgroupClassID); err != nil {
+			if err := i.config.Cgroup.Write("net_cls", "net_cls.classid", types.InjectorCgroupClassID); err != nil {
 				return fmt.Errorf("error writing classid to pod net_cls cgroup: %w", err)
 			}
 
 			// Redirect traffic marked by targeted InjectorDNSCgroupClassID to CHAOS-DNS
-			if err := i.config.Iptables.AddCgroupFilterRule("OUTPUT", InjectorDNSCgroupClassID, "udp", "53", "CHAOS-DNS"); err != nil {
+			if err := i.config.Iptables.AddCgroupFilterRule("OUTPUT", types.InjectorCgroupClassID, "udp", "53", "CHAOS-DNS"); err != nil {
 				return fmt.Errorf("unable to create new iptables rule: %w", err)
 			}
 		} else {
@@ -181,7 +180,7 @@ func (i DNSDisruptionInjector) Clean() error {
 			}
 
 			// Delete iptables rules
-			if err := i.config.Iptables.DeleteCgroupFilterRule("OUTPUT", InjectorDNSCgroupClassID, "udp", "53", "CHAOS-DNS"); err != nil {
+			if err := i.config.Iptables.DeleteCgroupFilterRule("OUTPUT", types.InjectorCgroupClassID, "udp", "53", "CHAOS-DNS"); err != nil {
 				return fmt.Errorf("unable to remove injected iptables rule: %w", err)
 			}
 		}

--- a/injector/dns_disruption_test.go
+++ b/injector/dns_disruption_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/DataDog/chaos-controller/injector"
 	"github.com/DataDog/chaos-controller/netns"
 	"github.com/DataDog/chaos-controller/network"
+	"github.com/DataDog/chaos-controller/types"
 	chaostypes "github.com/DataDog/chaos-controller/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -114,10 +115,10 @@ var _ = Describe("Failure", func() {
 				config.Level = chaostypes.DisruptionLevelPod
 			})
 			It("creates pod-level iptable filter rules", func() {
-				iptables.AssertCalled(GinkgoT(), "AddCgroupFilterRule", "OUTPUT", InjectorDNSCgroupClassID, "udp", "53", "CHAOS-DNS")
+				iptables.AssertCalled(GinkgoT(), "AddCgroupFilterRule", "OUTPUT", types.InjectorCgroupClassID, "udp", "53", "CHAOS-DNS")
 			})
 			It("should write the custom classid to the target net_cls cgroup", func() {
-				cgroupManager.AssertCalled(GinkgoT(), "Write", "net_cls", "net_cls.classid", InjectorDNSCgroupClassID)
+				cgroupManager.AssertCalled(GinkgoT(), "Write", "net_cls", "net_cls.classid", types.InjectorCgroupClassID)
 			})
 		})
 	})
@@ -148,7 +149,7 @@ var _ = Describe("Failure", func() {
 				config.Level = chaostypes.DisruptionLevelPod
 			})
 			It("should clear the pod-level iptables rules", func() {
-				iptables.AssertCalled(GinkgoT(), "DeleteCgroupFilterRule", "OUTPUT", InjectorDNSCgroupClassID, "udp", "53", "CHAOS-DNS")
+				iptables.AssertCalled(GinkgoT(), "DeleteCgroupFilterRule", "OUTPUT", types.InjectorCgroupClassID, "udp", "53", "CHAOS-DNS")
 			})
 			It("should reset the custom classid", func() {
 				cgroupManager.AssertCalled(GinkgoT(), "Write", "net_cls", "net_cls.classid", "0x0")

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/env"
 	"github.com/DataDog/chaos-controller/network"
+	"github.com/DataDog/chaos-controller/types"
 	chaostypes "github.com/DataDog/chaos-controller/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -170,7 +171,7 @@ func (i *networkDisruptionInjector) Inject() error {
 	i.config.Log.Info("editing pod net_cls cgroup to apply a classid to target container packets")
 
 	// write classid to pod net_cls cgroup
-	if err := i.config.Cgroup.Write("net_cls", "net_cls.classid", "0x00020002"); err != nil {
+	if err := i.config.Cgroup.Write("net_cls", "net_cls.classid", types.InjectorCgroupClassID); err != nil {
 		return fmt.Errorf("error writing classid to pod net_cls cgroup: %w", err)
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -68,7 +68,7 @@ const (
 
 	// InjectorCgroupClassID is linked to the TC tree in the injector network disruption.
 	// Also used in the DNS Disruption to allow combined Network + DNS Disruption
-	// This value hould NEVER be changed without changing the Network Disruption TC tree.
+	// This value should NEVER be changed without changing the Network Disruption TC tree.
 	InjectorCgroupClassID = "0x00020002"
 )
 

--- a/types/types.go
+++ b/types/types.go
@@ -65,6 +65,11 @@ const (
 	ChaosPodFinalizer   = finalizerPrefix + "/chaos-pod"
 
 	PulsingDisruptionMinimumDuration = 500 * time.Millisecond
+
+	// InjectorCgroupClassID is linked to the TC tree in the injector network disruption.
+	// Also used in the DNS Disruption to allow combined Network + DNS Disruption
+	// This value hould NEVER be changed without changing the Network Disruption TC tree.
+	InjectorCgroupClassID = "0x00020002"
 )
 
 func (d DisruptionKindName) String() string {


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [X] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
### Intro

On pods, the network namespace is shared, making it quite tough to identify traffic from a specific container. We have to use container-specific ressources -`cgroups`- to differenciate traffic from a specific container from the rest of the pod traffic. The dedicated cgroup file for this is `net_cls.classid`.

### Why are we talking about this ?

We made the DNS disruption possible by using a dedicated `iptable` plugin, called `cgroup`. This enables us to separate traffic coming from a specific container compared the rest of the pod traffic, by setting the `net_cls.classid` file to a specific value at the container level. At the network level (shared with the rest of the pod), `iptable` will then redirect concerned traffic onto a special chain based on the value of the `net_cls.classid` file.  This chain will then lead the traffic to a spoof DNS instance.

Network Disruption *also* uses `net_cls.classid` file, except the value we set it to is this time interpreted by a special `tc` (traffic control) tree, again at the network namespace level. This `tc` tree expects a specific value for the file, dependent on the tree's architecture.

To avoid friction between those two features relying on the same container-level file, at a time we were less confident in our ability to manage that friction, we decided to forbid DNS + Network combined disruptions, even though it's technically possible. Recently, it has become a frequent user request to enable this combination, and we feel it is time to evaluate its risks and limits.

### What will happen ?

We intend to make the DNS Disruption set-and-expected `net_cls.classid` value to be the same as the network disruption's. This way, on a combined scenario, the concerned traffic will be affected by ***both***  the `tc` tree and the `iptable` chain. If only DNS-disruption is activated, there will be no `tc` tree; if only network-disruption is activated, there will be no `iptable` chain, so there should be no issue there.

### Q&A-shaped risks analysis

- **Don't those two features rely on different values for the `net_cls.classid`, making them profoundly incompatible ?**

  No they don't : while the network disruption `tc` tree we designed requires the file value to be exactly `0x00020002`, the `iptable` plugin expects any arbitrary value. As long as we know what to set and expect, we can make the DNS Disruption set the file to `0x00020002`, and expect that exact value at the `iptable` level.

- **Network namespace is shared within a pod. What if you find a DNS disruption targeting a container and another Network disruption targeting another container within that same pod ? Wouldn't having the same `net_cls.classid` value for both disruption create confusion ?**

  Impossible; at the pod-targeting level, the controller doesn't allow a pod targeted by a disruption to be targeted by another simultaneous disruption.

- **A big topic with disruptions is clean-up. What if a disruption is badly cleaned-up and some traffic gets wrongly affected by a following disruption on another container, and/or of another kind ?**

  While it removes some clarity for investigation in the occurence this would happen -and would definitely create a bigger trouble- this is more a clean-up dedicated issue than a network/dns disruption issue. Clean-up is a topic we're constantly working on, and 

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
