### PR TITLE
fix: normalize protocol case

### DIFF
--- a/network/protocol.go
+++ b/network/protocol.go
@@ -5,6 +5,8 @@
 
 package network
 
+import "strings"
+
 type Protocol string
 
 const (
@@ -12,3 +14,7 @@ const (
 	UDP Protocol = "udp"
 	ARP Protocol = "arp"
 )
+
+func (p Protocol) String() string {
+	return strings.ToLower(string(p))
+}

--- a/network/tc.go
+++ b/network/tc.go
@@ -204,11 +204,11 @@ func (t *tc) AddFilter(ifaces []string, parent string, handle uint32, srcIP, dst
 	var params, filterProtocol string
 
 	// match protocol if specified, default to tcp otherwise
-	switch protocol {
-	case TCP, UDP:
+	switch protocol.String() {
+	case TCP.String(), UDP.String():
 		filterProtocol = "ip"
-		params += fmt.Sprintf("ip_proto %s ", strings.ToLower(string(protocol)))
-	case ARP:
+		params += fmt.Sprintf("ip_proto %s ", protocol.String())
+	case ARP.String():
 		filterProtocol = "arp"
 	default:
 		return 0, fmt.Errorf("unexpected protocol: %s", protocol)

--- a/network/tc_test.go
+++ b/network/tc_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Tc", func() {
 		}
 		srcPort = 12345
 		dstPort = 80
-		protocol = TCP
+		protocol = "TCP"
 		connState = ConnStateNew
 		flowid = "1:2"
 	})


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- This PR aims to ensure protocol case is irrelevant for tc filters
- In particular, protocol coming from Kubernetes services is uppercase and should be allowed

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - [x] locally by targeting a service with TCP/UDP protocol defined
    - [ ] as a canary deployment to a cluster.
