### PR TITLE
Change the reinject loop

### DIFF
--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -677,6 +677,7 @@ out:
 
 			if event.Type == watch.Bookmark {
 				resourceVersion = pod.ResourceVersion
+				log.Debugw("received bookmark event, new resource version found", "resourceVersion", pod.ResourceVersion)
 			}
 
 			if event.Type != watch.Modified {

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -637,6 +637,7 @@ func watchTargetAndReinject(deadline time.Time, commandName string, pulseActiveD
 
 			pod, ok := event.Object.(*v1.Pod)
 			if !ok {
+				log.Debugw("received event was not a pod", "event", event, "event.Object", event.Object)
 				return fmt.Errorf("watched object received from event is not a pod")
 			}
 

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -611,6 +611,7 @@ func watchTargetAndReinject(deadline time.Time, commandName string, pulseActiveD
 			// We've already consumed the signal from the channel, so our caller won't find it when checking after we return.
 			// Thus we need to put the signal back into the channel. We do it in a gothread in case we are blocked when writing to the channel
 			go func() { signals <- sig }()
+
 			return nil
 		case <-time.After(getDuration(deadline)):
 			log.Infow("duration has expired")

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -598,7 +598,6 @@ func watchTargetAndReinject(deadline time.Time, commandName string, pulseActiveD
 
 	var actionOnPulse func(string, bool, bool) bool
 
-out:
 	for {
 		if channel == nil {
 			if channel, err = initPodWatch(resourceVersion); err != nil {
@@ -634,7 +633,7 @@ out:
 			if !ok {
 				channel = nil
 
-				continue out
+				continue
 			}
 
 			pod, ok := event.Object.(*v1.Pod)
@@ -665,7 +664,7 @@ out:
 
 						log.Debugw("restarting pod watching channel with newest resource version", "resourceVersion", resourceVersion)
 
-						continue out
+						continue
 					}
 				}
 
@@ -674,6 +673,8 @@ out:
 
 			if event.Type == watch.Bookmark {
 				resourceVersion = pod.ResourceVersion
+				channel = nil
+
 				log.Debugw("received bookmark event, new resource version found", "resourceVersion", pod.ResourceVersion)
 			}
 

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -608,7 +608,9 @@ func watchTargetAndReinject(deadline time.Time, commandName string, pulseActiveD
 		select {
 		case sig := <-signals:
 			log.Infow("an exit signal has been received", "signal", sig.String())
-
+			// We've already consumed the signal from the channel, so our caller won't find it when checking after we return.
+			// Thus we need to put the signal back into the channel. We do it in a gothread in case we are blocked when writing to the channel
+			go func() { signals <- sig }()
 			return nil
 		case <-time.After(getDuration(deadline)):
 			log.Infow("duration has expired")

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -646,9 +646,15 @@ out:
 					if status.Code == 410 {
 						// Status Code 410 indicates our resource version has expired
 						// Get the newest resource version and re-create the channel
-						resourceVersion, err = getPodResourceVersion()
+						updResourceVersion, err := getPodResourceVersion()
 						if err != nil {
 							return fmt.Errorf("could not get latest resource version: %w", err)
+						}
+
+						if updResourceVersion == resourceVersion {
+							time.Sleep(time.Second * 15)
+						} else {
+							resourceVersion = updResourceVersion
 						}
 
 						channel = nil

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -183,7 +183,7 @@ func initConfig() {
 	pids := []uint32{}
 	ctns := []container.Container{}
 	dnsConfig := network.DNSConfig{DNSServer: dnsServer, KubeDNS: kubeDNS}
-	reg, _ = regexp.Compile("\\((.*)\\)")
+	reg, _ = regexp.Compile("\\S\\d{9}\\S")
 
 	// log when dry-run mode is enabled
 	if dryRun {
@@ -657,9 +657,8 @@ out:
 						if updResourceVersion == resourceVersion {
 							// try a hacky fix?
 							if reg != nil {
-								suggested := reg.FindString(updResourceVersion)
-								log.Debugw("getting latest", "suggested", suggested)
-								resourceVersion = suggested[1 : len(suggested)-1]
+								resourceVersion = reg.FindString(updResourceVersion)
+								log.Debugw("regexd this", "rv", resourceVersion)
 							}
 						} else {
 							resourceVersion = updResourceVersion

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -598,6 +598,7 @@ func watchTargetAndReinject(deadline time.Time, commandName string, pulseActiveD
 
 	var actionOnPulse func(string, bool, bool) bool
 
+out:
 	for {
 		if channel == nil {
 			if channel, err = initPodWatch(resourceVersion); err != nil {
@@ -633,7 +634,7 @@ func watchTargetAndReinject(deadline time.Time, commandName string, pulseActiveD
 			if !ok {
 				channel = nil
 
-				break
+				continue out
 			}
 
 			pod, ok := event.Object.(*v1.Pod)
@@ -654,7 +655,7 @@ func watchTargetAndReinject(deadline time.Time, commandName string, pulseActiveD
 
 						log.Debugw("restarting pod watching channel with newest resource version")
 
-						break
+						continue out
 					}
 				}
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Fix a potential livelock issue. The reinject loop listens for sigterms and leaves the loop. However when we return to our caller, we'll be greeted by a blocking call waiting for a sigterm. But, the reinject loop already consumed the sigterm from that channel! So we'll end up blocking until the controller or human retries sending the sigterm. That's not a great behavior, so instead slightly modify the behavior. We still return to our caller, but we also put the sigterm back into the channel.
- Handle expired resource versions during reinject. Previously we were relying on the BOOKMARK event to let us know when a new resource version was available. But sometimes we'd get explicitly told our version was expired. In these instances we'd just exit. However, there is an explicit status code for this situation. Now we check for that, and reset our resource version, and re-create the channel

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - [ ] locally.
    - [x] as a canary deployment to a cluster.
