### PR TITLE
Refactor cgroup.Read and cgroup.Write

### DIFF
--- a/cgroup/cgroup.go
+++ b/cgroup/cgroup.go
@@ -62,10 +62,10 @@ func (m cgroup) generatePath(kind string) (string, error) {
 }
 
 // Read reads the given cgroup file data and returns the content as a string
-func (m cgroup) Read(kind, file string) (string, error) {
+func (m cgroup) Read(controller, file string) (string, error) {
 	manager := *m.manager
-	kindPath := manager.Path(kind)
-	content, err := cgroups.ReadFile(kindPath, file)
+	controllerDir := manager.Path(controller)
+	content, err := cgroups.ReadFile(controllerDir, file)
 
 	if err != nil {
 		return "", err
@@ -75,11 +75,11 @@ func (m cgroup) Read(kind, file string) (string, error) {
 }
 
 // Write writes the given data to the given cgroup kind
-func (m cgroup) Write(kind, file, data string) error {
+func (m cgroup) Write(controller, file, data string) error {
 	manager := *m.manager
-	kindPath := manager.Path(kind)
+	controllerDir := manager.Path(controller)
 
-	return cgroups.WriteFile(kindPath, file, data)
+	return cgroups.WriteFile(controllerDir, file, data)
 }
 
 // Exists returns true if the given cgroup exists, false otherwise

--- a/cgroup/cgroup_manager.go
+++ b/cgroup/cgroup_manager.go
@@ -16,8 +16,8 @@ import (
 // Manager represents a cgroup manager able to join the given cgroup
 type Manager interface {
 	Join(kind string, pid int, inherit bool) error
-	Read(kind, file string) (string, error)
-	Write(kind, file, data string) error
+	Read(controller, file string) (string, error)
+	Write(controller, file, data string) error
 	Exists(kind string) (bool, error)
 	DiskThrottleRead(identifier, bps int) error
 	DiskThrottleWrite(identifier, bps int) error

--- a/cgroup/cgroup_v2.go
+++ b/cgroup/cgroup_v2.go
@@ -19,12 +19,12 @@ type cgroupV2 struct {
 }
 
 // Read reads the given cgroup file data and returns the content as a string
-func (m cgroupV2) Read(kind, file string) (string, error) {
+func (m cgroupV2) Read(controller, file string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
 // Write writes the given data to the given cgroup kind
-func (m cgroupV2) Write(kind, file, data string) error {
+func (m cgroupV2) Write(controller, file, data string) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/cgroup/mocks/Manager.go
+++ b/cgroup/mocks/Manager.go
@@ -90,19 +90,19 @@ func (_m *ManagerMock) Join(kind string, pid int, inherit bool) error {
 }
 
 // Read provides a mock function with given fields: kind, file
-func (_m *ManagerMock) Read(kind string, file string) (string, error) {
-	ret := _m.Called(kind, file)
+func (_m *ManagerMock) Read(controller string, file string) (string, error) {
+	ret := _m.Called(controller, file)
 
 	var r0 string
 	if rf, ok := ret.Get(0).(func(string, string) string); ok {
-		r0 = rf(kind, file)
+		r0 = rf(controller, file)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(kind, file)
+		r1 = rf(controller, file)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -111,12 +111,12 @@ func (_m *ManagerMock) Read(kind string, file string) (string, error) {
 }
 
 // Write provides a mock function with given fields: kind, file, data
-func (_m *ManagerMock) Write(kind string, file string, data string) error {
-	ret := _m.Called(kind, file, data)
+func (_m *ManagerMock) Write(controller string, file string, data string) error {
+	ret := _m.Called(controller, file, data)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
-		r0 = rf(kind, file, data)
+		r0 = rf(controller, file, data)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Purely refactor custom io implementation to use libcontainer Cgroups package.
- I'm slowly moving each public method to reduce broken features. If broken, it will be easier to revert. Next PRs will take care of Exist(), Join(), DiskThrottleRead(), DiskThrottleWrite() correspondingly

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
