### PR TITLE
Remove wrongly push config in deploy

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -62,9 +62,6 @@ spec:
         - mountPath: /etc/chaos-controller
           name: config
           readOnly: true
-        - mountPath: /etc/chaos-controller/cloud-provider-cache
-          name: cloud-provider-cache
-          readOnly: false
       {{- if .Values.images.pullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.images.pullSecrets }}
@@ -78,5 +75,3 @@ spec:
       - name: config
         configMap:
           name: chaos-controller-config
-      - name: cloud-provider-cache
-        emptyDir: {}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- This change was introduced in the cloud managed disruption new feature but is not used anywhere and should be removed.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
