### PR TITLE
CHAOS-408: Allow for filtering the disruption targets based on off-level resources

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -43,11 +43,11 @@ type DisruptionSpec struct {
 	// +nullable
 	AdvancedSelector []metav1.LabelSelectorRequirement `json:"advancedSelector,omitempty"` // advanced label selector
 	// +nullable
-	SecondarySelector []metav1.LabelSelectorRequirement `json:"secondarySelector,omitempty""` // label selector for off-level resource
-	DryRun            bool                              `json:"dryRun,omitempty"`             // enable dry-run mode
-	OnInit            bool                              `json:"onInit,omitempty"`             // enable disruption on init
-	Unsafemode        *UnsafemodeSpec                   `json:"unsafeMode,omitempty"`         // unsafemode spec used to turn off safemode safety nets
-	StaticTargeting   bool                              `json:"staticTargeting,omitempty"`    // enable dynamic targeting and cluster observation
+	SecondarySelector []metav1.LabelSelectorRequirement `json:"secondarySelector,omitempty"` // label selector for off-level resource
+	DryRun            bool                              `json:"dryRun,omitempty"`            // enable dry-run mode
+	OnInit            bool                              `json:"onInit,omitempty"`            // enable disruption on init
+	Unsafemode        *UnsafemodeSpec                   `json:"unsafeMode,omitempty"`        // unsafemode spec used to turn off safemode safety nets
+	StaticTargeting   bool                              `json:"staticTargeting,omitempty"`   // enable dynamic targeting and cluster observation
 	// +nullable
 	Pulse    *DisruptionPulse   `json:"pulse,omitempty"`    // enable pulsing diruptions and specify the duration of the active state and the dormant state of the pulsing duration
 	Duration DisruptionDuration `json:"duration,omitempty"` // time from disruption creation until chaos pods are deleted and no more are created

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -42,10 +42,12 @@ type DisruptionSpec struct {
 	Selector labels.Set `json:"selector,omitempty"` // label selector
 	// +nullable
 	AdvancedSelector []metav1.LabelSelectorRequirement `json:"advancedSelector,omitempty"` // advanced label selector
-	DryRun           bool                              `json:"dryRun,omitempty"`           // enable dry-run mode
-	OnInit           bool                              `json:"onInit,omitempty"`           // enable disruption on init
-	Unsafemode       *UnsafemodeSpec                   `json:"unsafeMode,omitempty"`       // unsafemode spec used to turn off safemode safety nets
-	StaticTargeting  bool                              `json:"staticTargeting,omitempty"`  // enable dynamic targeting and cluster observation
+	// +nullable
+	SecondarySelector []metav1.LabelSelectorRequirement `json:"secondarySelector,omitempty""` // label selector for off-level resource
+	DryRun            bool                              `json:"dryRun,omitempty"`             // enable dry-run mode
+	OnInit            bool                              `json:"onInit,omitempty"`             // enable disruption on init
+	Unsafemode        *UnsafemodeSpec                   `json:"unsafeMode,omitempty"`         // unsafemode spec used to turn off safemode safety nets
+	StaticTargeting   bool                              `json:"staticTargeting,omitempty"`    // enable dynamic targeting and cluster observation
 	// +nullable
 	Pulse    *DisruptionPulse   `json:"pulse,omitempty"`    // enable pulsing diruptions and specify the duration of the active state and the dormant state of the pulsing duration
 	Duration DisruptionDuration `json:"duration,omitempty"` // time from disruption creation until chaos pods are deleted and no more are created

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -283,6 +283,13 @@ func (in *DisruptionSpec) DeepCopyInto(out *DisruptionSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.SecondarySelector != nil {
+		in, out := &in.SecondarySelector, &out.SecondarySelector
+		*out = make([]v1.LabelSelectorRequirement, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Unsafemode != nil {
 		in, out := &in.Unsafemode, &out.Unsafemode
 		*out = new(UnsafemodeSpec)

--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -451,6 +451,34 @@ spec:
                     pattern: (^[a-z0-9-_]+$)|(^C[A-Z0-9]+$)
                     type: string
                 type: object
+              secondarySelector:
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                nullable: true
+                type: array
               selector:
                 additionalProperties:
                   type: string

--- a/controllers/cache_handler.go
+++ b/controllers/cache_handler.go
@@ -470,7 +470,7 @@ func (r *DisruptionReconciler) manageInstanceSelectorCache(instance *chaosv1beta
 	}
 
 	disCacheHash := disNamespacedName.String() + disSpecHash
-	disCompleteSelector, err := targetselector.GetLabelSelectorFromInstance(instance)
+	disCompleteSelector, _, err := targetselector.GetLabelSelectorsFromInstance(instance)
 
 	if err != nil {
 		return fmt.Errorf("error getting instance selector: %w", err)

--- a/targetselector/running_target_selector.go
+++ b/targetselector/running_target_selector.go
@@ -103,7 +103,7 @@ func (r runningTargetSelector) GetMatchingPodsOverTotalPods(c client.Client, ins
 		}
 	}
 
-	if secondarySelector != nil {
+	if instance.Spec.SecondarySelector != nil {
 		prunedRunningPods := &corev1.PodList{}
 		nodes := &corev1.NodeList{}
 		nodeNames := []string{}
@@ -178,7 +178,7 @@ func (r runningTargetSelector) GetMatchingNodesOverTotalNodes(c client.Client, i
 		}
 	}
 
-	if secondarySelector != nil {
+	if instance.Spec.SecondarySelector != nil {
 		prunedRunningNodes := &corev1.NodeList{}
 		pods := &corev1.PodList{}
 		podNodeNames := []string{}

--- a/targetselector/running_target_selector.go
+++ b/targetselector/running_target_selector.go
@@ -106,7 +106,8 @@ func (r runningTargetSelector) GetMatchingPodsOverTotalPods(c client.Client, ins
 	if secondarySelector != nil {
 		prunedRunningPods := &corev1.PodList{}
 		nodes := &corev1.NodeList{}
-		var nodeNames []string
+		nodeNames := []string{}
+
 		listOptions = &client.ListOptions{
 			LabelSelector: secondarySelector,
 		}
@@ -125,6 +126,7 @@ func (r runningTargetSelector) GetMatchingPodsOverTotalPods(c client.Client, ins
 				prunedRunningPods.Items = append(prunedRunningPods.Items, pod)
 			}
 		}
+
 		runningPods = prunedRunningPods
 	}
 
@@ -179,7 +181,8 @@ func (r runningTargetSelector) GetMatchingNodesOverTotalNodes(c client.Client, i
 	if secondarySelector != nil {
 		prunedRunningNodes := &corev1.NodeList{}
 		pods := &corev1.PodList{}
-		var podNodeNames []string
+		podNodeNames := []string{}
+
 		listOptions = &client.ListOptions{
 			LabelSelector: secondarySelector,
 		}
@@ -198,6 +201,7 @@ func (r runningTargetSelector) GetMatchingNodesOverTotalNodes(c client.Client, i
 				prunedRunningNodes.Items = append(prunedRunningNodes.Items, node)
 			}
 		}
+
 		runningNodes = prunedRunningNodes
 	}
 

--- a/targetselector/running_target_selector.go
+++ b/targetselector/running_target_selector.go
@@ -278,7 +278,7 @@ func GetLabelSelectorsFromInstance(instance *chaosv1beta1.Disruption) (labels.Se
 	// add advanced selectors
 	if instance.Spec.AdvancedSelector != nil {
 		for _, req := range instance.Spec.AdvancedSelector {
-			parsedReq, err := advancedSelectorToSelector(req)
+			parsedReq, err := advancedSelectorToRequirement(req)
 			if err != nil {
 				return nil, nil, fmt.Errorf("error parsing given advanced selector to requirements: %w", err)
 			}
@@ -301,7 +301,7 @@ func GetLabelSelectorsFromInstance(instance *chaosv1beta1.Disruption) (labels.Se
 	if instance.Spec.SecondarySelector != nil {
 		for _, s := range instance.Spec.SecondarySelector {
 			// generate and add the requirement to the selector
-			parsedReq, err := advancedSelectorToSelector(s)
+			parsedReq, err := advancedSelectorToRequirement(s)
 			if err != nil {
 				return nil, nil, fmt.Errorf("error parsing given advanced selector to requirements: %w", err)
 			}
@@ -313,7 +313,7 @@ func GetLabelSelectorsFromInstance(instance *chaosv1beta1.Disruption) (labels.Se
 	return selector, secondarySelector, nil
 }
 
-func advancedSelectorToSelector(req metav1.LabelSelectorRequirement) (*labels.Requirement, error) {
+func advancedSelectorToRequirement(req metav1.LabelSelectorRequirement) (*labels.Requirement, error) {
 	var op selection.Operator
 
 	// parse the operator to convert it from one package to another

--- a/targetselector/target_selector.go
+++ b/targetselector/target_selector.go
@@ -15,7 +15,7 @@ import (
 type TargetSelector interface {
 	// GetMatchingPodsOverTotalPods Returns list of matching ready and untargeted pods and number of total pods
 	GetMatchingPodsOverTotalPods(c client.Client, instance *chaosv1beta1.Disruption) (*corev1.PodList, int, error)
-	// GetMatchingPodsOverTotalPods Returns list of matching ready and untargeted nodes and number of total nodes
+	// GetMatchingNodesOverTotalNodes Returns list of matching ready and untargeted nodes and number of total nodes
 	GetMatchingNodesOverTotalNodes(c client.Client, instance *chaosv1beta1.Disruption) (*corev1.NodeList, int, error)
 	TargetIsHealthy(target string, c client.Client, instance *chaosv1beta1.Disruption) error
 }


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- I have yet to write up docs, but I'd like to get feedback on the approach
- We have some users that want to run disruptions but need to filter their targets based on both pod and node level labels. We have no way to do that within the disruption yaml at this time, even though it is feasible. It's also quite inconvenient to manually do ahead of time. 
  - The idea is, whenever we get a list of filtered pods|nodes, we then use a secondary set of label selectors to filter for the "off-level" resource (other terms welcome). We then union the lists.
  -  For a pod level disruption, this means we will disrupt pods who match the primary selector, iff those pods are running on nodes that match our secondary selector
  - For a node level disruption, this means we will disrupt nodes who match the secondary selector, iff those nodes have pods running on them that match our secondary selector
- I chose to use the generic term "secondarySelector", to avoid having multiple new yaml fields

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
