### PR TITLE
Add readiness probe to curl and nginx demo pods

### DIFF
--- a/examples/demo.yaml
+++ b/examples/demo.yaml
@@ -58,6 +58,10 @@ spec:
             port: 80
           initialDelaySeconds: 3
           periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -84,6 +88,12 @@ spec:
         volumeMounts:
         - mountPath: /mnt/data
           name: data
+        readinessProbe:
+          exec:
+            command:
+              - curl
+              - -vvv
+              - http://demo.chaos-demo.svc.cluster.local:8080
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [X] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:

For testing purposes, it makes sense to have readiness probes available. Initially I had intended to add a liveness probe to the curl pod, but decided not to.

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [X] I manually tested the following steps:
    - `x`
    - [X] locally.
    - [ ] as a canary deployment to a cluster.
