### PR TITLE
fix: change readiness event type to normal

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	chaosapi "github.com/DataDog/chaos-controller/api"
@@ -418,6 +419,16 @@ func (status *DisruptionStatus) RemoveTargets(toRemoveTargetsCount int) {
 		status.Targets[len(status.Targets)-1], status.Targets[index] = status.Targets[index], status.Targets[len(status.Targets)-1]
 		status.Targets = status.Targets[:len(status.Targets)-1]
 	}
+}
+
+// HasTarget returns true when a target exists in the Target List or returns false.
+func (status *DisruptionStatus) HasTarget(searchTarget string) bool {
+	for _, target := range status.Targets {
+		if strings.Compare(target, searchTarget) == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 var NonReinjectableDisruptions = map[chaostypes.DisruptionKindName]struct{}{

--- a/api/v1beta1/disruption_types_test.go
+++ b/api/v1beta1/disruption_types_test.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"github.com/DataDog/chaos-controller/api/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var disruptionStatus *v1beta1.DisruptionStatus
+
+var _ = Describe("Check if a target exist into DisruptionStatus targets list", func() {
+
+	BeforeEach(func() {
+		disruptionStatus = &v1beta1.DisruptionStatus{}
+	})
+
+	AfterEach(func() {
+		disruptionStatus = nil
+	})
+
+	Context("with an empty target", func() {
+		It("should return false", func() {
+			target := ""
+			Expect(disruptionStatus.HasTarget(target)).Should(BeFalse())
+		})
+	})
+
+	Context("with an existing target", func() {
+		It("should return true", func() {
+			disruptionStatus.Targets = append(disruptionStatus.Targets, "test-1")
+			Expect(disruptionStatus.HasTarget("test-1")).Should(BeTrue())
+		})
+	})
+
+	Context("with an non existing target", func() {
+		It("should return false", func() {
+			disruptionStatus.Targets = append(disruptionStatus.Targets, "test-1")
+			Expect(disruptionStatus.HasTarget("test-2")).Should(BeFalse())
+		})
+	})
+})

--- a/api/v1beta1/events.go
+++ b/api/v1beta1/events.go
@@ -36,10 +36,10 @@ const (
 	EventPodWarningState       string = "TargetPodInWarningState"
 	EventContainerWarningState string = "TargetPodContainersInWarningState"
 	EventLivenessProbeChange   string = "TargetPodLivenessProbe"
-	EventReadinessProbeChange  string = "TargetPodReadinessProbe"
 	EventTooManyRestarts       string = "TargetPodTooManyRestarts"
 	// Normal events
-	EventPodRecoveredState string = "RecoveredWarningStateInTargetPod"
+	EventPodRecoveredState    string = "RecoveredWarningStateInTargetPod"
+	EventReadinessProbeChange string = "TargetPodReadinessProbe"
 
 	// Targeted nodes related
 	// Warning events
@@ -94,7 +94,7 @@ var Events = map[string]DisruptionEvent{
 		Category:                       TargetEvent,
 	},
 	EventReadinessProbeChange: {
-		Type:                           corev1.EventTypeWarning,
+		Type:                           corev1.EventTypeNormal,
 		Reason:                         EventReadinessProbeChange,
 		OnDisruptionTemplateMessage:    "readiness probe on targeted pod %s are failing",
 		OnDisruptionTemplateAggMessage: "readiness probes on targeted pod(s) are failing",

--- a/controllers/cache_handler.go
+++ b/controllers/cache_handler.go
@@ -123,6 +123,12 @@ func (h DisruptionTargetWatcherHandler) OnChangeHandleNotifierSink(oldPod, newPo
 			eventType = corev1.EventTypeNormal
 		}
 
+		if eventReason == chaosv1beta1.EventReadinessProbeChange {
+			if h.disruption.Status.InjectionStatus == chaostypes.DisruptionInjectionStatusNotInjected || !h.disruption.Status.HasTarget(name) {
+				eventType = corev1.EventTypeWarning
+			}
+		}
+
 		// Send to updated target
 		h.reconciler.Recorder.Event(objectToNotify, eventType, eventReason, fmt.Sprintf(chaosv1beta1.Events[eventReason].OnTargetTemplateMessage, h.disruption.Name))
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:

- Change the event type of EventReadinessProbeChange to warning only if the disruption status has the DisruptionStatusNotInjected state or if the disruption is not already disrupted. The idea is to avoid spam user with warning alerts.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
