### PR TITLE
CHAOS-342: Clean CPU and container failures for free too

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -434,16 +434,16 @@ func DisruptionIsReinjectable(kind chaostypes.DisruptionKindName) bool {
 	return true
 }
 
-// CleanedFreeDisruptions is the list of all disruption kinds where the lifecycle of the failure matches the lifecycle of
+// NoSideEffectDisruptions is the list of all disruption kinds where the lifecycle of the failure matches the lifecycle of
 // the chaos pod. So once the chaos pod is gone, there's nothing left for us to clean.
-var CleanedFreeDisruptions = map[chaostypes.DisruptionKindName]interface{}{
-	chaostypes.DisruptionKindNodeFailure: nil,
+var NoSideEffectDisruptions = map[chaostypes.DisruptionKindName]interface{}{
+	chaostypes.DisruptionKindNodeFailure:      nil,
 	chaostypes.DisruptionKindContainerFailure: nil,
-	chaostypes.DisruptionKindCPUPressure: nil,
+	chaostypes.DisruptionKindCPUPressure:      nil,
 }
 
-func DisruptionIsCleanedForFree(kind string) bool {
-    _, found := CleanedFreeDisruptions[chaostypes.DisruptionKindName(kind)]
-    
-    return found
+func DisruptionHasNoSideEffects(kind string) bool {
+	_, found := NoSideEffectDisruptions[chaostypes.DisruptionKindName(kind)]
+
+	return found
 }

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -420,8 +420,8 @@ func (status *DisruptionStatus) RemoveTargets(toRemoveTargetsCount int) {
 	}
 }
 
-var NonReinjectableDisruptions = map[chaostypes.DisruptionKindName]interface{}{
-	chaostypes.DisruptionKindGRPCDisruption: nil,
+var NonReinjectableDisruptions = map[chaostypes.DisruptionKindName]struct{}{
+	chaostypes.DisruptionKindGRPCDisruption: {},
 }
 
 func DisruptionIsReinjectable(kind chaostypes.DisruptionKindName) bool {
@@ -432,10 +432,10 @@ func DisruptionIsReinjectable(kind chaostypes.DisruptionKindName) bool {
 
 // NoSideEffectDisruptions is the list of all disruption kinds where the lifecycle of the failure matches the lifecycle of
 // the chaos pod. So once the chaos pod is gone, there's nothing left for us to clean.
-var NoSideEffectDisruptions = map[chaostypes.DisruptionKindName]interface{}{
-	chaostypes.DisruptionKindNodeFailure:      nil,
-	chaostypes.DisruptionKindContainerFailure: nil,
-	chaostypes.DisruptionKindCPUPressure:      nil,
+var NoSideEffectDisruptions = map[chaostypes.DisruptionKindName]struct{}{
+	chaostypes.DisruptionKindNodeFailure:      {},
+	chaostypes.DisruptionKindContainerFailure: {},
+	chaostypes.DisruptionKindCPUPressure:      {},
 }
 
 func DisruptionHasNoSideEffects(kind string) bool {

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -420,18 +420,14 @@ func (status *DisruptionStatus) RemoveTargets(toRemoveTargetsCount int) {
 	}
 }
 
-var NonReinjectableDisruptions = []chaostypes.DisruptionKindName{
-	chaostypes.DisruptionKindGRPCDisruption,
+var NonReinjectableDisruptions = map[chaostypes.DisruptionKindName]interface{}{
+	chaostypes.DisruptionKindGRPCDisruption: nil,
 }
 
 func DisruptionIsReinjectable(kind chaostypes.DisruptionKindName) bool {
-	for _, dis := range NonReinjectableDisruptions {
-		if dis == kind {
-			return false
-		}
-	}
+	_, found := NonReinjectableDisruptions[kind]
 
-	return true
+	return found
 }
 
 // NoSideEffectDisruptions is the list of all disruption kinds where the lifecycle of the failure matches the lifecycle of

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -436,18 +436,14 @@ func DisruptionIsReinjectable(kind chaostypes.DisruptionKindName) bool {
 
 // CleanedFreeDisruptions is the list of all disruption kinds where the lifecycle of the failure matches the lifecycle of
 // the chaos pod. So once the chaos pod is gone, there's nothing left for us to clean.
-var CleanedFreeDisruptions = []chaostypes.DisruptionKindName{
-	chaostypes.DisruptionKindNodeFailure,
-	chaostypes.DisruptionKindContainerFailure,
-	chaostypes.DisruptionKindCPUPressure,
+var CleanedFreeDisruptions = map[chaostypes.DisruptionKindName]interface{}{
+	chaostypes.DisruptionKindNodeFailure: nil,
+	chaostypes.DisruptionKindContainerFailure: nil,
+	chaostypes.DisruptionKindCPUPressure: nil,
 }
 
 func DisruptionIsCleanedForFree(kind string) bool {
-	for _, dis := range CleanedFreeDisruptions {
-		if dis.String() == kind {
-			return true
-		}
-	}
-
-	return false
+    _, found := CleanedFreeDisruptions[chaostypes.DisruptionKindName(kind)]
+    
+    return found
 }

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -433,3 +433,21 @@ func DisruptionIsReinjectable(kind chaostypes.DisruptionKindName) bool {
 
 	return true
 }
+
+// CleanedFreeDisruptions is the list of all disruption kinds where the lifecycle of the failure matches the lifecycle of
+// the chaos pod. So once the chaos pod is gone, there's nothing left for us to clean.
+var CleanedFreeDisruptions = []chaostypes.DisruptionKindName{
+	chaostypes.DisruptionKindNodeFailure,
+	chaostypes.DisruptionKindContainerFailure,
+	chaostypes.DisruptionKindCPUPressure,
+}
+
+func DisruptionIsCleanedForFree(kind string) bool {
+	for _, dis := range CleanedFreeDisruptions {
+		if dis.String() == kind {
+			return true
+		}
+	}
+
+	return false
+}

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -677,7 +677,7 @@ func (r *DisruptionReconciler) handleChaosPodTermination(instance *chaosv1beta1.
 
 	// It is always safe to remove some chaos pods. It is usually hard to tell if these chaos pods have
 	// succeeded or not, but they have no possibility of leaving side effects, so we choose to always remove the finalizer.
-	if chaosv1beta1.DisruptionIsCleanedForFree(chaosPod.Labels[chaostypes.DisruptionKindLabel]) {
+	if chaosv1beta1.DisruptionHasNoSideEffects(chaosPod.Labels[chaostypes.DisruptionKindLabel]) {
 		removeFinalizer = true
 		ignoreStatus = true
 	}

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -675,9 +675,9 @@ func (r *DisruptionReconciler) handleChaosPodTermination(instance *chaosv1beta1.
 		}
 	}
 
-	// It is always safe to remove a node failure chaos pod. It is usually hard to tell if a node failure chaos pod has
-	// succeeded or not, so we choose to always remove the finalizer.
-	if chaosPod.Labels[chaostypes.DisruptionKindLabel] == chaostypes.DisruptionKindNodeFailure {
+	// It is always safe to remove some chaos pods. It is usually hard to tell if these chaos pods have
+	// succeeded or not, but they have no possibility of leaving side effects, so we choose to always remove the finalizer.
+	if chaosv1beta1.DisruptionIsCleanedForFree(chaosPod.Labels[chaostypes.DisruptionKindLabel]) {
 		removeFinalizer = true
 		ignoreStatus = true
 	}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Always marks CPU pressure and container failure chaos pods as safe to remove, just like node failures

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
