### PR TITLE
Remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,16 +10,13 @@ run:
     - cpuset/*
 linters:
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - bodyclose
     - depguard
     - dogsled

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -68,8 +68,9 @@ type DisruptionSpec struct {
 	GRPC *GRPCDisruptionSpec `json:"grpc,omitempty"`
 }
 
-//go:embed *
 // EmbeddedChaosAPI includes the library so it can be statically exported to chaosli
+//
+//go:embed *
 var EmbeddedChaosAPI embed.FS
 
 type DisruptionDuration string

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -4,8 +4,8 @@
 // Copyright 2022 Datadog, Inc.
 
 // Package v1beta1 contains API Schema definitions for the chaos v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=chaos.datadoghq.com
+// +kubebuilder:object:generate=true
+// +groupName=chaos.datadoghq.com
 package v1beta1
 
 import (

--- a/container/container_mock.go
+++ b/container/container_mock.go
@@ -8,6 +8,7 @@ package container
 import "github.com/stretchr/testify/mock"
 
 // ContainerMock is a mock implementation of the Container interface
+//
 //nolint:golint
 type ContainerMock struct {
 	mock.Mock

--- a/ddmark/ddmark.go
+++ b/ddmark/ddmark.go
@@ -15,8 +15,9 @@ import (
 	k8smarkers "sigs.k8s.io/controller-tools/pkg/markers"
 )
 
-//go:embed validation_teststruct.go
 // EmbeddedDDMarkAPI includes the teststruct so it can be statically exported for ddmark testing
+//
+//go:embed validation_teststruct.go
 var EmbeddedDDMarkAPI embed.FS
 
 func initializeMarkers() *k8smarkers.Collector {


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The linter has been yelling about deprecations for months, fixing them

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
