### PR TITLE
Support headless services in `spec.network.services`

### DIFF
--- a/docs/network_disruption/hosts.md
+++ b/docs/network_disruption/hosts.md
@@ -32,6 +32,12 @@ network:
       namespace: example_namespace
 ```
 
+### Headless Services
+
+A "headless" service is a ClusterIP service whose ClusterIP is defined as "None". This means that connecting clients 
+need to resolve the service's hostname via a separate service resolution system. When a headless service is specified under 
+`spec.network.services`, we will resolve the service and block all traffic to all returned endpoints.
+
 ## Q: How can I exclude some hosts from being disrupted?
 
 It is sometimes handy to disrupt all packets going to a whole CIDR but excluding some of them. You have two ways to exclude some hosts from being disrupted in a network disruption:

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -528,6 +528,10 @@ func (i *networkDisruptionInjector) buildServiceFiltersFromService(service v1.Se
 
 	endpointsToWatch := []tcServiceFilter{}
 
+	if service.Spec.ClusterIP == "" || strings.ToLower(service.Spec.ClusterIP) == "none" {
+		return endpointsToWatch
+	}
+
 	for _, port := range servicePorts {
 		filter := tcServiceFilter{
 			service: networkDisruptionService{

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -236,28 +236,29 @@ func (i *networkDisruptionInjector) Clean() error {
 
 // applyOperations applies the added operations by building a tc tree
 // Here's what happen on tc side:
-//  - a first prio qdisc will be created and attached to root
-//    - it'll be used to apply the first filter, filtering on packet IP destination, source/destination ports and protocol
-//  - a second prio qdisc will be created and attached to the first one
-//    - it'll be used to apply the second filter, filtering on packet classid to identify packets coming from the targeted process
-//  - operations will be chained to the second band of the second prio qdisc
-//  - a cgroup filter will be created to classify packets according to their classid (if any)
-//  - a filter will be created to redirect traffic related to the specified host(s) through the last prio band
-//    - if no host, port or protocol is specified, a filter redirecting all the traffic (0.0.0.0/0) to the disrupted band will be created
-//  - a last filter will be created to redirect traffic related to the local node through a not disrupted band
+//   - a first prio qdisc will be created and attached to root
+//     it'll be used to apply the first filter, filtering on packet IP destination, source/destination ports and protocol
+//   - a second prio qdisc will be created and attached to the first one
+//     it'll be used to apply the second filter, filtering on packet classid to identify packets coming from the targeted process
+//   - operations will be chained to the second band of the second prio qdisc
+//   - a cgroup filter will be created to classify packets according to their classid (if any)
+//   - a filter will be created to redirect traffic related to the specified host(s) through the last prio band
+//     if no host, port or protocol is specified, a filter redirecting all the traffic (0.0.0.0/0) to the disrupted band will be created
+//   - a last filter will be created to redirect traffic related to the local node through a not disrupted band
 //
 // Here's the tc tree representation:
 // root (1:) <-- prio qdisc with 4 bands with a filter classifying packets matching the given dst ip, src/dst ports and protocol with class 1:4
-//   |- (1:1) <-- first band
-//   |- (1:2) <-- second band
-//   |- (1:3) <-- third band
-//   |- (1:4) <-- fourth band
-//     |- (2:) <-- prio qdisc with 2 bands with a cgroup filter to classify packets according to their classid (packets with classid 2:2 will be affected by operations)
-//       |- (2:1) <-- first band
-//       |- (2:2) <-- second band
-//         |- (3:) <-- first operation
-//           |- (4:) <-- second operation
-//             ...
+//
+//	|- (1:1) <-- first band
+//	|- (1:2) <-- second band
+//	|- (1:3) <-- third band
+//	|- (1:4) <-- fourth band
+//	  |- (2:) <-- prio qdisc with 2 bands with a cgroup filter to classify packets according to their classid (packets with classid 2:2 will be affected by operations)
+//	    |- (2:1) <-- first band
+//	    |- (2:2) <-- second band
+//	      |- (3:) <-- first operation
+//	        |- (4:) <-- second operation
+//	          ...
 func (i *networkDisruptionInjector) applyOperations() error {
 	i.tcFilterPriority = tcPriority
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Previously we were blocking traffic to the ClusterIP of a service no matter what. Even when that clusterIP is "None". This leads to blocking all traffic on the service port to all endpoints (even those not for the targeted service). This is the bug I want to fix
- Now, for headless services, we only resolve endpoints, and we block _all_ traffic to those endpoints

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
