### PR TITLE
Dont conflate durationOver event with GCOver event

### DIFF
--- a/api/v1beta1/events.go
+++ b/api/v1beta1/events.go
@@ -61,6 +61,7 @@ const (
 	// Normal events
 	EventDisruptionCreated      string = "Created"
 	EventDisruptionDurationOver string = "DurationOver"
+	EventDisruptionGCOver       string = "GCOver"
 	EventDisrupted              string = "Disrupted"
 )
 
@@ -156,6 +157,12 @@ var Events = map[string]DisruptionEvent{
 	EventDisruptionDurationOver: {
 		Type:                        corev1.EventTypeWarning,
 		Reason:                      EventDisruptionDurationOver,
+		OnDisruptionTemplateMessage: "The disruption has lived longer than its specified duration, and will be deleted in %s.",
+		Category:                    DisruptEvent,
+	},
+	EventDisruptionGCOver: {
+		Type:                        corev1.EventTypeWarning,
+		Reason:                      EventDisruptionGCOver,
 		OnDisruptionTemplateMessage: "The disruption has lived %s longer than its specified duration, and will now be deleted.",
 		Category:                    DisruptEvent,
 	},

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -215,7 +215,7 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// and if less than that, it means we have exceeded the deadline by at least ExpiredDisruptionGCDelay, so we can delete
 		if r.ExpiredDisruptionGCDelay != nil && (calculateRemainingDuration(*instance) <= (-1 * *r.ExpiredDisruptionGCDelay)) {
 			r.log.Infow("disruption has lived for more than its duration, it will now be deleted.", "duration", instance.Spec.Duration)
-			r.recordEventOnDisruption(instance, chaosv1beta1.EventDisruptionDurationOver, r.ExpiredDisruptionGCDelay.String())
+			r.recordEventOnDisruption(instance, chaosv1beta1.EventDisruptionGCOver, r.ExpiredDisruptionGCDelay.String())
 
 			var err error
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- `x`

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
