### PR TITLE
Allow to configure cloud providers for network disruptions

### DIFF
--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -123,7 +123,7 @@ func (r *Disruption) ValidateCreate() error {
 
 				ipRangesPerService, err := cloudServicesProvidersManager.GetServicesIPRanges(cloudtypes.CloudProviderName(cloudName), serviceListNames)
 				if err != nil {
-					return fmt.Errorf("%s. Available services are: %s", err.Error(), strings.Join(cloudServicesProvidersManager.GetServiceList(cloudtypes.CloudProviderName(cloudName)), ", "))
+					return err
 				}
 
 				for _, ipRanges := range ipRangesPerService {

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -35,7 +35,17 @@ data:
         datadog:
           enabled: {{ .Values.controller.notifiers.datadog.enabled }}
       cloudProviders:
-        pullInterval: 24h
+        disableAll: {{ .Values.controller.cloudProviders.disableAll }}
+        pullInterval: {{ .Values.controller.cloudProviders.pullInterval }}
+        aws:
+          enabled: {{ .Values.controller.cloudProviders.aws.enabled }}
+          ipRangesURL: {{ .Values.controller.cloudProviders.aws.ipRangesURL }}
+        gcp:
+          enabled: {{ .Values.controller.cloudProviders.gcp.enabled }}
+          ipRangesURL: {{ .Values.controller.cloudProviders.gcp.ipRangesURL }}
+        datadog:
+          enabled: {{ .Values.controller.cloudProviders.datadog.enabled }}
+          ipRangesURL: {{ .Values.controller.cloudProviders.datadog.ipRangesURL }}
       deleteOnly: {{ .Values.controller.deleteOnly }}
       imagePullSecrets: {{ .Values.images.pullSecrets }}
       defaultDuration: {{ .Values.controller.defaultDuration }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -32,8 +32,18 @@ controller:
       url: ""
       headersFilepath: ""
       headers: []
-  cloudProviders:
-    pullInterval: 1h
+  cloudProviders: # cloud providers specific disruptions configuration
+    disableAll: false # disable all cloud providers disruption, it overrides per cloud provider configuration (you can't disable all + enable one)
+    pullInterval: 24h # pull interval used by the controller to update ip ranges files
+    aws: # aws cloud provider config
+      enabled: true # enable the provider
+      ipRangesURL: "https://ip-ranges.amazonaws.com/ip-ranges.json" # URL to the IP ranges file (format must be the expected one, defaults is the public file provided by the cloud provider)
+    gcp: # gcp cloud provider config
+      enabled: true # enable the provider
+      ipRangesURL: "https://www.gstatic.com/ipranges/goog.json" # URL to the IP ranges file (format must be the expected one, defaults is the public file provided by the cloud provider)
+    datadog: # datadog cloud provider config
+      enabled: true # enable the provider
+      ipRangesURL: "https://ip-ranges.datadoghq.com/" # URL to the IP ranges file (format must be the expected one, defaults is the public file provided by the cloud provider)
   defaultDuration: 1h # default spec.duration for a disruption with none specified
   expiredDisruptionGCDelay: 10m # time after a disruption expires before deleting it
   userInfoHook: true

--- a/cloudservice/types/types.go
+++ b/cloudservice/types/types.go
@@ -5,12 +5,18 @@
 
 package types
 
+import "time"
+
 type CloudProviderName string
 
 const (
 	CloudProviderDatadog CloudProviderName = "Datadog"
 	CloudProviderGCP     CloudProviderName = "GCP"
 	CloudProviderAWS     CloudProviderName = "AWS"
+)
+
+var (
+	AllCloudProviders = []CloudProviderName{CloudProviderAWS, CloudProviderGCP, CloudProviderDatadog}
 )
 
 // CloudProviderIPRangeInfo information related to the ip ranges pulled from a cloud provider
@@ -22,10 +28,15 @@ type CloudProviderIPRangeInfo struct {
 
 // CloudProviderConfig Single configuration for any cloud provider
 type CloudProviderConfig struct {
-	IPRangesURL string `json:"iprangesurl"`
+	Enabled     bool   `json:"enabled"`
+	IPRangesURL string `json:"ipRangesURL"`
 }
 
 // CloudProviderConfigs all cloud provider configurations for the manager
 type CloudProviderConfigs struct {
-	PullInterval string `json:"pullinterval"`
+	DisableAll   bool                `json:"disableAll"`
+	PullInterval time.Duration       `json:"pullinterval"`
+	AWS          CloudProviderConfig `json:"aws"`
+	GCP          CloudProviderConfig `json:"gcp"`
+	Datadog      CloudProviderConfig `json:"datadog"`
 }

--- a/cloudservice/types/types.go
+++ b/cloudservice/types/types.go
@@ -35,7 +35,7 @@ type CloudProviderConfig struct {
 // CloudProviderConfigs all cloud provider configurations for the manager
 type CloudProviderConfigs struct {
 	DisableAll   bool                `json:"disableAll"`
-	PullInterval time.Duration       `json:"pullinterval"`
+	PullInterval time.Duration       `json:"pullInterval"`
 	AWS          CloudProviderConfig `json:"aws"`
 	GCP          CloudProviderConfig `json:"gcp"`
 	Datadog      CloudProviderConfig `json:"datadog"`

--- a/docs/network_disruption/cloud-managed-services.md
+++ b/docs/network_disruption/cloud-managed-services.md
@@ -11,11 +11,21 @@ Available providers are:
 
 ### Cloud Provider Manager
 
-The service will pull and parse the IP Ranges from the available cloud providers every x minutes/hours, defined in the chaos-controller configuration:
+The manager handles regular IP ranges files pulls to refresh the file content on enabled providers. The chart contains the default public URL for each cloud provider but it can be customized if needed. You can also disable some providers or all of them in case you want to disable the feature. Please note that if you specify a custom URL, the file must match the same format as the public one to be loaded successfully, otherwise the controller will crash.
 
 ```
 cloudProviders:
+    disableAll: false
     pullInterval: "24h"
+    aws:
+      enabled: true
+      ipRangesURL: "https://ip-ranges.amazonaws.com/ip-ranges.json"
+    gcp:
+      enabled: true
+      ipRangesURL: "https://www.gstatic.com/ipranges/goog.json"
+    datadog:
+      enabled: true
+      ipRangesURL: "https://ip-ranges.datadoghq.com/"
 ```
 
 On the creation of the chaos pod, the chaos-controller will then use those ip ranges for the Network Disruption and transform it into a Host Network Disruption.

--- a/main.go
+++ b/main.go
@@ -249,8 +249,29 @@ func main() {
 		"Threshold which safemode checks against to see if the number of targets is over safety measures within a cluster")
 	handleFatalError(viper.BindPFlag("controller.safemode.clusterThreshold", pflag.Lookup("safemode-cluster-threshold")))
 
-	pflag.StringVar(&cfg.Controller.CloudProviders.PullInterval, "cloud-providers-pull-interval", "24h", "Interval of time to pull the ip ranges of all cloud providers' services (default to 1 day)")
+	pflag.BoolVar(&cfg.Controller.CloudProviders.DisableAll, "cloud-providers-disable-all", false, "Disable all cloud providers disruptions (defaults to false, overrides all individual cloud providers configuration)")
+	handleFatalError(viper.BindPFlag("controller.cloudProviders.disableAll", pflag.Lookup("cloud-providers-disable-all")))
+
+	pflag.DurationVar(&cfg.Controller.CloudProviders.PullInterval, "cloud-providers-pull-interval", 24*time.Hour, "Interval of time to pull the ip ranges of all cloud providers' services (defaults to 1 day)")
 	handleFatalError(viper.BindPFlag("controller.cloudProviders.pullinterval", pflag.Lookup("cloud-providers-pull-interval")))
+
+	pflag.BoolVar(&cfg.Controller.CloudProviders.AWS.Enabled, "cloud-providers-aws-enabled", true, "Enable AWS cloud provider disruptions (defaults to true, is overridden by --cloud-providers-disable-all)")
+	handleFatalError(viper.BindPFlag("controller.cloudProviders.aws.enabled", pflag.Lookup("cloud-providers-aws-enabled")))
+
+	pflag.StringVar(&cfg.Controller.CloudProviders.AWS.IPRangesURL, "cloud-providers-aws-iprangesurl", "", "Configure the cloud provider URL to the IP ranges file used by the disruption")
+	handleFatalError(viper.BindPFlag("controller.cloudProviders.aws.ipRangesURL", pflag.Lookup("cloud-providers-aws-iprangesurl")))
+
+	pflag.BoolVar(&cfg.Controller.CloudProviders.GCP.Enabled, "cloud-providers-gcp-enabled", true, "Enable GCP cloud provider disruptions (defaults to true, is overridden by --cloud-providers-disable-all)")
+	handleFatalError(viper.BindPFlag("controller.cloudProviders.gcp.enabled", pflag.Lookup("cloud-providers-gcp-enabled")))
+
+	pflag.StringVar(&cfg.Controller.CloudProviders.GCP.IPRangesURL, "cloud-providers-gcp-iprangesurl", "", "Configure the cloud provider URL to the IP ranges file used by the disruption")
+	handleFatalError(viper.BindPFlag("controller.cloudProviders.gcp.ipRangesURL", pflag.Lookup("cloud-providers-gcp-iprangesurl")))
+
+	pflag.BoolVar(&cfg.Controller.CloudProviders.Datadog.Enabled, "cloud-providers-datadog-enabled", true, "Enable Datadog cloud provider disruptions (defaults to true, is overridden by --cloud-providers-disable-all)")
+	handleFatalError(viper.BindPFlag("controller.cloudProviders.datadog.enabled", pflag.Lookup("cloud-providers-datadog-enabled")))
+
+	pflag.StringVar(&cfg.Controller.CloudProviders.Datadog.IPRangesURL, "cloud-providers-datadog-iprangesurl", "", "Configure the cloud provider URL to the IP ranges file used by the disruption")
+	handleFatalError(viper.BindPFlag("controller.cloudProviders.datadog.ipRangesURL", pflag.Lookup("cloud-providers-datadog-iprangesurl")))
 
 	pflag.Parse()
 
@@ -341,6 +362,7 @@ func main() {
 		gcPtr = &cfg.Controller.ExpiredDisruptionGCDelay
 	}
 
+	// initialize the cloud provider manager which will handle ip ranges files updates
 	cloudProviderManager, err := cloudservice.New(logger, cfg.Controller.CloudProviders)
 	if err != nil {
 		handleFatalError(fmt.Errorf("error initializing CloudProviderManager: %s", err.Error()))


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Fixes #622 
- Allow to enable or disable cloud providers in the network disruptions
- Allow to configure a custom URL for cloud providers IP ranges file

Errors sent by the admission webhook are adapted so disruptions using a disabled provider will be rejected with the appropriate message.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
