### PR TITLE
Use Eventually when waiting for event

### DIFF
--- a/controllers/cache_handler_test.go
+++ b/controllers/cache_handler_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Cache Handler verifications", func() {
 
 			By("ensuring created event was fired")
 			event := findEvent(disruption.CreationTimestamp.Time, v1beta1.Events[v1beta1.EventDisrupted], eventList.Items, targetPodA.Name)
-			Expect(event).ToNot(BeNil())
+			Eventually(event).ShouldNot(BeNil())
 
 			By("ensuring container target in warning state event was not fired")
 			event = findEvent(disruption.CreationTimestamp.Time, v1beta1.Events[v1beta1.EventContainerWarningState], eventList.Items, targetPodA.Name)

--- a/controllers/cache_handler_test.go
+++ b/controllers/cache_handler_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Cache Handler verifications", func() {
 			By("ensuring created event was fired")
 			Eventually(func(g Gomega) {
 				event := findEvent(disruption.CreationTimestamp.Time, v1beta1.Events[v1beta1.EventDisrupted], eventList.Items, targetPodA.Name)
-				Expect(event).ShouldNot(BeNil())
+				g.Expect(event).ShouldNot(BeNil())
 			}).Should(Succeed())
 
 			By("ensuring container target in warning state event was not fired")

--- a/controllers/cache_handler_test.go
+++ b/controllers/cache_handler_test.go
@@ -138,11 +138,13 @@ var _ = Describe("Cache Handler verifications", func() {
 			Expect(err).To(BeNil())
 
 			By("ensuring created event was fired")
-			event := findEvent(disruption.CreationTimestamp.Time, v1beta1.Events[v1beta1.EventDisrupted], eventList.Items, targetPodA.Name)
-			Eventually(event).ShouldNot(BeNil())
+			Eventually(func(g Gomega) {
+				event := findEvent(disruption.CreationTimestamp.Time, v1beta1.Events[v1beta1.EventDisrupted], eventList.Items, targetPodA.Name)
+				Expect(event).ShouldNot(BeNil())
+			}).Should(Succeed())
 
 			By("ensuring container target in warning state event was not fired")
-			event = findEvent(disruption.CreationTimestamp.Time, v1beta1.Events[v1beta1.EventContainerWarningState], eventList.Items, targetPodA.Name)
+			event := findEvent(disruption.CreationTimestamp.Time, v1beta1.Events[v1beta1.EventContainerWarningState], eventList.Items, targetPodA.Name)
 			Expect(event).To(BeNil())
 		})
 	})


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- I've seen this test fail intermittently in CI these past few days. It seems very safe to wait on the event being emitted with an Eventually, rather than synchronously checking once

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
