### PR TITLE
Remove unmatched log tag keys for safemode logging

### DIFF
--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -256,7 +256,7 @@ func (r *Disruption) initialSafetyNets() ([]string, error) {
 	responses := []string{}
 	// handle initial safety nets if safemode is enabled
 	if r.Spec.Unsafemode == nil || !r.Spec.Unsafemode.DisableAll {
-		if caught, response, err := safetyNetCountNotTooLarge(*r); err != nil {
+		if caught, response, err := safetyNetCountNotTooLarge(r); err != nil {
 			return nil, fmt.Errorf("error checking for countNotTooLarge safetynet: %w", err)
 		} else if caught {
 			logger.Debugw("the specified count represents a large percentage of targets in either the namespace or the kubernetes cluster", "SafetyNet Catch", "Generic")
@@ -281,7 +281,7 @@ func (r *Disruption) initialSafetyNets() ([]string, error) {
 // > 66% of the k8s system being targeted warrants a safety check if we assume each of our targets are replicated
 // at least twice. > 80% in a namespace also warrants a safety check as namespaces may be shared between services.
 // returning true indicates the safety net caught something
-func safetyNetCountNotTooLarge(r Disruption) (bool, string, error) {
+func safetyNetCountNotTooLarge(r *Disruption) (bool, string, error) {
 	if r.Spec.Unsafemode != nil && r.Spec.Unsafemode.DisableCountTooLarge {
 		return false, "", nil
 	}

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -266,9 +266,9 @@ func (r *Disruption) initialSafetyNets() ([]string, error) {
 
 		if r.Spec.Network != nil {
 			if caught := safetyNetNeitherHostNorPort(*r); caught {
-				logger.Debugw("the specified disruption either contains no Hosts or contains a Host which has neither a port or a host. The more ambiguous, the larger the blast radius.", "SafetyNet Catch", "Network")
+				logger.Debugw("the specified disruption either contains no Hosts or contains a Host which has neither a port nor a host. The more ambiguous, the larger the blast radius.", "SafetyNet Catch", "Network")
 
-				responses = append(responses, "the specified disruption either contains no Hosts or contains a Host which has neither a port or a host. The more ambiguous, the larger the blast radius.")
+				responses = append(responses, "the specified disruption either contains no Hosts or contains a Host which has neither a port nor a host. The more ambiguous, the larger the blast radius.")
 			}
 		}
 	}

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -259,16 +259,16 @@ func (r *Disruption) initialSafetyNets() ([]string, error) {
 		if caught, response, err := safetyNetCountNotTooLarge(*r); err != nil {
 			return nil, fmt.Errorf("error checking for countNotTooLarge safetynet: %w", err)
 		} else if caught {
-			logger.Debugw("the specified count represents a large percentage of targets in either the namespace or the kubernetes cluster", r.Name, "SafetyNet Catch", "Generic")
+			logger.Debugw("the specified count represents a large percentage of targets in either the namespace or the kubernetes cluster", "SafetyNet Catch", "Generic")
 
 			responses = append(responses, response)
 		}
 
 		if r.Spec.Network != nil {
 			if caught := safetyNetNeitherHostNorPort(*r); caught {
-				logger.Debugw("The specified disruption either contains no Hosts or contains a Host which has neither a port or a host. The more ambiguous, the larger the blast radius.", r.Name, "SafetyNet Catch", "Network")
+				logger.Debugw("the specified disruption either contains no Hosts or contains a Host which has neither a port or a host. The more ambiguous, the larger the blast radius.", "SafetyNet Catch", "Network")
 
-				responses = append(responses, "The specified disruption either contains no Hosts or contains a Host which has neither a port or a host. The more ambiguous, the larger the blast radius.")
+				responses = append(responses, "the specified disruption either contains no Hosts or contains a Host which has neither a port or a host. The more ambiguous, the larger the blast radius.")
 			}
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- We were specifying an odd number of key/values, so `zap` was unable to pair them and explodes whenever we hit these logs.
- I also standardized the capitalization of logs and the receiver type for the functions in dis_webhook

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
