### PR TITLE
Add connection state filter in network disruptions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,3 +54,4 @@ issues:
     - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
     # revive
     - and that stutters
+    - unexported-return

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ all: manager injector handler
 
 # Run unit tests
 test: generate manifests
-	go test -race $(shell go list ./... | grep -v chaos-controller/controllers) -coverprofile cover.out
+	CGO_ENABLED=1 go test -race $(shell go list ./... | grep -v chaos-controller/controllers) -coverprofile cover.out
 
 # This target is dedicated for CI and aims to reuse the Kubernetes version defined here as the source of truth
 ci-install-minikube:
@@ -48,7 +48,7 @@ ci-install-minikube:
 # Run e2e tests (against a real cluster)
 e2e-test: generate
 	$(MAKE) colima-install EXPIRED_DISRUPTION_GC_DELAY=10s
-	USE_EXISTING_CLUSTER=true CLUSTER_NAME=${CLUSTER_NAME} go test -race ./controllers/... -coverprofile cover.out
+	USE_EXISTING_CLUSTER=true CLUSTER_NAME=${CLUSTER_NAME} CGO_ENABLED=1 go test -race ./controllers/... -coverprofile cover.out
 
 # Build manager binary
 manager: generate

--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -82,6 +82,9 @@ type NetworkDisruptionHostSpec struct {
 	// +kubebuilder:validation:Enum=ingress;egress;""
 	// +ddmark:validation:Enum=ingress;egress;""
 	Flow string `json:"flow,omitempty"`
+	// +kubebuilder:validation:Enum=new;est;""
+	// +ddmark:validation:Enum=new;est;""
+	ConnState string `json:"connState,omitempty"`
 }
 
 type NetworkDisruptionServiceSpec struct {
@@ -141,12 +144,12 @@ func (s *NetworkDisruptionSpec) GenerateArgs() []string {
 
 	// append hosts
 	for _, host := range s.Hosts {
-		args = append(args, "--hosts", fmt.Sprintf("%s;%d;%s;%s", host.Host, host.Port, host.Protocol, host.Flow))
+		args = append(args, "--hosts", fmt.Sprintf("%s;%d;%s;%s;%s", host.Host, host.Port, host.Protocol, host.Flow, host.ConnState))
 	}
 
 	// append allowed hosts
 	for _, host := range s.AllowedHosts {
-		args = append(args, "--allowed-hosts", fmt.Sprintf("%s;%d;%s;%s", host.Host, host.Port, host.Protocol, host.Flow))
+		args = append(args, "--allowed-hosts", fmt.Sprintf("%s;%d;%s;%s;%s", host.Host, host.Port, host.Protocol, host.Flow, host.ConnState))
 	}
 
 	// append services
@@ -158,7 +161,7 @@ func (s *NetworkDisruptionSpec) GenerateArgs() []string {
 }
 
 // NetworkDisruptionHostSpecFromString parses the given hosts to host specs
-// The expected format for hosts is <host>;<port>;<protocol>;<flow>
+// The expected format for hosts is <host>;<port>;<protocol>;<flow>;<connState>
 func NetworkDisruptionHostSpecFromString(hosts []string) ([]NetworkDisruptionHostSpec, error) {
 	var err error
 
@@ -169,9 +172,10 @@ func NetworkDisruptionHostSpecFromString(hosts []string) ([]NetworkDisruptionHos
 		port := 0
 		protocol := ""
 		flow := ""
+		connState := ""
 
-		// parse host with format <host>;<port>;<protocol>;<flow>
-		parsedHost := strings.SplitN(host, ";", 4)
+		// parse host with format <host>;<port>;<protocol>;<flow>;<connState>
+		parsedHost := strings.SplitN(host, ";", 5)
 
 		// cast port to int if specified
 		if len(parsedHost) > 1 && parsedHost[1] != "" {
@@ -191,12 +195,18 @@ func NetworkDisruptionHostSpecFromString(hosts []string) ([]NetworkDisruptionHos
 			flow = parsedHost[3]
 		}
 
+		// get conn state if specified
+		if len(parsedHost) > 4 && parsedHost[4] != "" {
+			connState = parsedHost[4]
+		}
+
 		// generate host spec
 		parsedHosts = append(parsedHosts, NetworkDisruptionHostSpec{
-			Host:     parsedHost[0],
-			Port:     port,
-			Protocol: protocol,
-			Flow:     flow,
+			Host:      parsedHost[0],
+			Port:      port,
+			Protocol:  protocol,
+			Flow:      flow,
+			ConnState: connState,
 		})
 	}
 

--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -200,6 +200,12 @@ spec:
                   allowedHosts:
                     items:
                       properties:
+                        connState:
+                          enum:
+                          - new
+                          - est
+                          - ""
+                          type: string
                         flow:
                           enum:
                           - ingress
@@ -252,6 +258,12 @@ spec:
                   hosts:
                     items:
                       properties:
+                        connState:
+                          enum:
+                          - new
+                          - est
+                          - ""
+                          type: string
                         flow:
                           enum:
                           - ingress

--- a/cli/injector/network_disruption.go
+++ b/cli/injector/network_disruption.go
@@ -64,13 +64,18 @@ var networkDisruptionCmd = &cobra.Command{
 			}
 
 			// generate injector
-			injectors = append(injectors, injector.NewNetworkDisruptionInjector(spec, injector.NetworkDisruptionInjectorConfig{Config: config}))
+			inj, err := injector.NewNetworkDisruptionInjector(spec, injector.NetworkDisruptionInjectorConfig{Config: config})
+			if err != nil {
+				log.Fatalw("error initializing the network disruption injector: %w", err)
+			}
+
+			injectors = append(injectors, inj)
 		}
 	},
 }
 
 func init() {
-	networkDisruptionCmd.Flags().StringSlice("hosts", []string{}, "List of hosts (hostname, single IP or IP block) with port and protocol to apply disruptions to (format: <host>;<port>;<protocol>;<flow>)")
+	networkDisruptionCmd.Flags().StringSlice("hosts", []string{}, "List of hosts (hostname, single IP or IP block) with port and protocol to apply disruptions to (format: <host>;<port>;<protocol>;<flow>;<connState>)")
 	networkDisruptionCmd.Flags().StringSlice("allowed-hosts", []string{}, "List of allowed hosts not being impacted by the disruption (hostname, single IP or IP block) with port and protocol to apply disruptions to (format: <host>;<port>;<protocol>;<flow>)")
 	networkDisruptionCmd.Flags().StringSlice("services", []string{}, "List of services to apply disruptions to (format: <name>;<namespace>)")
 	networkDisruptionCmd.Flags().Int("drop", 100, "Percentage to drop packets (100 is a total drop)")

--- a/docs/changes_handling.md
+++ b/docs/changes_handling.md
@@ -24,13 +24,13 @@ spec:
 
 In order to have an up to date state of the filtered on services / pods destination, we dynamically resolve them by:
 * installing **kubernetes watchers** on the kubernetes services and kubernetes pods (more info on watchers [here](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes))
-* keeping track of **tc filters** (more info on filters [here](https://man7.org/linux/man-pages/man8/tc-u32.8.html))
+* keeping track of **tc filters** (more info on filters [here](https://man7.org/linux/man-pages/man8/tc-flower.8.html))
 
 ### TC Filters Technicalities
 
 To delete tc filters, we need to keep in memory the priority (or preference) of each tc filter created, by assigning a priority when adding a tc filter:
 
-`tc filter add dev eth0 priority 49155 parent 1:0 u32 match ip dst 10.98.115.140/32 match ip dport 8080 0xffff match ip protocol 6 0xff flowid 1:4`
+`tc filter add dev eth0 protocol ip priority 49155 parent 1:0 flower ip_proto tcp dst_ip 10.98.115.140/32 dst_port 8080 flowid 1:4`
 
 The priority will indicate the order of the filter. (We don't need for the filters to have a specific order at this stage)
 

--- a/examples/complete.yaml
+++ b/examples/complete.yaml
@@ -45,11 +45,13 @@ spec:
         port: 80 # optional, port to drop packets on
         protocol: tcp # optional, protocol to drop packets on (can be tcp or udp, defaults to both)
         flow: ingress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
+        connState: new # optional, connection state (new: new connections, est: established connections, defaults to all states)
     allowedHosts: # optional, list of excluded hosts which would not be disrupted
       - host: 10.0.0.1 # optional, IP, CIDR or hostname to filter on
         port: 80 # optional, port to filter on
         protocol: tcp # optional, protocol to filter on (can be tcp or udp, defaults to both)
         flow: ingress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
+        connState: new # optional, connection state (new: new connections, est: established connections, defaults to all states)
     services: # optional, list of destination Kubernetes services to filter on
       - name: foo # service name
         namespace: bar # service namespace

--- a/examples/network_filters.yaml
+++ b/examples/network_filters.yaml
@@ -18,7 +18,8 @@ spec:
     hosts: # filter on hosts (an IP, a port, a protocol, or a combination of those)
       - host: 1.2.3.4 # optional, the destination host to filter on (can be an IP, a CIDR or a hostname)
         port: 80 # optional, the destination port to filter on
-        protocol: tcp # optional, the protocol to filter on
+        protocol: tcp # optional, the protocol to filter on (can be tcp or udp)
+        connState: new # optional, the connection state to filter on (can be new or est (established))
     services: # filter on Kubernetes services; this will correctly handle the port differences in node vs. pod-level disruptions
       - name: demo # service name
         namespace: chaos-demo # service namespace

--- a/injector/dns_disruption.go
+++ b/injector/dns_disruption.go
@@ -132,16 +132,16 @@ func (i *DNSDisruptionInjector) Inject() error {
 
 	if i.config.Level == chaostypes.DisruptionLevelNode {
 		// Exempt chaos pod from iptables re-routing
-		if err := i.config.Iptables.PrependRule("CHAOS-DNS", "-s", podIP, "-j", "RETURN"); err != nil {
+		if err := i.config.Iptables.PrependRuleSpec("CHAOS-DNS", "-s", podIP, "-j", "RETURN"); err != nil {
 			return fmt.Errorf("unable to create new iptables rule: %w", err)
 		}
 
 		// Re-route all pods under node
-		if err := i.config.Iptables.PrependRule("OUTPUT", "-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"); err != nil {
+		if err := i.config.Iptables.PrependRuleSpec("OUTPUT", "-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"); err != nil {
 			return fmt.Errorf("unable to create new iptables rule: %w", err)
 		}
 
-		if err := i.config.Iptables.PrependRule("PREROUTING", "-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"); err != nil {
+		if err := i.config.Iptables.PrependRuleSpec("PREROUTING", "-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"); err != nil {
 			return fmt.Errorf("unable to create new iptables rule: %w", err)
 		}
 	}

--- a/injector/dns_disruption_test.go
+++ b/injector/dns_disruption_test.go
@@ -57,8 +57,9 @@ var _ = Describe("Failure", func() {
 		iptables.On("AddRuleWithIP", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		iptables.On("AddWideFilterRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		iptables.On("AddCgroupFilterRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		iptables.On("PrependRule", mock.Anything, mock.Anything).Return(nil)
+		iptables.On("PrependRuleSpec", mock.Anything, mock.Anything).Return(nil)
 		iptables.On("DeleteRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		iptables.On("DeleteRuleSpec", mock.Anything, mock.Anything).Return(nil)
 		iptables.On("DeleteCgroupFilterRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 		// environment variables
@@ -104,9 +105,9 @@ var _ = Describe("Failure", func() {
 
 		Context("disruption is node-level", func() {
 			It("creates node-level iptable filter rules", func() {
-				iptables.AssertCalled(GinkgoT(), "PrependRule", "CHAOS-DNS", []string{"-s", "10.0.0.2", "-j", "RETURN"})
-				iptables.AssertCalled(GinkgoT(), "PrependRule", "OUTPUT", []string{"-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"})
-				iptables.AssertCalled(GinkgoT(), "PrependRule", "PREROUTING", []string{"-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"})
+				iptables.AssertCalled(GinkgoT(), "PrependRuleSpec", "CHAOS-DNS", []string{"-s", "10.0.0.2", "-j", "RETURN"})
+				iptables.AssertCalled(GinkgoT(), "PrependRuleSpec", "OUTPUT", []string{"-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"})
+				iptables.AssertCalled(GinkgoT(), "PrependRuleSpec", "PREROUTING", []string{"-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"})
 			})
 		})
 

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/chaos-controller/env"
 	"github.com/DataDog/chaos-controller/network"
 	"github.com/DataDog/chaos-controller/types"
-	chaostypes "github.com/DataDog/chaos-controller/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -36,7 +35,7 @@ var tcPriority = uint32(49149)
 type networkDisruptionService struct {
 	ip       *net.IPNet
 	port     int
-	protocol string
+	protocol network.Protocol
 }
 
 func (n networkDisruptionService) String() string {
@@ -62,6 +61,7 @@ type networkDisruptionInjector struct {
 type NetworkDisruptionInjectorConfig struct {
 	Config
 	TrafficController network.TrafficController
+	Iptables          network.Iptables
 	NetlinkAdapter    network.NetlinkAdapter
 	DNSClient         network.DNSClient
 	State             DisruptionState
@@ -98,7 +98,16 @@ type serviceWatcher struct {
 
 // NewNetworkDisruptionInjector creates a NetworkDisruptionInjector object with the given config,
 // missing field being initialized with the defaults
-func NewNetworkDisruptionInjector(spec v1beta1.NetworkDisruptionSpec, config NetworkDisruptionInjectorConfig) Injector {
+func NewNetworkDisruptionInjector(spec v1beta1.NetworkDisruptionSpec, config NetworkDisruptionInjectorConfig) (Injector, error) {
+	var err error
+
+	if config.Iptables == nil {
+		config.Iptables, err = network.NewIptables(config.Log, config.DryRun)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if config.TrafficController == nil {
 		config.TrafficController = network.NewTrafficController(config.Log, config.DryRun)
 	}
@@ -121,11 +130,11 @@ func NewNetworkDisruptionInjector(spec v1beta1.NetworkDisruptionSpec, config Net
 		spec:       spec,
 		config:     config,
 		operations: []linkOperation{},
-	}
+	}, nil
 }
 
-func (i *networkDisruptionInjector) GetDisruptionKind() chaostypes.DisruptionKindName {
-	return chaostypes.DisruptionKindNetworkDisruption
+func (i *networkDisruptionInjector) GetDisruptionKind() types.DisruptionKindName {
+	return types.DisruptionKindNetworkDisruption
 }
 
 // Inject injects the given network disruption into the given container
@@ -163,6 +172,13 @@ func (i *networkDisruptionInjector) Inject() error {
 
 	// apply operations if any
 	if len(i.operations) > 0 {
+		// add a conntrack reference to enable it
+		// it consists of adding a noop iptables rule loading the conntrack module so it enables connection tracking in the targeted network namespace
+		// cf. https://thermalcircle.de/doku.php?id=blog:linux:connection_tracking_1_modules_and_hooks for more information on how conntrack works outside of the main network namespace
+		if err := i.config.Iptables.PrependRuleSpec("OUTPUT", "-m", "state", "--state", "new,established", "-j", "LOG"); err != nil {
+			return fmt.Errorf("error injecting the conntrack reference iptables rule: %w", err)
+		}
+
 		if err := i.applyOperations(); err != nil {
 			return fmt.Errorf("error applying tc operations: %w", err)
 		}
@@ -224,6 +240,11 @@ func (i *networkDisruptionInjector) Clean() error {
 		if err := i.config.Cgroup.Write("net_cls", "net_cls.classid", "0x0"); err != nil {
 			return fmt.Errorf("error reseting classid of pod net_cls cgroup: %w", err)
 		}
+	}
+
+	// remove the conntrack reference to disable conntrack in the network namespace
+	if err := i.config.Iptables.DeleteRuleSpec("OUTPUT", "-m", "state", "--state", "new,established", "-j", "LOG"); err != nil {
+		return fmt.Errorf("error injecting the conntrack reference iptables rule: %w", err)
 	}
 
 	// exit target network namespace
@@ -342,7 +363,7 @@ func (i *networkDisruptionInjector) applyOperations() error {
 	// create a second qdisc to filter packets coming from this specific pod processes only
 	// if the disruption is applied on init, we consider that some more containers may be created within
 	// the pod so we can't scope the disruption to a specific set of containers
-	if i.config.Level == chaostypes.DisruptionLevelPod && !i.config.OnInit {
+	if i.config.Level == types.DisruptionLevelPod && !i.config.OnInit {
 		// create second prio with only 2 bands to filter traffic with a specific classid
 		if err := i.config.TrafficController.AddPrio(interfaces, "1:4", 2, 2, [16]uint32{}); err != nil {
 			return fmt.Errorf("can't create a new qdisc: %w", err)
@@ -375,7 +396,7 @@ func (i *networkDisruptionInjector) applyOperations() error {
 	// depending on the network configuration, only one of those filters can be useful but we must add all of them
 	// those filters are only added if the related interface has been impacted by a disruption so far
 	// NOTE: those filters must be added after every other filters applied to the interface so they are used first
-	if i.config.Level == chaostypes.DisruptionLevelPod {
+	if i.config.Level == types.DisruptionLevelPod {
 		// this filter allows the pod to communicate with the default route gateway IP
 		for _, defaultRoute := range defaultRoutes {
 			gatewayIP := &net.IPNet{
@@ -383,31 +404,31 @@ func (i *networkDisruptionInjector) applyOperations() error {
 				Mask: net.CIDRMask(32, 32),
 			}
 
-			if err := i.config.TrafficController.AddFilter([]string{defaultRoute.Link().Name()}, "1:0", i.getNewPriority(), 0, nil, gatewayIP, 0, 0, "", "1:1"); err != nil {
+			if err := i.config.TrafficController.AddFilter([]string{defaultRoute.Link().Name()}, "1:0", i.getNewPriority(), 0, nil, gatewayIP, 0, 0, network.TCP, network.ConnStateUndefined, "1:1"); err != nil {
 				return fmt.Errorf("can't add the default route gateway IP filter: %w", err)
 			}
 		}
 
 		// this filter allows the pod to communicate with the node IP
-		if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, nil, nodeIPNet, 0, 0, "", "1:1"); err != nil {
+		if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, nil, nodeIPNet, 0, 0, network.TCP, network.ConnStateUndefined, "1:1"); err != nil {
 			return fmt.Errorf("can't add the target pod node IP filter: %w", err)
 		}
-	} else if i.config.Level == chaostypes.DisruptionLevelNode {
+	} else if i.config.Level == types.DisruptionLevelNode {
 		// GENERIC SAFEGUARDS
 		// allow SSH connections on all interfaces (port 22/tcp)
-		if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, nil, nil, 22, 0, "tcp", "1:1"); err != nil {
+		if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, nil, nil, 22, 0, network.TCP, network.ConnStateUndefined, "1:1"); err != nil {
 			return fmt.Errorf("error adding filter allowing SSH connections: %w", err)
 		}
 
 		// CLOUD PROVIDER SPECIFIC SAFEGUARDS
 		// allow cloud provider health checks on all interfaces(arp)
-		if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, nil, nil, 0, 0, "arp", "1:1"); err != nil {
+		if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, nil, nil, 0, 0, network.ARP, network.ConnStateUndefined, "1:1"); err != nil {
 			return fmt.Errorf("error adding filter allowing cloud providers health checks (ARP packets): %w", err)
 		}
 
 		// allow cloud provider metadata service communication
-		if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, nil, metadataIPNet, 0, 0, "", "1:1"); err != nil {
-			return fmt.Errorf("error adding filter allowing cloud providers health checks (ARP packets): %w", err)
+		if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, nil, metadataIPNet, 0, 0, network.TCP, network.ConnStateUndefined, "1:1"); err != nil {
+			return fmt.Errorf("error adding filter allowing cloud providers metadata service requests: %w", err)
 		}
 	}
 
@@ -421,7 +442,7 @@ func (i *networkDisruptionInjector) applyOperations() error {
 	if len(i.spec.Hosts) == 0 && len(i.spec.Services) == 0 {
 		_, nullIP, _ := net.ParseCIDR("0.0.0.0/0")
 
-		if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, nil, nullIP, 0, 0, "", "1:4"); err != nil {
+		if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, nil, nullIP, 0, 0, network.TCP, network.ConnStateUndefined, "1:4"); err != nil {
 			return fmt.Errorf("can't add a filter: %w", err)
 		}
 	} else {
@@ -459,7 +480,7 @@ func (i *networkDisruptionInjector) addServiceFilters(serviceName string, filter
 
 		i.config.Log.Infow("found service endpoint", "resolvedEndpoint", filter.service.String(), "resolvedService", serviceName)
 
-		err := i.config.TrafficController.AddFilter(interfaces, "1:0", filter.priority, 0, nil, filter.service.ip, 0, filter.service.port, filter.service.protocol, flowid)
+		err := i.config.TrafficController.AddFilter(interfaces, "1:0", filter.priority, 0, nil, filter.service.ip, 0, filter.service.port, filter.service.protocol, network.ConnStateUndefined, flowid)
 		if err != nil {
 			return nil, err
 		}
@@ -510,7 +531,7 @@ func (i *networkDisruptionInjector) buildServiceFiltersFromPod(pod v1.Pod, servi
 			service: networkDisruptionService{
 				ip:       endpointIP,
 				port:     int(port.TargetPort.IntVal),
-				protocol: string(port.Protocol),
+				protocol: network.Protocol(port.Protocol),
 			},
 		}
 
@@ -538,7 +559,7 @@ func (i *networkDisruptionInjector) buildServiceFiltersFromService(service v1.Se
 			service: networkDisruptionService{
 				ip:       serviceIP,
 				port:     int(port.Port),
-				protocol: string(port.Protocol),
+				protocol: network.Protocol(port.Protocol),
 			},
 		}
 
@@ -889,12 +910,12 @@ func (i *networkDisruptionInjector) addFiltersForHosts(interfaces []string, host
 		i.config.Log.Infof("resolved %s as %s", host.Host, ips)
 
 		for _, ip := range ips {
-			// handle flow direction
 			var (
 				srcPort, dstPort int
 				srcIP, dstIP     *net.IPNet
 			)
 
+			// handle flow direction
 			switch host.Flow {
 			case v1beta1.FlowIngress:
 				srcPort = host.Port
@@ -904,8 +925,16 @@ func (i *networkDisruptionInjector) addFiltersForHosts(interfaces []string, host
 				dstIP = ip
 			}
 
+			// default protocol to tcp if not specified
+			if host.Protocol == "" {
+				host.Protocol = string(network.TCP)
+			}
+
+			// cast connection state
+			connState := network.NewConnState(host.ConnState)
+
 			// create tc filter
-			if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, srcIP, dstIP, srcPort, dstPort, host.Protocol, flowid); err != nil {
+			if err := i.config.TrafficController.AddFilter(interfaces, "1:0", i.getNewPriority(), 0, srcIP, dstIP, srcPort, dstPort, network.Protocol(host.Protocol), connState, flowid); err != nil {
 				return fmt.Errorf("error adding filter for host %s: %w", host.Host, err)
 			}
 		}

--- a/network/iptables.go
+++ b/network/iptables.go
@@ -19,8 +19,9 @@ type Iptables interface {
 	AddRuleWithIP(chain string, protocol string, port string, jump string, destinationIP string) error
 	AddWideFilterRule(chain string, protocol string, port string, jump string) error
 	AddCgroupFilterRule(chain string, cgroupid string, protocol string, port string, jump string) error
-	PrependRule(chain string, rulespec ...string) error
+	PrependRuleSpec(chain string, rulespec ...string) error
 	DeleteRule(chain string, protocol string, port string, jump string) error
+	DeleteRuleSpec(chain string, rulespec ...string) error
 	DeleteCgroupFilterRule(chain string, cgroupid string, protocol string, port string, jump string) error
 }
 
@@ -75,7 +76,7 @@ func (i iptables) AddRuleWithIP(chain string, protocol string, port string, jump
 	return i.ip.AppendUnique("nat", chain, "-p", protocol, "--dport", port, "-j", jump, "--to-destination", fmt.Sprintf("%s:%s", destinationIP, port))
 }
 
-func (i iptables) PrependRule(chain string, rulespec ...string) error {
+func (i iptables) PrependRuleSpec(chain string, rulespec ...string) error {
 	if i.dryRun {
 		return nil
 	}
@@ -113,12 +114,6 @@ func (i iptables) DeleteRule(chain string, protocol string, port string, jump st
 		return nil
 	}
 
-	i.log.Infow("deleting iptables rule", "chain name", chain, "protocol", protocol, "port", port, "jump target", jump)
-
-	if exists, _ := i.ip.ChainExists("nat", chain); !exists {
-		return nil
-	}
-
 	// Why do we check if the jump target exists? A command of the form
 	// iptables -t nat -C OUTPUT -p udp --dport 53 -j CHAOS-DNS
 	// will actually error if the jump target does not exist. However, you are unable
@@ -128,7 +123,21 @@ func (i iptables) DeleteRule(chain string, protocol string, port string, jump st
 		return nil
 	}
 
-	return i.ip.DeleteIfExists("nat", chain, "-p", protocol, "--dport", port, "-j", jump)
+	return i.DeleteRuleSpec("nat", chain, "-p", protocol, "--dport", port, "-j", jump)
+}
+
+func (i iptables) DeleteRuleSpec(chain string, rulespec ...string) error {
+	if i.dryRun {
+		return nil
+	}
+
+	i.log.Infow("deleting iptables rule", "chain name", chain, "rulespec", rulespec)
+
+	if exists, _ := i.ip.ChainExists("nat", chain); !exists {
+		return nil
+	}
+
+	return i.ip.DeleteIfExists("nat", chain, rulespec...)
 }
 
 // Delete a rule with cgroup filter

--- a/network/iptables_mock.go
+++ b/network/iptables_mock.go
@@ -34,7 +34,7 @@ func (f *IptablesMock) AddRuleWithIP(chain string, protocol string, port string,
 }
 
 //nolint:golint
-func (f *IptablesMock) PrependRule(chain string, rulespec ...string) error {
+func (f *IptablesMock) PrependRuleSpec(chain string, rulespec ...string) error {
 	args := f.Called(chain, rulespec)
 
 	return args.Error(0)
@@ -43,6 +43,13 @@ func (f *IptablesMock) PrependRule(chain string, rulespec ...string) error {
 //nolint:golint
 func (f *IptablesMock) DeleteRule(chain string, protocol string, port string, jump string) error {
 	args := f.Called(chain, protocol, port, jump)
+
+	return args.Error(0)
+}
+
+//nolint:golint
+func (f *IptablesMock) DeleteRuleSpec(chain string, rulespec ...string) error {
+	args := f.Called(chain, rulespec)
 
 	return args.Error(0)
 }

--- a/network/protocol.go
+++ b/network/protocol.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+package network
+
+type Protocol string
+
+const (
+	TCP Protocol = "tcp"
+	UDP Protocol = "udp"
+	ARP Protocol = "arp"
+)

--- a/network/tc_mock.go
+++ b/network/tc_mock.go
@@ -32,7 +32,7 @@ func (f *TcMock) AddPrio(ifaces []string, parent string, handle uint32, bands ui
 }
 
 //nolint:golint
-func (f *TcMock) AddFilter(ifaces []string, parent string, priority uint32, handle uint32, srcIP, dstIP *net.IPNet, srcPort, dstPort int, protocol string, flowid string) error {
+func (f *TcMock) AddFilter(ifaces []string, parent string, priority uint32, handle uint32, srcIP, dstIP *net.IPNet, srcPort, dstPort int, protocol Protocol, connState connState, flowid string) error {
 	srcIPs := "nil"
 	dstIPs := "nil"
 
@@ -44,7 +44,7 @@ func (f *TcMock) AddFilter(ifaces []string, parent string, priority uint32, hand
 		dstIPs = dstIP.String()
 	}
 
-	args := f.Called(ifaces, parent, priority, handle, srcIPs, dstIPs, srcPort, dstPort, protocol, flowid)
+	args := f.Called(ifaces, parent, priority, handle, srcIPs, dstIPs, srcPort, dstPort, string(protocol), string(connState), flowid)
 
 	return args.Error(0)
 }

--- a/network/tc_test.go
+++ b/network/tc_test.go
@@ -41,7 +41,8 @@ var _ = Describe("Tc", func() {
 		priomap           [16]uint32
 		srcIP, dstIP      *net.IPNet
 		srcPort, dstPort  int
-		protocol          string
+		protocol          Protocol
+		connState         connState
 		flowid            string
 	)
 
@@ -76,7 +77,8 @@ var _ = Describe("Tc", func() {
 		}
 		srcPort = 12345
 		dstPort = 80
-		protocol = "tcp"
+		protocol = TCP
+		connState = ConnStateNew
 		flowid = "1:2"
 	})
 
@@ -126,7 +128,7 @@ var _ = Describe("Tc", func() {
 
 	Describe("AddFilter", func() {
 		JustBeforeEach(func() {
-			tcRunner.AddFilter(ifaces, parent, 0, handle, srcIP, dstIP, srcPort, dstPort, protocol, flowid)
+			tcRunner.AddFilter(ifaces, parent, 0, handle, srcIP, dstIP, srcPort, dstPort, protocol, connState, flowid)
 		})
 
 		Context("add a filter on packets going to IP 10.0.0.1 and port 80 with flowid 1:4 on egress traffic", func() {
@@ -136,7 +138,7 @@ var _ = Describe("Tc", func() {
 			})
 
 			It("should execute", func() {
-				tcExecuter.AssertCalled(GinkgoT(), "Run", "filter add dev lo root u32 match ip dst 10.0.0.1/32 match ip dport 80 0xffff match ip protocol 6 0xff flowid 1:2")
+				tcExecuter.AssertCalled(GinkgoT(), "Run", "filter add dev lo protocol ip root flower ip_proto tcp dst_ip 10.0.0.1/32 dst_port 80 ct_state +trk+new flowid 1:2")
 			})
 		})
 
@@ -147,13 +149,13 @@ var _ = Describe("Tc", func() {
 			})
 
 			It("should execute", func() {
-				tcExecuter.AssertCalled(GinkgoT(), "Run", "filter add dev lo root u32 match ip src 192.168.0.1/32 match ip sport 12345 0xffff match ip protocol 6 0xff flowid 1:2")
+				tcExecuter.AssertCalled(GinkgoT(), "Run", "filter add dev lo protocol ip root flower ip_proto tcp src_ip 192.168.0.1/32 src_port 12345 ct_state +trk+new flowid 1:2")
 			})
 		})
 
 		Context("add a filter on packets leaving IP 192.168.0.1 port 12345 and going to IP 10.0.0.1 port 80 with flowid 1:4 on egress traffic", func() {
 			It("should execute", func() {
-				tcExecuter.AssertCalled(GinkgoT(), "Run", "filter add dev lo root u32 match ip src 192.168.0.1/32 match ip dst 10.0.0.1/32 match ip sport 12345 0xffff match ip dport 80 0xffff match ip protocol 6 0xff flowid 1:2")
+				tcExecuter.AssertCalled(GinkgoT(), "Run", "filter add dev lo protocol ip root flower ip_proto tcp src_ip 192.168.0.1/32 dst_ip 10.0.0.1/32 src_port 12345 dst_port 80 ct_state +trk+new flowid 1:2")
 			})
 		})
 	})


### PR DESCRIPTION
## What does this PR do?

- [x] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Switch from u32 tc filters to [flower](https://man7.org/linux/man-pages/man8/tc-flower.8.html) tc filters to have a more specific set of features for filtering
- Add the connection state filtering in network disruption hosts options for one to be able to affect only new or only already established connections

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - Applying already existing network disruptions and ensure they are still working correctly
    - Applying a network disruption filtering on the connection state and try with both new and established connections
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
