### PR TITLE
CHAOS-326:  Make logging changes

### DIFF
--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/DataDog/chaos-controller/ddmark"
-	"github.com/DataDog/chaos-controller/types"
 	"github.com/DataDog/chaos-controller/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -43,7 +42,7 @@ var handlerEnabled bool
 var defaultDuration time.Duration
 
 func (r *Disruption) SetupWebhookWithManager(setupWebhookConfig utils.SetupWebhookWithManagerConfig) error {
-	if err := ddmark.InitLibrary(EmbeddedChaosAPI, types.DDMarkChaoslibPrefix); err != nil {
+	if err := ddmark.InitLibrary(EmbeddedChaosAPI, chaostypes.DDMarkChaoslibPrefix); err != nil {
 		return err
 	}
 
@@ -108,7 +107,7 @@ func (r *Disruption) ValidateCreate() error {
 		return err
 	}
 
-	multiErr := ddmark.ValidateStructMultierror(r.Spec, "validation_webhook", types.DDMarkChaoslibPrefix)
+	multiErr := ddmark.ValidateStructMultierror(r.Spec, "validation_webhook", chaostypes.DDMarkChaoslibPrefix)
 	if multiErr.ErrorOrNil() != nil {
 		return multierror.Prefix(multiErr, "ddmark: ")
 	}

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -346,7 +346,7 @@ func (r *DisruptionReconciler) updateInjectionStatus(instance *chaosv1beta1.Disr
 
 			// consider the disruption as not fully injected if at least one not ready pod is found
 			if !podReady {
-				r.log.Infow("chaos pod is not ready yet", "chaosPod", chaosPod.Name)
+				r.log.Debugw("chaos pod is not ready yet", "chaosPod", chaosPod.Name)
 			}
 		}
 
@@ -623,6 +623,7 @@ func (r *DisruptionReconciler) handleOrphanedChaosPods(req ctrl.Request) error {
 //   - the pod is pending
 //   - the pod is succeeded (exit code == 0)
 //   - the pod target is not healthy (not existing anymore for instance)
+//
 // if a finalizer can't be removed because none of the conditions above are fulfilled, the instance is flagged
 // as stuck on removal and the pod finalizer won't be removed unless someone does it manually
 // the pod target will be moved to ignored targets, so it is not picked up by the next reconcile loop

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -804,18 +804,15 @@ func (r *DisruptionReconciler) selectTargets(instance *chaosv1beta1.Disruption) 
 	cTargetsCount := len(instance.Status.Targets)
 	dTargetsCount := targetsCount
 
-	switch {
-	case cTargetsCount < dTargetsCount:
+	if cTargetsCount < dTargetsCount {
 		// not enough targets: pick more targets from eligibleTargets
 		instance.Status.AddTargets(dTargetsCount-cTargetsCount, eligibleTargets)
-	case cTargetsCount > dTargetsCount:
+	} else if cTargetsCount > dTargetsCount {
 		// too many targets: remove random extra targets
 		instance.Status.RemoveTargets(cTargetsCount - dTargetsCount)
-	default:
-		return nil
 	}
 
-	r.log.Infow("updating instance status with targets selected for injection")
+	r.log.Debugw("updating instance status with targets selected for injection")
 
 	instance.Status.SelectedTargetsCount = len(instance.Status.Targets)
 	instance.Status.IgnoredTargetsCount = totalAvailableTargetsCount - targetsCount

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -383,10 +383,6 @@ func (r *DisruptionReconciler) updateInjectionStatus(instance *chaosv1beta1.Disr
 
 // startInjection creates non-existing chaos pod for the given disruption
 func (r *DisruptionReconciler) startInjection(instance *chaosv1beta1.Disruption) error {
-	if len(instance.Status.Targets) > 0 {
-		r.log.Infow("starting targets injection", "targets", instance.Status.Targets)
-	}
-
 	// chaosPodsMap is used to check if a target's chaos pods already exist or not
 	chaosPodsMap := make(map[string]map[string]bool, len(instance.Status.Targets))
 
@@ -406,6 +402,10 @@ func (r *DisruptionReconciler) startInjection(instance *chaosv1beta1.Disruption)
 		} else {
 			chaosPodsMap[chaosPod.Labels[chaostypes.TargetLabel]][chaosPod.Labels[chaostypes.DisruptionKindLabel]] = true
 		}
+	}
+
+	if len(instance.Status.Targets) > 0 && (len(instance.Status.Targets) != len(chaosPodsMap)) {
+		r.log.Infow("starting targets injection", "targets", instance.Status.Targets)
 	}
 
 	// iterate through target + existing disruption kind -- to ensure all chaos pods exist

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -804,13 +804,14 @@ func (r *DisruptionReconciler) selectTargets(instance *chaosv1beta1.Disruption) 
 	cTargetsCount := len(instance.Status.Targets)
 	dTargetsCount := targetsCount
 
-	if cTargetsCount < dTargetsCount {
+	switch {
+	case cTargetsCount < dTargetsCount:
 		// not enough targets: pick more targets from eligibleTargets
 		instance.Status.AddTargets(dTargetsCount-cTargetsCount, eligibleTargets)
-	} else if cTargetsCount > dTargetsCount {
+	case cTargetsCount > dTargetsCount:
 		// too many targets: remove random extra targets
 		instance.Status.RemoveTargets(cTargetsCount - dTargetsCount)
-	} else {
+	default:
 		return nil
 	}
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -806,6 +806,8 @@ func (r *DisruptionReconciler) selectTargets(instance *chaosv1beta1.Disruption) 
 	} else if cTargetsCount > dTargetsCount {
 		// too many targets: remove random extra targets
 		instance.Status.RemoveTargets(cTargetsCount - dTargetsCount)
+	} else {
+		return nil
 	}
 
 	r.log.Infow("updating instance status with targets selected for injection")

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -726,7 +726,11 @@ func (r *DisruptionReconciler) handleChaosPodTermination(instance *chaosv1beta1.
 		controllerutil.RemoveFinalizer(&chaosPod, chaostypes.ChaosPodFinalizer)
 
 		if err := r.Client.Update(context.Background(), &chaosPod); err != nil {
-			r.log.Errorw("error removing chaos pod finalizer", "error", err, "chaosPod", chaosPod.Name)
+			if strings.Contains(err.Error(), "latest version and try again") {
+				r.log.Debugw("cannot remove chaos pod finalizer, need to re-reconcile", "error", err)
+			} else {
+				r.log.Errorw("error removing chaos pod finalizer", "error", err, "chaosPod", chaosPod.Name)
+			}
 
 			return
 		}

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -149,10 +149,10 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				return ctrl.Result{}, err
 			}
 
-			// if not cleaned yet, requeue and reconcile again in 5s-10s
+			// if not cleaned yet, requeue and reconcile again in 15s-20s
 			// the reason why we don't rely on the exponential backoff here is that it retries too fast at the beginning
 			if !isCleaned {
-				requeueAfter := time.Duration(rand.Intn(5)+5) * time.Second //nolint:gosec
+				requeueAfter := time.Duration(rand.Intn(5)+15) * time.Second //nolint:gosec
 
 				r.log.Infow(fmt.Sprintf("disruption has not been fully cleaned yet, re-queuing in %v", requeueAfter))
 
@@ -281,8 +281,8 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 			return ctrl.Result{}, fmt.Errorf("error updating disruption injection status: %w", err)
 		} else if !injected {
-			// requeue after 5-10 seconds, as default 1ms is too quick here
-			requeueAfter := time.Duration(rand.Intn(5)+5) * time.Second //nolint:gosec
+			// requeue after 15-20 seconds, as default 1ms is too quick here
+			requeueAfter := time.Duration(rand.Intn(5)+15) * time.Second //nolint:gosec
 			r.log.Infow("disruption is not fully injected yet, requeuing", "injectionStatus", instance.Status.InjectionStatus)
 
 			return ctrl.Result{

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	chaosv1beta1 "github.com/DataDog/chaos-controller/api/v1beta1"
@@ -486,22 +487,22 @@ var _ = Describe("Disruption Controller", func() {
 	// the feature is broken now that we moved all chaos pods into the same namespace
 	// because we had to remove the owner reference on those pods, meaning that
 	// the reconcile loop does not automatically trigger anymore on chaos pods events like a delete
-	// Context("manually delete a chaos pod", func() {
-	// 	It("should properly handle the chaos pod finalizer", func() {
-	// 		By("Ensuring that the chaos pods have been created")
-	// 		Eventually(func() error { return expectChaosPod(disruption, 5) }, timeout).Should(Succeed())
+	FContext("manually delete a chaos pod", func() {
+		It("should properly handle the chaos pod finalizer", func() {
+			By("Ensuring that the chaos pods have been created")
+			Eventually(func() error { return expectChaosPod(disruption, 4) }, timeout).Should(Succeed())
 
-	// 		By("Listing chaos pods to pick one to delete")
-	// 		chaosPods, err := listChaosPods(disruption)
-	// 		Expect(err).To(BeNil())
-	// 		chaosPod := chaosPods.Items[0]
-	// 		chaosPodKey := types.NamespacedName{Namespace: chaosPod.Namespace, Name: chaosPod.Name}
+			By("Listing chaos pods to pick one to delete")
+			chaosPods, err := listChaosPods(disruption)
+			Expect(err).To(BeNil())
+			chaosPod := chaosPods.Items[0]
+			chaosPodKey := types.NamespacedName{Namespace: chaosPod.Namespace, Name: chaosPod.Name}
 
-	// 		By("Deleting one of the chaos pod")
-	// 		Expect(k8sClient.Delete(context.Background(), &chaosPod)).To(BeNil())
+			By("Deleting one of the chaos pod")
+			Expect(k8sClient.Delete(context.Background(), &chaosPod)).To(BeNil())
 
-	// 		By("Waiting for the chaos pod finalizer to be removed")
-	// 		Eventually(func() error { return k8sClient.Get(context.Background(), chaosPodKey, &chaosPod) }, timeout).Should(MatchError(fmt.Sprintf("Pod \"%s\" not found", chaosPod.Name)))
-	// 	})
-	// })
+			By("Waiting for the chaos pod finalizer to be removed")
+			Eventually(func() error { return k8sClient.Get(context.Background(), chaosPodKey, &chaosPod) }, timeout).Should(MatchError(fmt.Sprintf("Pod \"%s\" not found", chaosPod.Name)))
+		})
+	})
 })

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -483,10 +483,6 @@ var _ = Describe("Disruption Controller", func() {
 		})
 	})
 
-	// NOTE: disabled until fixed
-	// the feature is broken now that we moved all chaos pods into the same namespace
-	// because we had to remove the owner reference on those pods, meaning that
-	// the reconcile loop does not automatically trigger anymore on chaos pods events like a delete
 	Context("manually delete a chaos pod", func() {
 		It("should properly handle the chaos pod finalizer", func() {
 			By("Ensuring that the chaos pods have been created")

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -128,7 +128,7 @@ func expectChaosInjectors(instance *chaosv1beta1.Disruption, count int) error {
 	return nil
 }
 
-func expectDisruptionStatus(instance *chaosv1beta1.Disruption, desiredTargetsCount int, ignoredTargetsCount int, selectedTargetsCount int, injectedTargetsCount int) error {
+func expectDisruptionStatus(desiredTargetsCount int, ignoredTargetsCount int, selectedTargetsCount int, injectedTargetsCount int) error {
 	updatedInstance := &chaosv1beta1.Disruption{}
 
 	if err := k8sClient.Get(context.Background(), instanceKey, updatedInstance); err != nil {
@@ -136,16 +136,16 @@ func expectDisruptionStatus(instance *chaosv1beta1.Disruption, desiredTargetsCou
 	}
 
 	if desiredTargetsCount != updatedInstance.Status.DesiredTargetsCount {
-		return fmt.Errorf("incorred number of desired targets: expected %d, found %d", desiredTargetsCount, updatedInstance.Status.DesiredTargetsCount)
+		return fmt.Errorf("incorrect number of desired targets: expected %d, found %d", desiredTargetsCount, updatedInstance.Status.DesiredTargetsCount)
 	}
 	if ignoredTargetsCount != updatedInstance.Status.IgnoredTargetsCount {
-		return fmt.Errorf("incorred number of ignored targets: expected %d, found %d", ignoredTargetsCount, updatedInstance.Status.IgnoredTargetsCount)
+		return fmt.Errorf("incorrect number of ignored targets: expected %d, found %d", ignoredTargetsCount, updatedInstance.Status.IgnoredTargetsCount)
 	}
 	if injectedTargetsCount != updatedInstance.Status.InjectedTargetsCount {
-		return fmt.Errorf("incorred number of injected targets: expected %d, found %d", injectedTargetsCount, updatedInstance.Status.InjectedTargetsCount)
+		return fmt.Errorf("incorrect number of injected targets: expected %d, found %d", injectedTargetsCount, updatedInstance.Status.InjectedTargetsCount)
 	}
 	if selectedTargetsCount != updatedInstance.Status.SelectedTargetsCount {
-		return fmt.Errorf("incorred number of selected targets: expected %d, found %d", selectedTargetsCount, updatedInstance.Status.SelectedTargetsCount)
+		return fmt.Errorf("incorrect number of selected targets: expected %d, found %d", selectedTargetsCount, updatedInstance.Status.SelectedTargetsCount)
 	}
 
 	return nil
@@ -414,7 +414,7 @@ var _ = Describe("Disruption Controller", func() {
 			Expect(expectChaosInjectors(disruption, 2)).To(BeNil())
 
 			By("Ensuring that the disruption status is displaying the right number of targets")
-			Eventually(func() error { return expectDisruptionStatus(disruption, 2, 0, 2, 2) }, timeout).Should(Succeed())
+			Eventually(func() error { return expectDisruptionStatus(2, 0, 2, 2) }, timeout).Should(Succeed())
 
 			By("Adding an extra target")
 			Expect(k8sClient.Create(context.Background(), targetPodA2)).To(BeNil())
@@ -423,7 +423,7 @@ var _ = Describe("Disruption Controller", func() {
 			Eventually(func() error { return expectChaosPod(disruption, 3) }, timeout).Should(Succeed())
 
 			By("Ensuring that the disruption status is displaying the right number of targets")
-			Eventually(func() error { return expectDisruptionStatus(disruption, 3, 0, 3, 3) }, timeout).Should(Succeed())
+			Eventually(func() error { return expectDisruptionStatus(3, 0, 3, 3) }, timeout).Should(Succeed())
 
 			By("Deleting the extra target")
 			Expect(k8sClient.Delete(context.Background(), targetPodA2)).To(BeNil())
@@ -432,7 +432,7 @@ var _ = Describe("Disruption Controller", func() {
 			Eventually(func() error { return expectChaosPod(disruption, 2) }, timeout).Should(Succeed())
 
 			By("Ensuring that the disruption status is displaying the right number of targets")
-			Eventually(func() error { return expectDisruptionStatus(disruption, 2, 0, 2, 2) }, timeout).Should(Succeed())
+			Eventually(func() error { return expectDisruptionStatus(2, 0, 2, 2) }, timeout).Should(Succeed())
 		})
 	})
 
@@ -464,7 +464,7 @@ var _ = Describe("Disruption Controller", func() {
 
 		It("should scale up then down with the right number of targets count", func() {
 			By("Ensuring that the disruption status is displaying the right number of targets")
-			Eventually(func() error { return expectDisruptionStatus(disruption, 3, 0, 2, 2) }, timeout).Should(Succeed())
+			Eventually(func() error { return expectDisruptionStatus(3, 0, 2, 2) }, timeout).Should(Succeed())
 
 			By("Adding an extra target")
 			Expect(k8sClient.Create(context.Background(), targetPodA3)).To(BeNil())
@@ -473,7 +473,7 @@ var _ = Describe("Disruption Controller", func() {
 			Expect(k8sClient.Create(context.Background(), targetPodA4)).To(BeNil())
 
 			By("Ensuring that the disruption status is displaying the right number of targets")
-			Eventually(func() error { return expectDisruptionStatus(disruption, 3, 1, 3, 3) }, timeout).Should(Succeed())
+			Eventually(func() error { return expectDisruptionStatus(3, 1, 3, 3) }, timeout).Should(Succeed())
 
 			By("Deleting the extra target")
 			Expect(k8sClient.Delete(context.Background(), targetPodA3)).To(BeNil())

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -487,7 +487,7 @@ var _ = Describe("Disruption Controller", func() {
 	// the feature is broken now that we moved all chaos pods into the same namespace
 	// because we had to remove the owner reference on those pods, meaning that
 	// the reconcile loop does not automatically trigger anymore on chaos pods events like a delete
-	FContext("manually delete a chaos pod", func() {
+	Context("manually delete a chaos pod", func() {
 		It("should properly handle the chaos pod finalizer", func() {
 			By("Ensuring that the chaos pods have been created")
 			Eventually(func() error { return expectChaosPod(disruption, 4) }, timeout).Should(Succeed())

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -230,29 +230,28 @@ func (i *networkDisruptionInjector) Clean() error {
 
 // applyOperations applies the added operations by building a tc tree
 // Here's what happen on tc side:
-//   - a first prio qdisc will be created and attached to root
-//   - it'll be used to apply the first filter, filtering on packet IP destination, source/destination ports and protocol
-//   - a second prio qdisc will be created and attached to the first one
-//   - it'll be used to apply the second filter, filtering on packet classid to identify packets coming from the targeted process
-//   - operations will be chained to the second band of the second prio qdisc
-//   - a cgroup filter will be created to classify packets according to their classid (if any)
-//   - a filter will be created to redirect traffic related to the specified host(s) through the last prio band
-//   - if no host, port or protocol is specified, a filter redirecting all the traffic (0.0.0.0/0) to the disrupted band will be created
-//   - a last filter will be created to redirect traffic related to the local node through a not disrupted band
+//  - a first prio qdisc will be created and attached to root
+//    - it'll be used to apply the first filter, filtering on packet IP destination, source/destination ports and protocol
+//  - a second prio qdisc will be created and attached to the first one
+//    - it'll be used to apply the second filter, filtering on packet classid to identify packets coming from the targeted process
+//  - operations will be chained to the second band of the second prio qdisc
+//  - a cgroup filter will be created to classify packets according to their classid (if any)
+//  - a filter will be created to redirect traffic related to the specified host(s) through the last prio band
+//    - if no host, port or protocol is specified, a filter redirecting all the traffic (0.0.0.0/0) to the disrupted band will be created
+//  - a last filter will be created to redirect traffic related to the local node through a not disrupted band
 //
 // Here's the tc tree representation:
 // root (1:) <-- prio qdisc with 4 bands with a filter classifying packets matching the given dst ip, src/dst ports and protocol with class 1:4
-//
-//	|- (1:1) <-- first band
-//	|- (1:2) <-- second band
-//	|- (1:3) <-- third band
-//	|- (1:4) <-- fourth band
-//	  |- (2:) <-- prio qdisc with 2 bands with a cgroup filter to classify packets according to their classid (packets with classid 2:2 will be affected by operations)
-//	    |- (2:1) <-- first band
-//	    |- (2:2) <-- second band
-//	      |- (3:) <-- first operation
-//	        |- (4:) <-- second operation
-//	          ...
+//   |- (1:1) <-- first band
+//   |- (1:2) <-- second band
+//   |- (1:3) <-- third band
+//   |- (1:4) <-- fourth band
+//     |- (2:) <-- prio qdisc with 2 bands with a cgroup filter to classify packets according to their classid (packets with classid 2:2 will be affected by operations)
+//       |- (2:1) <-- first band
+//       |- (2:2) <-- second band
+//         |- (3:) <-- first operation
+//           |- (4:) <-- second operation
+//             ...
 func (i *networkDisruptionInjector) applyOperations() error {
 	i.tcFilterPriority = tcPriority
 

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -809,8 +809,6 @@ func (i *networkDisruptionInjector) handleFiltersForServices(interfaces []string
 	// build the watchers to handle changes in services and pod endpoints
 	serviceWatchers := []serviceWatcher{}
 
-	//TODO log the service resolution
-
 	for _, serviceSpec := range i.spec.Services {
 		// retrieve serviceSpec
 		k8sService, err := i.config.K8sClient.CoreV1().Services(serviceSpec.Namespace).Get(context.Background(), serviceSpec.Name, metav1.GetOptions{})
@@ -843,13 +841,14 @@ func (i *networkDisruptionInjector) handleFiltersForServices(interfaces []string
 
 // addFiltersForHosts creates tc filters on given interfaces for given hosts classifying matching packets in the given flowid
 func (i *networkDisruptionInjector) addFiltersForHosts(interfaces []string, hosts []v1beta1.NetworkDisruptionHostSpec, flowid string) error {
-	// TODO log the set of all ips here? Or maybe ip per host
 	for _, host := range hosts {
 		// resolve given hosts if needed
 		ips, err := resolveHost(i.config.DNSClient, host.Host)
 		if err != nil {
 			return fmt.Errorf("error resolving given host %s: %w", host.Host, err)
 		}
+
+		i.config.Log.Infof("resolved %s as %s", host.Host, ips)
 
 		for _, ip := range ips {
 			// handle flow direction

--- a/log/log.go
+++ b/log/log.go
@@ -14,7 +14,7 @@ import (
 func NewZapLogger() (*zap.SugaredLogger, error) {
 	// configure logger
 	loggerConfig := zap.NewProductionConfig()
-	loggerConfig.Level.SetLevel(zapcore.InfoLevel)
+	loggerConfig.Level.SetLevel(zapcore.DebugLevel)
 	loggerConfig.EncoderConfig.MessageKey = "message"
 	loggerConfig.EncoderConfig.EncodeTime = zapcore.EpochMillisTimeEncoder
 

--- a/network/tc.go
+++ b/network/tc.go
@@ -61,7 +61,7 @@ func (e defaultTcExecuter) Run(args ...string) (int, string, error) {
 	cmd.Stderr = stderr
 
 	// run command
-	e.log.Infof("running tc command: %v", cmd.String())
+	e.log.Debugf("running tc command: %v", cmd.String())
 
 	// early exit if dry-run mode is enabled
 	if e.dryRun {


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Makes a number of changes to reduce log verbosity
- Moves some logs to DEBUG, while changing our log level to DEBUG, so they're still visible, but more easily filtered out. This include tc rules
- Some log messages run on every reconcile loop, but the action they're logging doesn't necessarily happen, these have been moved into `if`s
- Added a more user understandable log when resolving hostnames to IPs
- Slowed the requeue delay when cleaning and creating chaos pods, there is no need to check every 5s when we frequently see this take 60-90s

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
