### PR TITLE
fix: change readiness event type to normal chaos-349

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -420,6 +420,17 @@ func (status *DisruptionStatus) RemoveTargets(toRemoveTargetsCount int) {
 	}
 }
 
+// HasTarget returns true when a target exists in the Target List or returns false.
+func (status *DisruptionStatus) HasTarget(searchTarget string) bool {
+	for _, target := range status.Targets {
+		if target == searchTarget {
+			return true
+		}
+	}
+
+	return false
+}
+
 var NonReinjectableDisruptions = map[chaostypes.DisruptionKindName]struct{}{
 	chaostypes.DisruptionKindGRPCDisruption: {},
 }

--- a/api/v1beta1/disruption_types_test.go
+++ b/api/v1beta1/disruption_types_test.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"github.com/DataDog/chaos-controller/api/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var disruptionStatus *v1beta1.DisruptionStatus
+
+var _ = Describe("Check if a target exist into DisruptionStatus targets list", func() {
+
+	BeforeEach(func() {
+		disruptionStatus = &v1beta1.DisruptionStatus{}
+	})
+
+	AfterEach(func() {
+		disruptionStatus = nil
+	})
+
+	Context("with an empty target", func() {
+		It("should return false", func() {
+			target := ""
+			Expect(disruptionStatus.HasTarget(target)).Should(BeFalse())
+		})
+	})
+
+	Context("with an existing target", func() {
+		It("should return true", func() {
+			disruptionStatus.Targets = append(disruptionStatus.Targets, "test-1")
+			Expect(disruptionStatus.HasTarget("test-1")).Should(BeTrue())
+		})
+	})
+
+	Context("with an non existing target", func() {
+		It("should return false", func() {
+			disruptionStatus.Targets = append(disruptionStatus.Targets, "test-1")
+			Expect(disruptionStatus.HasTarget("test-2")).Should(BeFalse())
+		})
+	})
+})

--- a/api/v1beta1/events.go
+++ b/api/v1beta1/events.go
@@ -33,13 +33,14 @@ type DisruptionEvent struct {
 const (
 	// Targeted pods related
 	// Warning events
-	EventPodWarningState       string = "TargetPodInWarningState"
-	EventContainerWarningState string = "TargetPodContainersInWarningState"
-	EventLivenessProbeChange   string = "TargetPodLivenessProbe"
-	EventReadinessProbeChange  string = "TargetPodReadinessProbe"
-	EventTooManyRestarts       string = "TargetPodTooManyRestarts"
+	EventPodWarningState                      string = "TargetPodInWarningState"
+	EventContainerWarningState                string = "TargetPodContainersInWarningState"
+	EventLivenessProbeChange                  string = "TargetPodLivenessProbe"
+	EventTooManyRestarts                      string = "TargetPodTooManyRestarts"
+	EventReadinessProbeChangeBeforeDisruption string = "EventReadinessProbeChangeBeforeDisruption"
 	// Normal events
-	EventPodRecoveredState string = "RecoveredWarningStateInTargetPod"
+	EventPodRecoveredState                    string = "RecoveredWarningStateInTargetPod"
+	EventReadinessProbeChangeDuringDisruption string = "EventReadinessProbeChangeDuringDisruption"
 
 	// Targeted nodes related
 	// Warning events
@@ -92,11 +93,17 @@ var Events = map[string]DisruptionEvent{
 		OnDisruptionTemplateAggMessage: "liveness probe(s) on targeted pod(s) are failing",
 		OnTargetTemplateMessage:        EventOnTargetTemplate + "liveness probes on pod are failing",
 		Category:                       TargetEvent,
-	},
-	EventReadinessProbeChange: {
+	}, EventReadinessProbeChangeDuringDisruption: {
+		Type:                           corev1.EventTypeNormal,
+		Reason:                         EventReadinessProbeChangeDuringDisruption,
+		OnDisruptionTemplateMessage:    "readiness probe on targeted pod %s is failing",
+		OnDisruptionTemplateAggMessage: "readiness probes on targeted pod(s) are failing",
+		OnTargetTemplateMessage:        EventOnTargetTemplate + "readiness probes on pod are failing",
+		Category:                       TargetEvent,
+	}, EventReadinessProbeChangeBeforeDisruption: {
 		Type:                           corev1.EventTypeWarning,
-		Reason:                         EventReadinessProbeChange,
-		OnDisruptionTemplateMessage:    "readiness probe on targeted pod %s are failing",
+		Reason:                         EventReadinessProbeChangeBeforeDisruption,
+		OnDisruptionTemplateMessage:    "readiness probe on targeted pod %s is failing",
 		OnDisruptionTemplateAggMessage: "readiness probes on targeted pod(s) are failing",
 		OnTargetTemplateMessage:        EventOnTargetTemplate + "readiness probes on pod are failing",
 		Category:                       TargetEvent,

--- a/controllers/cache_handler.go
+++ b/controllers/cache_handler.go
@@ -118,7 +118,8 @@ func (h DisruptionTargetWatcherHandler) OnChangeHandleNotifierSink(oldPod, newPo
 			continue
 		}
 
-		eventType := corev1.EventTypeWarning
+		eventType := chaosv1beta1.Events[eventReason].Type
+
 		if eventReason == chaosv1beta1.EventNodeRecoveredState || eventReason == chaosv1beta1.EventPodRecoveredState {
 			eventType = corev1.EventTypeNormal
 		}
@@ -226,7 +227,11 @@ func (h DisruptionTargetWatcherHandler) findNotifiableEvents(eventsToSend map[st
 					case strings.Contains(lowerCasedMessage, "liveness probe"):
 						eventsToSend[chaosv1beta1.EventLivenessProbeChange] = true
 					case strings.Contains(lowerCasedMessage, "readiness probe"):
-						eventsToSend[chaosv1beta1.EventReadinessProbeChange] = true
+						if h.disruption.Status.HasTarget(event.InvolvedObject.Name) {
+							eventsToSend[chaosv1beta1.EventReadinessProbeChangeDuringDisruption] = true
+						} else {
+							eventsToSend[chaosv1beta1.EventReadinessProbeChangeBeforeDisruption] = true
+						}
 					default:
 						eventsToSend[chaosv1beta1.EventPodWarningState] = true
 					}

--- a/controllers/cache_handler.go
+++ b/controllers/cache_handler.go
@@ -223,6 +223,8 @@ func (h DisruptionTargetWatcherHandler) findNotifiableEvents(eventsToSend map[st
 					case strings.Contains(lowerCasedMessage, "liveness probe"):
 						eventsToSend[chaosv1beta1.EventLivenessProbeChange] = true
 					case strings.Contains(lowerCasedMessage, "readiness probe"):
+						// If the object of the disruption is in the list of targets, it means it has been injected.
+						// The readiness probe is failing during the injection
 						if h.disruption.Status.HasTarget(event.InvolvedObject.Name) {
 							eventsToSend[chaosv1beta1.EventReadinessProbeChangeDuringDisruption] = true
 						} else {

--- a/controllers/cache_handler.go
+++ b/controllers/cache_handler.go
@@ -120,10 +120,6 @@ func (h DisruptionTargetWatcherHandler) OnChangeHandleNotifierSink(oldPod, newPo
 
 		eventType := chaosv1beta1.Events[eventReason].Type
 
-		if eventReason == chaosv1beta1.EventNodeRecoveredState || eventReason == chaosv1beta1.EventPodRecoveredState {
-			eventType = corev1.EventTypeNormal
-		}
-
 		// Send to updated target
 		h.reconciler.Recorder.Event(objectToNotify, eventType, eventReason, fmt.Sprintf(chaosv1beta1.Events[eventReason].OnTargetTemplateMessage, h.disruption.Name))
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:

- Replace the event **EventReadinessProbeChange** by two events :
  - **EventReadinessProbeChangeDuringDisruption** : Raised **during** a disruption with a **normal type**.
  - **EventReadinessProbeChangeBeforeDisruption** : Raised **before** a disruption with a **warning type**.

The idea is to avoid spamming users with warning alerts if a disruption is running.

![disruption-events(1)](https://user-images.githubusercontent.com/8859832/197241885-69828983-c3cb-4703-8745-e016318976cf.png)

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
