### PR TITLE
staticTargeting: add flag to switch default to true

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -68,8 +68,9 @@ type DisruptionSpec struct {
 	GRPC *GRPCDisruptionSpec `json:"grpc,omitempty"`
 }
 
-//go:embed *
 // EmbeddedChaosAPI includes the library so it can be statically exported to chaosli
+//
+//go:embed *
 var EmbeddedChaosAPI embed.FS
 
 type DisruptionDuration string

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -44,7 +44,7 @@ type DisruptionSpec struct {
 	DryRun           bool                              `json:"dryRun,omitempty"`           // enable dry-run mode
 	OnInit           bool                              `json:"onInit,omitempty"`           // enable disruption on init
 	Unsafemode       *UnsafemodeSpec                   `json:"unsafeMode,omitempty"`       // unsafemode spec used to turn off safemode safety nets
-	StaticTargeting  bool                              `json:"staticTargeting,omitempty"`  // enable dynamic targeting and cluster observation
+	StaticTargeting  *bool                             `json:"staticTargeting,omitempty"`  // disable dynamic targeting and cluster observation
 	// +nullable
 	Pulse    *DisruptionPulse   `json:"pulse,omitempty"`    // enable pulsing diruptions and specify the duration of the active state and the dormant state of the pulsing duration
 	Duration DisruptionDuration `json:"duration,omitempty"` // time from disruption creation until chaos pods are deleted and no more are created

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -4,8 +4,8 @@
 // Copyright 2022 Datadog, Inc.
 
 // Package v1beta1 contains API Schema definitions for the chaos v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=chaos.datadoghq.com
+// +kubebuilder:object:generate=true
+// +groupName=chaos.datadoghq.com
 package v1beta1
 
 import (

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -283,6 +283,11 @@ func (in *DisruptionSpec) DeepCopyInto(out *DisruptionSpec) {
 		*out = new(UnsafemodeSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.StaticTargeting != nil {
+		in, out := &in.StaticTargeting, &out.StaticTargeting
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Pulse != nil {
 		in, out := &in.Pulse, &out.Pulse
 		*out = new(DisruptionPulse)

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -35,6 +35,7 @@ data:
       deleteOnly: {{ .Values.controller.deleteOnly }}
       imagePullSecrets: {{ .Values.images.pullSecrets }}
       defaultDuration: {{ .Values.controller.defaultDuration }}
+      staticTargetingDefault: {{ .Values.controller.staticTargetingDefault }}
       expiredDisruptionGCDelay: {{ .Values.controller.expiredDisruptionGCDelay }}
       userInfoHook: {{ .Values.controller.userInfoHook }}
       webhook:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -31,6 +31,7 @@ controller:
       headersFilepath: ""
       headers: []
   defaultDuration: 1h # default spec.duration for a disruption with none specified
+  staticTargetingDefault: false
   expiredDisruptionGCDelay: 10m # time after a disruption expires before deleting it
   userInfoHook: true
   webhook: # admission webhook configuration

--- a/cli/chaosli/cmd/create.go
+++ b/cli/chaosli/cmd/create.go
@@ -682,14 +682,14 @@ func getLevel() types.DisruptionLevel {
 	return types.DisruptionLevel(level)
 }
 
-func getStaticTargeting() bool {
+func getStaticTargeting() *bool {
 	staticTargetingExplanations := "StaticTargeting means the target selection will only happen once at disruption creation, and will never be run again. New targets will not be targeted. StaticTargeting is temporarily defaulting to true, and will eventually default to false"
 
 	fmt.Println(staticTargetingExplanations)
 
 	a := confirmOption("Would you like to enable StaticTargeting? Blocks new pods from being targeted after the initial injection.", staticTargetingExplanations)
 
-	return a
+	return &a
 }
 
 func getDryRun() bool {

--- a/cli/chaosli/cmd/explain.go
+++ b/cli/chaosli/cmd/explain.go
@@ -58,11 +58,12 @@ func explainMetaSpec(spec v1beta1.DisruptionSpec) {
 
 	fmt.Printf("\tℹ️  is going to target %s %s(s) (either described as a percentage of total %ss or actual number of them).\n", spec.Count, spec.Level, spec.Level)
 
-	if spec.StaticTargeting == nil {
+	switch {
+	case spec.StaticTargeting == nil:
 		fmt.Printf("\tℹ️  has StaticTargeting unspecified. It defaults to false (new pods/nodes will be targeted) unless specified in the chaos-controller charts. \n")
-	} else if *spec.StaticTargeting {
+	case *spec.StaticTargeting:
 		fmt.Printf("\tℹ️  has StaticTargeting activated, so new pods/nodes will be NOT be targeted \n")
-	} else {
+	default:
 		fmt.Printf("\tℹ️  has StaticTargeting deactivated, so new pods/nodes will be targeted\n")
 	}
 

--- a/cli/chaosli/cmd/explain.go
+++ b/cli/chaosli/cmd/explain.go
@@ -58,7 +58,9 @@ func explainMetaSpec(spec v1beta1.DisruptionSpec) {
 
 	fmt.Printf("\tℹ️  is going to target %s %s(s) (either described as a percentage of total %ss or actual number of them).\n", spec.Count, spec.Level, spec.Level)
 
-	if spec.StaticTargeting {
+	if spec.StaticTargeting == nil {
+		fmt.Printf("\tℹ️  has StaticTargeting unspecified. It defaults to false (new pods/nodes will be targeted) unless specified in the chaos-controller charts. \n")
+	} else if *spec.StaticTargeting {
 		fmt.Printf("\tℹ️  has StaticTargeting activated, so new pods/nodes will be NOT be targeted \n")
 	} else {
 		fmt.Printf("\tℹ️  has StaticTargeting deactivated, so new pods/nodes will be targeted\n")

--- a/container/container_mock.go
+++ b/container/container_mock.go
@@ -8,6 +8,7 @@ package container
 import "github.com/stretchr/testify/mock"
 
 // ContainerMock is a mock implementation of the Container interface
+//
 //nolint:golint
 type ContainerMock struct {
 	mock.Mock

--- a/controllers/cache_handler.go
+++ b/controllers/cache_handler.go
@@ -450,7 +450,12 @@ func (h DisruptionTargetWatcherHandler) buildNodeEventsToSend(oldNode corev1.Nod
 func (r *DisruptionReconciler) manageInstanceSelectorCache(instance *chaosv1beta1.Disruption) error {
 	r.clearExpiredCacheContexts()
 
-	if instance.Spec.StaticTargeting {
+	if instance.Spec.StaticTargeting == nil {
+		r.log.Errorw("StaticTargeting pointer is nil")
+	}
+
+	// if static targeting is activated, no cache is required
+	if instance.Spec.StaticTargeting != nil && *instance.Spec.StaticTargeting {
 		return nil
 	}
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -752,7 +752,12 @@ func (r *DisruptionReconciler) handleChaosPodTermination(instance *chaosv1beta1.
 // the chosen targets names will be reflected in the instance status
 // subsequent calls to this function will always return the same targets as the first call
 func (r *DisruptionReconciler) selectTargets(instance *chaosv1beta1.Disruption) error {
-	if len(instance.Status.Targets) != 0 && instance.Spec.StaticTargeting {
+	if instance.Spec.StaticTargeting == nil {
+		r.log.Errorw("StaticTargeting pointer is nil")
+	}
+
+	// if there already are targets and static targeting is activated, do not look for targets
+	if len(instance.Status.Targets) != 0 && (instance.Spec.StaticTargeting != nil && *instance.Spec.StaticTargeting) {
 		return nil
 	}
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -64,6 +64,7 @@ type DisruptionReconciler struct {
 	InjectorNetworkDisruptionAllowedHosts []string
 	SafetyNets                            []safemode.Safemode
 	ExpiredDisruptionGCDelay              *time.Duration
+	StaticTargetingDefault                bool
 	CacheContextStore                     map[string]CtxTuple
 	Controller                            controller.Controller
 	Reader                                client.Reader // Use the k8s API without the cache

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -383,7 +383,7 @@ var _ = Describe("Disruption Controller", func() {
 	Context("Dynamic targeting", func() {
 		BeforeEach(func() {
 			disruption.Spec = chaosv1beta1.DisruptionSpec{
-				StaticTargeting: false,
+				StaticTargeting: func() *bool { b := false; return &b }(),
 				DryRun:          true,
 				Count:           &intstr.IntOrString{Type: intstr.String, StrVal: "100%"},
 				Unsafemode: &chaosv1beta1.UnsafemodeSpec{
@@ -439,7 +439,7 @@ var _ = Describe("Disruption Controller", func() {
 	Context("Targets count", func() {
 		BeforeEach(func() {
 			disruption.Spec = chaosv1beta1.DisruptionSpec{
-				StaticTargeting: false,
+				StaticTargeting: func() *bool { b := false; return &b }(),
 				DryRun:          true,
 				Count:           &intstr.IntOrString{Type: intstr.String, StrVal: "3"},
 				Unsafemode: &chaosv1beta1.UnsafemodeSpec{

--- a/ddmark/ddmark.go
+++ b/ddmark/ddmark.go
@@ -15,8 +15,9 @@ import (
 	k8smarkers "sigs.k8s.io/controller-tools/pkg/markers"
 )
 
-//go:embed validation_teststruct.go
 // EmbeddedDDMarkAPI includes the teststruct so it can be statically exported for ddmark testing
+//
+//go:embed validation_teststruct.go
 var EmbeddedDDMarkAPI embed.FS
 
 func initializeMarkers() *k8smarkers.Collector {

--- a/docs/features.md
+++ b/docs/features.md
@@ -48,24 +48,26 @@ If a `pulse` is not specified, then a disruption will not be pulsing.
 
 ## Targeting
 
-**NEW:** StaticTargeting currently defaults to false. Please mention explicitely if you wish to activate it. [Read StaticTargeting](#StaticTargeting-(current-default-behaviour)).
+**NEW**: StaticTargeting is set to `false` by default. If you'd rather have Static Targeting as the default behaviour of the controller in your deployement, you can now change this in the [configmap](https://github.com/DataDog/chaos-controller/blob/master/chart/values.yaml#L34). If unspecified, the controller will default the field to false.
 
 The `Disruption` resource uses [label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to target pods and nodes. The controller will retrieve all pods or nodes matching the given label selector and will randomly select a number (defined in the `count` field) of matching targets. It's possible to specify multiple label selectors, in which case the controller will select from targets that match all of them. Once applied, you can see the targeted pods/nodes by describing the `Disruption` resource.
 
-
 **NOTE:** If you are targeting pods, the disruption must be created in the same namespace as the targeted pods.
 
-### DynamicTargeting (default)
+### Dynamic Targeting (default)
 By default, there is a constant re-targeting for disruptions. This means at any given time, any target within the selector's scope will be added to the target list and be disrupted.
 Although default, this is to use with care as a disruption gone wrong can quickly get out of control: per example, a disruption targeting 100% of an application's pod will affect all existing **and** future pods which can appear once the disruption started. As long as this 100% disruption exists, there will be no spared pod.
 
 `DynamicTargeting` behaviour design choices:
+
 - the controller will consider as a still-alive target any pod that exists - regardless of its state.
 - the controller will reconcile/update its targets list on any chaos or selector pod movement (create, update, delete)
 
-### StaticTargeting
+### Static Targeting
 
-Activate `StaticTargeting` to limit the disruption to a single target selection step at the disruption's creation. It allows for more controlled disruption impact and propagation, as the targets will never change and _can_ be compensated for in case they are made useless. Its major limit is not being able to follow targets through deployments/rollouts.
+Activate `StaticTargeting` in the Disruption spec to limit the disruption to a single target selection step at the disruption's creation. It allows for more controlled disruption impact and propagation, as the targets will never change and _can_ be compensated for in case they are made useless. Its major limit is not being able to follow targets through deployments/rollouts.
+
+If you'd rather have Static Targeting be the default mode for the controller, switch the dedicated [configmap field](https://github.com/DataDog/chaos-controller/blob/master/chart/values.yaml#L34) to `true`.
 
 ### Targeting safeguards
 

--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ type controllerConfig struct {
 	Notifiers                eventnotifier.NotifiersConfig `json:"notifiersConfig"`
 	UserInfoHook             bool                          `json:"userInfoHook"`
 	SafeMode                 safeModeConfig                `json:"safeMode"`
+	StaticTargetingDefault   bool                          `json:"staticTargetingDefault`
 }
 
 type controllerWebhookConfig struct {
@@ -244,6 +245,10 @@ func main() {
 	pflag.IntVar(&cfg.Controller.SafeMode.ClusterThreshold, "safemode-cluster-threshold", 66,
 		"Threshold which safemode checks against to see if the number of targets is over safety measures within a cluster")
 	handleFatalError(viper.BindPFlag("controller.safemode.clusterThreshold", pflag.Lookup("safemode-cluster-threshold")))
+
+	pflag.BoolVar(&cfg.Controller.StaticTargetingDefault, "statictargeting-default", false,
+		"Default value for staticTargeting field in all disruptions.")
+	handleFatalError(viper.BindPFlag("controller.staticTargetingDefault", pflag.Lookup("statictargeting-default")))
 
 	pflag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -390,6 +390,7 @@ func main() {
 		DeleteOnlyFlag:         cfg.Controller.DeleteOnly,
 		HandlerEnabledFlag:     cfg.Handler.Enabled,
 		DefaultDurationFlag:    cfg.Controller.DefaultDuration,
+		StaticTargetingDefault: cfg.Controller.StaticTargetingDefault,
 	}
 	if err = (&chaosv1beta1.Disruption{}).SetupWebhookWithManager(setupWebhookConfig); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Disruption")

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ type controllerConfig struct {
 	Notifiers                eventnotifier.NotifiersConfig `json:"notifiersConfig"`
 	UserInfoHook             bool                          `json:"userInfoHook"`
 	SafeMode                 safeModeConfig                `json:"safeMode"`
-	StaticTargetingDefault   bool                          `json:"staticTargetingDefault`
+	StaticTargetingDefault   bool                          `json:"staticTargetingDefault"`
 }
 
 type controllerWebhookConfig struct {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -48,4 +48,5 @@ type SetupWebhookWithManagerConfig struct {
 	DeleteOnlyFlag         bool
 	HandlerEnabledFlag     bool
 	DefaultDurationFlag    time.Duration
+	StaticTargetingDefault bool
 }


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [X] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Now places the default value for staticTargeting to a flag in the controller's config map.

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [X] I manually tested the following steps:
    - Deploy the controller with the `staticTargetingDefault` field set to false, launch a disruption with `staticTargeting` unspecified, check out the description
    - Do all of those combinations (flag false/true, staticTargeting field unspecified/false/true) and assert you have the expected results.
    - [X] locally.
    - [ ] as a canary deployment to a cluster.
