### PR TITLE
Handle disruptions with only advanced selectors better

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -33,11 +33,11 @@ import (
 // +ddmark:validation:ExclusiveFields={ContainerFailure,CPUPressure,DiskPressure,NodeFailure,Network,DNS}
 // +ddmark:validation:ExclusiveFields={NodeFailure,CPUPressure,DiskPressure,ContainerFailure,Network,DNS}
 // +ddmark:validation:AtLeastOneOf={DNS,CPUPressure,Network,NodeFailure,ContainerFailure,DiskPressure,GRPC}
+// +ddmark:validation:AtLeastOneOf={Selector,AdvancedSelector}
 type DisruptionSpec struct {
 	// +ddmark:validation:Required=true
 	Count *intstr.IntOrString `json:"count"` // number of pods to target in either integer form or percent form appended with a %
 	// +nullable
-	// +ddmark:validation:Required=true
 	Selector labels.Set `json:"selector,omitempty"` // label selector
 	// +nullable
 	AdvancedSelector []metav1.LabelSelectorRequirement `json:"advancedSelector,omitempty"` // advanced label selector

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -240,6 +240,7 @@ func (r *Disruption) getMetricsTags() []string {
 		if lsr.Operator == metav1.LabelSelectorOpIn || lsr.Operator == metav1.LabelSelectorOpNotIn {
 			value = fmt.Sprintf(":%s", lsr.Values)
 		}
+
 		tags = append(tags, fmt.Sprintf("selector:%s:%s%s", lsr.Key, lsr.Operator, value))
 	}
 

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/DataDog/chaos-controller/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/chaos-controller/metrics"
 	chaostypes "github.com/DataDog/chaos-controller/types"
@@ -232,6 +233,14 @@ func (r *Disruption) getMetricsTags() []string {
 	// add selectors
 	for key, val := range r.Spec.Selector {
 		tags = append(tags, fmt.Sprintf("selector:%s:%s", key, val))
+	}
+
+	for _, lsr := range r.Spec.AdvancedSelector {
+		value := ""
+		if lsr.Operator == metav1.LabelSelectorOpIn || lsr.Operator == metav1.LabelSelectorOpNotIn {
+			value = fmt.Sprintf(":%s", lsr.Values)
+		}
+		tags = append(tags, fmt.Sprintf("selector:%s:%s%s", lsr.Key, lsr.Operator, value))
 	}
 
 	// add kinds


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- ddmark annotation that Selector is Required is inaccurate, changed to `AtLeastOneOf`
- advanced selectors are now specified in the metric tags, so we don't have empty selector tags anymore when people use advanced selectors only

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
