### PR TITLE
Fix disruption with onInit not working

### DIFF
--- a/injector/network_disruption_test.go
+++ b/injector/network_disruption_test.go
@@ -401,6 +401,10 @@ var _ = Describe("Failure", func() {
 				tc.AssertNotCalled(GinkgoT(), "AddPrio", []string{"lo", "eth0", "eth1"}, "1:4", uint32(2), uint32(2), mock.Anything)
 				tc.AssertNotCalled(GinkgoT(), "AddCgroupFilter", []string{"lo", "eth0", "eth1"}, "2:0", mock.Anything)
 			})
+
+			It("should apply tc filters to block traffic", func() {
+				tc.AssertCalled(GinkgoT(), "AddFilter", []string{"lo", "eth0", "eth1"}, "1:0", mock.Anything, "nil", "0.0.0.0/0", 0, 0, "tcp", "", "1:4")
+			})
 		})
 
 		Context("with allowed hosts", func() {


### PR DESCRIPTION

## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:

A bug was introduced where the onInit field would prevent from injecting: it would skip the chaos-handler container injection which means it would not inject at all as it was the only container targeted as it's the only container in a ready state at the beginning of the disruption (because the chaos-handler init container is there to prevent the actual targeted pod containers from running).

- Removing the condition doing this
- Adding a test to make sure a on init network disruption is injected
- Making small changes to have better error logs and make the code easier to read in the injection loop code

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `on init injection`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
