### PR TITLE
Fix bug not count all distinct cores when applying cpu-pressure.

### DIFF
--- a/cli/injector/cpu_pressure.go
+++ b/cli/injector/cpu_pressure.go
@@ -8,6 +8,7 @@ package main
 import (
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/injector"
+	"github.com/DataDog/chaos-controller/stress"
 	"github.com/spf13/cobra"
 )
 
@@ -18,10 +19,15 @@ var cpuPressureCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 		// prepare spec
 		spec := v1beta1.CPUPressureSpec{}
+		stresserManager := stress.NewCPUStresserManager(log)
 
 		// create injector
 		for _, config := range configs {
-			injectors = append(injectors, injector.NewCPUPressureInjector(spec, injector.CPUPressureInjectorConfig{Config: config}))
+			injector, _ := injector.NewCPUPressureInjector(spec, injector.CPUPressureInjectorConfig{
+				Config:          config,
+				StresserManager: stresserManager,
+			})
+			injectors = append(injectors, injector)
 		}
 	},
 }

--- a/cpuset/cpuset.go
+++ b/cpuset/cpuset.go
@@ -24,12 +24,11 @@ package cpuset
 import (
 	"bytes"
 	"fmt"
+	"k8s.io/klog/v2"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
-
-	"k8s.io/klog/v2"
 )
 
 // Builder is a mutable builder for CPUSet. Functions that mutate instances

--- a/injector/cpu_pressure.go
+++ b/injector/cpu_pressure.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
-	"github.com/DataDog/chaos-controller/cpuset"
 	"github.com/DataDog/chaos-controller/process"
 	"github.com/DataDog/chaos-controller/stress"
 	"github.com/DataDog/chaos-controller/types"
@@ -26,13 +25,14 @@ type cpuPressureInjector struct {
 // CPUPressureInjectorConfig is the CPU pressure injector config
 type CPUPressureInjectorConfig struct {
 	Config
-	Stresser       stress.Stresser
-	StresserExit   chan struct{}
-	ProcessManager process.Manager
+	Stresser        stress.Stresser
+	StresserExit    chan struct{}
+	ProcessManager  process.Manager
+	StresserManager stress.StresserManager
 }
 
 // NewCPUPressureInjector creates a CPU pressure injector with the given config
-func NewCPUPressureInjector(spec v1beta1.CPUPressureSpec, config CPUPressureInjectorConfig) Injector {
+func NewCPUPressureInjector(spec v1beta1.CPUPressureSpec, config CPUPressureInjectorConfig) (Injector, error) {
 	// create stresser
 	if config.Stresser == nil {
 		config.Stresser = stress.NewCPU(config.DryRun)
@@ -47,10 +47,14 @@ func NewCPUPressureInjector(spec v1beta1.CPUPressureSpec, config CPUPressureInje
 		config.ProcessManager = process.NewManager(config.DryRun)
 	}
 
+	if config.StresserManager == nil {
+		return nil, fmt.Errorf("StresserManager does not exist")
+	}
+
 	return &cpuPressureInjector{
 		spec:   spec,
 		config: config,
-	}
+	}, nil
 }
 
 func (i *cpuPressureInjector) GetDisruptionKind() types.DisruptionKindName {
@@ -58,29 +62,14 @@ func (i *cpuPressureInjector) GetDisruptionKind() types.DisruptionKindName {
 }
 
 func (i *cpuPressureInjector) Inject() error {
-	// read cpuset allocated cores
-	i.config.Log.Infow("retrieving target cpuset allocated cores")
+	cores, err := i.config.StresserManager.TrackInjectorCores(i.config.Cgroup)
 
-	cpusetCores, err := i.config.Cgroup.Read("cpuset", "cpuset.cpus")
 	if err != nil {
-		return fmt.Errorf("failed to read the target allocated cpus from the cpuset cgroup: %w", err)
+		return fmt.Errorf("failed to parse CPUSet %w", err)
 	}
-
-	// parse allocated cores
-	cores, err := cpuset.Parse(cpusetCores)
-	if err != nil {
-		return fmt.Errorf("error parsing cpuset allocated cores: %w", err)
-	}
-
-	i.config.Log.Infow(fmt.Sprintf("target identified to be running on %d cores", cores.Size()), "cores", cores.ToSlice())
-
-	// set new GOMAXPROCS value
-	oldMaxProcs := runtime.GOMAXPROCS(cores.Size())
-	i.config.Log.Infof("changed GOMAXPROCS value from %d to %d", oldMaxProcs, cores.Size())
 
 	wg := sync.WaitGroup{}
 	succeeded := true
-	tids := []int{}
 	mutex := sync.Mutex{}
 
 	// create one stress goroutine per allocated core
@@ -90,19 +79,14 @@ func (i *cpuPressureInjector) Inject() error {
 	// each thread is also niced to the highest priority
 	// because of linux scheduling, each thread will occupy a different core of allocated cores when stressing the cpu
 	for _, core := range cores.ToSlice() {
+		if i.config.StresserManager.IsCoreAlreadyStressed(core) {
+			i.config.Log.Infof("core %d is already stressed, skipping", core)
+			continue
+		}
+
 		wg.Add(1)
 
 		go func(core int) {
-			var err error
-
-			defer func() {
-				if err != nil {
-					succeeded = false
-
-					wg.Done()
-				}
-			}()
-
 			// lock the routine on the current thread
 			runtime.LockOSThread()
 			defer runtime.UnlockOSThread()
@@ -110,42 +94,16 @@ func (i *cpuPressureInjector) Inject() error {
 			// retrieve current thread PID
 			pid := i.config.ProcessManager.ThreadID()
 
-			// join target CPU cgroup
-			i.config.Log.Infow("joining target CPU cgroup", "core", core, "pid", pid)
-
-			if err = i.config.Cgroup.Join("cpu", pid, false); err != nil {
-				i.config.Log.Errorw("failed join the target CPU cgroup", "error", err, "core", core, "pid", pid)
-
-				return
+			if i.joinCgroup(core, pid) && i.prioritizeStresserProcess(core, pid) {
+				mutex.Lock()
+				i.routines++
+				mutex.Unlock()
+				wg.Done()
+				i.startStresser(core, pid)
+			} else {
+				succeeded = false
+				wg.Done()
 			}
-
-			// join target cpuset cgroup in case it is used to pin the target on specific cores
-			i.config.Log.Infow("joining target cpuset cgroup", "core", core, "pid", pid)
-
-			if err = i.config.Cgroup.Join("cpuset", pid, false); err != nil {
-				i.config.Log.Errorw("failed to join the target cpuset cgroup", "error", err, "core", core, "pid", pid)
-
-				return
-			}
-
-			// prioritize the current process
-			i.config.Log.Infow("highering current process priority", "core", core, "pid", pid)
-
-			if err = i.config.ProcessManager.Prioritize(); err != nil {
-				i.config.Log.Errorw("error highering the current process priority", "error", err, "core", core, "pid", pid)
-
-				return
-			}
-
-			i.config.Log.Infow("starting the stresser", "core", core, "pid", pid)
-
-			mutex.Lock()
-			tids = append(tids, pid)
-			i.routines++
-			mutex.Unlock()
-
-			wg.Done()
-			i.config.Stresser.Stress(i.config.StresserExit)
 		}(core)
 	}
 
@@ -156,9 +114,46 @@ func (i *cpuPressureInjector) Inject() error {
 		return fmt.Errorf("at least one stresser routine failed to execute")
 	}
 
-	i.config.Log.Infow("all routines have been created successfully, now stressing", "routinesPID", tids)
+	i.config.Log.Infow("all routines have been created successfully, now stressing", "stresserPIDPerCore", i.config.StresserManager.StresserPIDs())
 
 	return nil
+}
+
+func (i *cpuPressureInjector) joinCgroup(core int, pid int) bool {
+	// join target CPU cgroup
+	i.config.Log.Infow("joining target CPU cgroup", "core", core, "pid", pid)
+
+	if err := i.config.Cgroup.Join("cpu", pid, false); err != nil {
+		i.config.Log.Errorw("failed join the target CPU cgroup", "error", err, "core", core, "pid", pid)
+		return false
+	}
+
+	// join target cpuset cgroup in case it is used to pin the target on specific cores
+	i.config.Log.Infow("joining target cpuset cgroup", "core", core, "pid", pid)
+
+	if err := i.config.Cgroup.Join("cpuset", pid, false); err != nil {
+		i.config.Log.Errorw("failed to join the target cpuset cgroup", "error", err, "core", core, "pid", pid)
+		return false
+	}
+
+	return true
+}
+
+func (i *cpuPressureInjector) startStresser(core int, pid int) {
+	i.config.Log.Infow("starting the stresser", "core", core, "pid", pid)
+	i.config.StresserManager.TrackCoreAlreadyStressed(core, pid)
+	i.config.Stresser.Stress(i.config.StresserExit)
+}
+
+func (i *cpuPressureInjector) prioritizeStresserProcess(core int, pid int) bool {
+	i.config.Log.Infow("prioritizing the current stresser process", "core", core, "pid", pid)
+
+	if err := i.config.ProcessManager.Prioritize(); err != nil {
+		i.config.Log.Errorw("failed to prioritize the current stresser process", "error", err, "core", core, "pid", pid)
+		return false
+	}
+
+	return true
 }
 
 func (i *cpuPressureInjector) UpdateConfig(config Config) {
@@ -166,7 +161,7 @@ func (i *cpuPressureInjector) UpdateConfig(config Config) {
 }
 
 func (i *cpuPressureInjector) Clean() error {
-	i.config.Log.Info("killing routines")
+	i.config.Log.Info("killing %d routines", i.routines)
 
 	// exit the stress routines
 	for r := 0; r < i.routines; r++ {

--- a/injector/cpu_pressure_test.go
+++ b/injector/cpu_pressure_test.go
@@ -5,35 +5,35 @@
 package injector_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/cgroup"
 	"github.com/DataDog/chaos-controller/container"
+	"github.com/DataDog/chaos-controller/cpuset"
 	. "github.com/DataDog/chaos-controller/injector"
 	"github.com/DataDog/chaos-controller/process"
 	"github.com/DataDog/chaos-controller/stress"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
 )
 
 var _ = Describe("Failure", func() {
 	var (
-		config        CPUPressureInjectorConfig
-		cgroupManager *cgroup.ManagerMock
-		ctn           *container.ContainerMock
-		stresser      *stress.StresserMock
-		stresserExit  chan struct{}
-		manager       *process.ManagerMock
-		inj           Injector
-		spec          v1beta1.CPUPressureSpec
+		config          CPUPressureInjectorConfig
+		cgroupManager   *cgroup.ManagerMock
+		ctn             *container.ContainerMock
+		stresser        *stress.StresserMock
+		stresserExit    chan struct{}
+		manager         *process.ManagerMock
+		inj             Injector
+		spec            v1beta1.CPUPressureSpec
+		stresserManager *stress.StresserManagerMock
 	)
 
 	BeforeEach(func() {
 		// cgroup
 		cgroupManager = &cgroup.ManagerMock{}
 		cgroupManager.On("Join", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		cgroupManager.On("Read", "cpuset", "cpuset.cpus").Return("0-1", nil)
 
 		// container
 		ctn = &container.ContainerMock{}
@@ -50,6 +50,13 @@ var _ = Describe("Failure", func() {
 		manager.On("Prioritize").Return(nil)
 		manager.On("ThreadID").Return(666)
 
+		stresserManager = &stress.StresserManagerMock{}
+		stresserManager.On("TrackInjectorCores", mock.Anything).Return(cpuset.NewCPUSet(0, 1), nil)
+		stresserManager.On("TrackCoreAlreadyStressed", mock.Anything, mock.Anything).Return(nil)
+		stresserManager.On("StresserPIDs").Return(map[int]int{0: 666})
+		stresserManager.On("IsCoreAlreadyStressed", 0).Return(true)
+		stresserManager.On("IsCoreAlreadyStressed", 1).Return(false)
+
 		//config
 		config = CPUPressureInjectorConfig{
 			Config: Config{
@@ -58,15 +65,18 @@ var _ = Describe("Failure", func() {
 				Log:             log,
 				MetricsSink:     ms,
 			},
-			Stresser:       stresser,
-			StresserExit:   stresserExit,
-			ProcessManager: manager,
+			Stresser:        stresser,
+			StresserExit:    stresserExit,
+			ProcessManager:  manager,
+			StresserManager: stresserManager,
 		}
 
 		// spec
 		spec = v1beta1.CPUPressureSpec{}
 
-		inj = NewCPUPressureInjector(spec, config)
+		var err error
+		inj, err = NewCPUPressureInjector(spec, config)
+		Expect(err).To(BeNil())
 
 		// because the cleaning phase is blocking, we start it in a goroutine
 		// and send a signal to the stresser exit handler
@@ -78,20 +88,37 @@ var _ = Describe("Failure", func() {
 
 		stresserExit <- struct{}{}
 	})
+
+	AfterEach(func() {
+		manager.AssertExpectations(GinkgoT())
+		stresser.AssertExpectations(GinkgoT())
+		stresserManager.AssertExpectations(GinkgoT())
+		cgroupManager.AssertExpectations(GinkgoT())
+		ctn.AssertExpectations(GinkgoT())
+	})
+
 	Describe("injection", func() {
 
-		It("should join the cpu and cpuset cgroups", func() {
+		It("should join the cpu and cpuset cgroups for the unstressed core", func() {
 			cgroupManager.AssertCalled(GinkgoT(), "Join", "cpu", 666, false)
 			cgroupManager.AssertCalled(GinkgoT(), "Join", "cpuset", 666, false)
-			cgroupManager.AssertNumberOfCalls(GinkgoT(), "Join", 4)
+			cgroupManager.AssertNumberOfCalls(GinkgoT(), "Join", 2)
 		})
 
 		It("should prioritize the current process", func() {
 			manager.AssertCalled(GinkgoT(), "Prioritize")
 		})
 
-		It("should run the stress routines", func() {
-			stresser.AssertCalled(GinkgoT(), "Stress")
+		It("should run the stress on one core", func() {
+			stresser.AssertNumberOfCalls(GinkgoT(), "Stress", 1)
+		})
+
+		It("should record core and StresserPID in StresserManager", func() {
+			stresserManager.AssertCalled(GinkgoT(), "TrackCoreAlreadyStressed", 1, 666)
+		})
+
+		It("should skip a target core that was already stress", func() {
+			stresserManager.AssertNotCalled(GinkgoT(), "TrackCoreAlreadyStressed", 0, mock.Anything)
 		})
 	})
 })

--- a/stress/cpu.go
+++ b/stress/cpu.go
@@ -5,7 +5,9 @@
 
 package stress
 
-import "runtime"
+import (
+	"runtime"
+)
 
 type cpu struct {
 	dryRun bool

--- a/stress/cpuset_manager.go
+++ b/stress/cpuset_manager.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+package stress
+
+import (
+	"fmt"
+	"github.com/DataDog/chaos-controller/cgroup"
+	"github.com/DataDog/chaos-controller/cpuset"
+	"go.uber.org/zap"
+	"runtime"
+	"sync"
+)
+
+type StresserManager interface {
+	TrackInjectorCores(cgroup cgroup.Manager) (cpuset.CPUSet, error)
+	IsCoreAlreadyStressed(core int) bool
+	TrackCoreAlreadyStressed(core int, stresserPID int)
+	StresserPIDs() map[int]int
+}
+
+type cpuStressserManager struct {
+	mutex              sync.RWMutex
+	coresToBeStressed  cpuset.CPUSet
+	stresserPIDPerCore map[int]int
+	log                *zap.SugaredLogger
+}
+
+func NewCPUStresserManager(log *zap.SugaredLogger) StresserManager {
+	return &cpuStressserManager{
+		coresToBeStressed:  cpuset.NewCPUSet(),
+		stresserPIDPerCore: map[int]int{},
+		log:                log,
+	}
+}
+
+func (manager *cpuStressserManager) setCoresToBeStressed(cores cpuset.CPUSet) {
+	manager.mutex.Lock()
+	defer manager.mutex.Unlock()
+
+	manager.coresToBeStressed = cores
+	oldMaxProcs := runtime.GOMAXPROCS(cores.Size())
+
+	manager.log.Infof("changed GOMAXPROCS value from %d to %d", oldMaxProcs, cores.Size())
+}
+
+func (manager *cpuStressserManager) IsCoreAlreadyStressed(core int) bool {
+	manager.mutex.RLock()
+	defer manager.mutex.RUnlock()
+	_, isCoreStressed := manager.stresserPIDPerCore[core]
+	return isCoreStressed
+}
+
+func (manager *cpuStressserManager) TrackCoreAlreadyStressed(core int, stresserPID int) {
+	manager.mutex.Lock()
+	defer manager.mutex.Unlock()
+	manager.stresserPIDPerCore[core] = stresserPID
+}
+
+func (manager *cpuStressserManager) StresserPIDs() map[int]int {
+	return manager.stresserPIDPerCore
+}
+
+func (manager *cpuStressserManager) TrackInjectorCores(cgroup cgroup.Manager) (cpuset.CPUSet, error) {
+	// read cpuset allocated cores
+	manager.log.Infow("retrieving target cpuset allocated cores")
+
+	cpusetCores, err := cgroup.Read("cpuset", "cpuset.cpus")
+	if err != nil {
+		return cpuset.NewCPUSet(), fmt.Errorf("failed to read the target allocated cpus from the cpuset cgroup: %w", err)
+	}
+
+	// parse allocated cores
+	cores, err := cpuset.Parse(cpusetCores)
+	if err != nil {
+		return cpuset.NewCPUSet(), fmt.Errorf("error parsing cpuset allocated cores: %w", err)
+	}
+
+	manager.setCoresToBeStressed(manager.coresToBeStressed.Union(cores))
+
+	return cores, nil
+}

--- a/stress/cpuset_manager_mock.go
+++ b/stress/cpuset_manager_mock.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+package stress
+
+import (
+	"github.com/DataDog/chaos-controller/cgroup"
+	"github.com/stretchr/testify/mock"
+)
+import (
+	"github.com/DataDog/chaos-controller/cpuset"
+)
+
+type StresserManagerMock struct {
+	mock.Mock
+}
+
+//nolint:golint
+func (f *StresserManagerMock) IsCoreAlreadyStressed(core int) bool {
+	args := f.Called(core)
+	return args.Bool(0)
+}
+
+//nolint:golint
+func (f *StresserManagerMock) TrackCoreAlreadyStressed(core int, stresserPID int) {
+	f.Called(core, stresserPID)
+}
+
+//nolint:golint
+func (f *StresserManagerMock) StresserPIDs() map[int]int {
+	args := f.Called()
+	return args.Get(0).(map[int]int)
+}
+
+//nolint:golint
+func (f *StresserManagerMock) TrackInjectorCores(cgroup cgroup.Manager) (cpuset.CPUSet, error) {
+	args := f.Called(cgroup)
+	return args.Get(0).(cpuset.CPUSet), args.Error(1)
+}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The `injector` currently inspects each container cpuset to determine how many cores it should stress. 2 containers may have different subset of cores and we're supposed to stress all of the involved cores.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - Check that the new CPUSet which is created by appending all the cores from each container has the correct value
    - [x] locally.
    - [ ] as a canary deployment to a cluster.

---------------
some interesting local log lines
```
{"level":"info","ts":1666113867823.0247,"caller":"injector/cpu_pressure.go:161","message":"target identified to be running on 4 cores","disruptionName":"cpu-pressure","disruptionNamespace":"chaos-demo","targetName":"demo-curl-79bf7b74c9-tchgv","targetNodeName":"colima","cores":[0,1,2,3]}
{"level":"info","ts":1666113867823.0354,"caller":"injector/cpu_pressure.go:168","message":"changed GOMAXPROCS value from 4 to 4","disruptionName":"cpu-pressure","disruptionNamespace":"chaos-demo","targetName":"demo-curl-79bf7b74c9-tchgv","targetNodeName":"colima"}
{"level":"info","ts":1666113867905.8123,"caller":"injector/cpu_pressure.go:113","message":"all routines have been created successfully, now stressing","disruptionName":"cpu-pressure","disruptionNamespace":"chaos-demo","targetName":"demo-curl-79bf7b74c9-tchgv","targetNodeName":"colima","StresserPIDPerCore":{"0":10100,"1":10119,"2":10118,"3":10113}}

{"level":"info","ts":1666113867926.2175,"caller":"injector/cpu_pressure.go:161","message":"target identified to be running on 4 cores","disruptionName":"cpu-pressure","disruptionNamespace":"chaos-demo","targetName":"demo-curl-79bf7b74c9-tchgv","targetNodeName":"colima","cores":[0,1,2,3]}
{"level":"info","ts":1666113867926.2415,"caller":"injector/cpu_pressure.go:168","message":"changed GOMAXPROCS value from 4 to 4","disruptionName":"cpu-pressure","disruptionNamespace":"chaos-demo","targetName":"demo-curl-79bf7b74c9-tchgv","targetNodeName":"colima"}
{"level":"info","ts":1666113867926.2505,"caller":"injector/cpu_pressure.go:78","message":"core 0 is already stressed, skipping","disruptionName":"cpu-pressure","disruptionNamespace":"chaos-demo","targetName":"demo-curl-79bf7b74c9-tchgv","targetNodeName":"colima"}
{"level":"info","ts":1666113867926.2822,"caller":"injector/cpu_pressure.go:78","message":"core 1 is already stressed, skipping","disruptionName":"cpu-pressure","disruptionNamespace":"chaos-demo","targetName":"demo-curl-79bf7b74c9-tchgv","targetNodeName":"colima"}
{"level":"info","ts":1666113867926.3054,"caller":"injector/cpu_pressure.go:78","message":"core 2 is already stressed, skipping","disruptionName":"cpu-pressure","disruptionNamespace":"chaos-demo","targetName":"demo-curl-79bf7b74c9-tchgv","targetNodeName":"colima"}
{"level":"info","ts":1666113867926.3184,"caller":"injector/cpu_pressure.go:78","message":"core 3 is already stressed, skipping","disruptionName":"cpu-pressure","disruptionNamespace":"chaos-demo","targetName":"demo-curl-79bf7b74c9-tchgv","targetNodeName":"colima"}
```
