### PR TITLE
Fix link to metrics documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Check out [Chaosli](./cli/chaosli/README.md) if you want some help understanding
 
 - [Examples](docs/features.md#disruption-examples)
 - [Design](docs/design.md)
-- [Metrics](docs/metrics.md)
+- [Metrics](docs/metrics_events.md)
 - [FAQ](docs/faq.md)
 - [Contributing](CONTRIBUTING.md)
 


### PR DESCRIPTION
Signed-off-by: Michael Beasley <michael.beasley@alvaria.com>

## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [x] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- This PR fixes the link to the metrics documentation in the repo's README

## Code Quality Checklist

- [N/A] The documentation is up to date.
- [N/A] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [N/A] I leveraged continuous integration testing
    - [N/A] by depending on existing `unit` tests or `end-to-end` tests.
    - [N/A] by adding new `unit` tests or `end-to-end` tests.
- [N/A] I manually tested the following steps:
    - `x`
    - [N/A] locally.
    - [N/A] as a canary deployment to a cluster.
