### PR TITLE
Adding Format method to the Network Disruption

### DIFF
--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -252,9 +252,15 @@ func (s *NetworkDisruptionSpec) Format() string {
 
 	if s.Cloud != nil {
 		services := []NetworkDisruptionCloudServiceSpec{}
-		services = append(services, *s.Cloud.AWSServiceList...)
-		services = append(services, *s.Cloud.DatadogServiceList...)
-		services = append(services, *s.Cloud.GCPServiceList...)
+		if s.Cloud.AWSServiceList != nil {
+			services = append(services, *s.Cloud.AWSServiceList...)
+		}
+		if s.Cloud.DatadogServiceList != nil {
+			services = append(services, *s.Cloud.DatadogServiceList...)
+		}
+		if s.Cloud.GCPServiceList != nil {
+			services = append(services, *s.Cloud.GCPServiceList...)
+		}
 
 		for _, service := range services {
 			descr := ""

--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -193,7 +193,7 @@ func (s *NetworkDisruptionSpec) GenerateArgs() []string {
 // Format describe a NetworkDisruptionSpec
 func (s *NetworkDisruptionSpec) Format() string {
 	networkVerbs := []string{}
-	addOfWord := false
+	addOfWord := false // know whether or not we should suffix the verbs with a "of" word. example: delaying of 100ms the traffic vs dropping 100% of the traffic
 
 	if s.Delay != 0 {
 		networkVerbs = append(networkVerbs, fmt.Sprintf("delaying of %dms", s.Delay))
@@ -201,16 +201,19 @@ func (s *NetworkDisruptionSpec) Format() string {
 
 	if s.Drop != 0 {
 		addOfWord = true
+
 		networkVerbs = append(networkVerbs, fmt.Sprintf("dropping %d%%", s.Drop))
 	}
 
 	if s.Duplicate != 0 {
 		addOfWord = true
+
 		networkVerbs = append(networkVerbs, fmt.Sprintf("duplicating %d%%", s.Duplicate))
 	}
 
 	if s.Corrupt != 0 {
 		addOfWord = true
+
 		networkVerbs = append(networkVerbs, fmt.Sprintf("corrupting %d%%", s.Corrupt))
 	}
 
@@ -232,6 +235,7 @@ func (s *NetworkDisruptionSpec) Format() string {
 
 	filterDescriptions := []string{}
 
+	// Add host to description
 	for _, host := range s.Hosts {
 		descr := ""
 
@@ -253,10 +257,12 @@ func (s *NetworkDisruptionSpec) Format() string {
 		filterDescriptions = append(filterDescriptions, descr)
 	}
 
+	// Add services to description
 	for _, service := range s.Services {
 		filterDescriptions = append(filterDescriptions, fmt.Sprintf(" going to %s/%s", service.Name, service.Namespace))
 	}
 
+	// Add cloud services to description
 	if s.Cloud != nil {
 		services := []NetworkDisruptionCloudServiceSpec{}
 
@@ -293,6 +299,7 @@ func (s *NetworkDisruptionSpec) Format() string {
 
 	networkDescription += strings.Join(filterDescriptions[:len(filterDescriptions)-1], ",")
 
+	// Last filter uses and instead of a comma
 	if len(filterDescriptions) > 1 {
 		networkDescription += " and"
 	}

--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -250,6 +250,7 @@ func (s *NetworkDisruptionSpec) Format() string {
 		if host.Port != 0 {
 			descr += fmt.Sprintf(":%d", host.Port)
 		}
+
 		if host.Protocol != "" {
 			descr += fmt.Sprintf(" with protocol %s", host.Protocol)
 		}

--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -215,7 +215,7 @@ func (s *NetworkDisruptionSpec) Format() string {
 		return ""
 	}
 
-	networkDescription := strings.Join(networkVerbs, ", ")
+	networkDescription := "Network disruption " + strings.Join(networkVerbs, ", ")
 	if addOfWord {
 		networkDescription += " of"
 	}

--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -198,14 +198,17 @@ func (s *NetworkDisruptionSpec) Format() string {
 	if s.Delay != 0 {
 		networkVerbs = append(networkVerbs, fmt.Sprintf("delaying of %dms", s.Delay))
 	}
+
 	if s.Drop != 0 {
 		addOfWord = true
 		networkVerbs = append(networkVerbs, fmt.Sprintf("dropping %d%%", s.Drop))
 	}
+
 	if s.Duplicate != 0 {
 		addOfWord = true
 		networkVerbs = append(networkVerbs, fmt.Sprintf("duplicating %d%%", s.Duplicate))
 	}
+
 	if s.Corrupt != 0 {
 		addOfWord = true
 		networkVerbs = append(networkVerbs, fmt.Sprintf("corrupting %d%%", s.Corrupt))
@@ -216,9 +219,11 @@ func (s *NetworkDisruptionSpec) Format() string {
 	}
 
 	networkDescription := "Network disruption " + strings.Join(networkVerbs, ", ")
+
 	if addOfWord {
 		networkDescription += " of"
 	}
+
 	networkDescription += " the traffic"
 
 	if s.DelayJitter != 0 {
@@ -229,6 +234,7 @@ func (s *NetworkDisruptionSpec) Format() string {
 
 	for _, host := range s.Hosts {
 		descr := ""
+
 		if host.Flow == FlowIngress {
 			descr += " coming from "
 		} else {
@@ -236,6 +242,7 @@ func (s *NetworkDisruptionSpec) Format() string {
 		}
 
 		descr += host.Host
+
 		if host.Port != 0 {
 			descr += fmt.Sprintf(":%d", host.Port)
 		}
@@ -252,18 +259,22 @@ func (s *NetworkDisruptionSpec) Format() string {
 
 	if s.Cloud != nil {
 		services := []NetworkDisruptionCloudServiceSpec{}
+
 		if s.Cloud.AWSServiceList != nil {
 			services = append(services, *s.Cloud.AWSServiceList...)
 		}
+
 		if s.Cloud.DatadogServiceList != nil {
 			services = append(services, *s.Cloud.DatadogServiceList...)
 		}
+
 		if s.Cloud.GCPServiceList != nil {
 			services = append(services, *s.Cloud.GCPServiceList...)
 		}
 
 		for _, service := range services {
 			descr := ""
+
 			if service.Flow == FlowIngress {
 				descr += " coming from "
 			} else {
@@ -271,6 +282,7 @@ func (s *NetworkDisruptionSpec) Format() string {
 			}
 
 			descr += service.ServiceName
+
 			if service.Protocol != "" {
 				descr += fmt.Sprintf(" with protocol %s", service.Protocol)
 			}
@@ -286,6 +298,7 @@ func (s *NetworkDisruptionSpec) Format() string {
 	}
 
 	networkDescription += filterDescriptions[len(filterDescriptions)-1]
+
 	return networkDescription
 }
 

--- a/api/v1beta1/network_disruption_test.go
+++ b/api/v1beta1/network_disruption_test.go
@@ -1,0 +1,133 @@
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NetworkDisruption Format test", func() {
+	When("NetworkDisruption has filters", func() {
+		It("expects good formatting for multiple hosts", func() {
+			disruptionSpec := NetworkDisruptionSpec{
+				Hosts: []NetworkDisruptionHostSpec{
+					{
+						Host: "1.2.3.4",
+						Port: 9000,
+					},
+					{
+						Host: "2.2.3.4",
+						Port: 8000,
+						Flow: "ingress",
+					},
+				},
+				Drop: 100,
+			}
+
+			expected := "Network disruption dropping 100% of the traffic going to 1.2.3.4:9000 and coming from 2.2.3.4:8000"
+			result := disruptionSpec.Format()
+
+			Expect(result).To(Equal(expected))
+		})
+
+		It("expects good formatting for multiple services", func() {
+			disruptionSpec := NetworkDisruptionSpec{
+				Services: []NetworkDisruptionServiceSpec{
+					{
+						Name:      "demo-service",
+						Namespace: "demo-namespace",
+					},
+					{
+						Name:      "demo-worker",
+						Namespace: "demo-namespace",
+					},
+				},
+				Corrupt: 100,
+			}
+
+			expected := "Network disruption corrupting 100% of the traffic going to demo-service/demo-namespace and going to demo-worker/demo-namespace"
+			result := disruptionSpec.Format()
+
+			Expect(result).To(Equal(expected))
+		})
+
+		It("expects good formatting for cloud network disruption", func() {
+			disruptionSpec := NetworkDisruptionSpec{
+				Cloud: &NetworkDisruptionCloudSpec{
+					AWSServiceList: &[]NetworkDisruptionCloudServiceSpec{
+						{
+							ServiceName: "S3",
+						},
+					},
+					DatadogServiceList: &[]NetworkDisruptionCloudServiceSpec{
+						{
+							ServiceName: "synthetics",
+						},
+					},
+				},
+				Delay:       100,
+				DelayJitter: 50,
+			}
+
+			expected := "Network disruption delaying of 100ms the traffic with 50ms of delay jitter going to S3 and going to synthetics"
+			result := disruptionSpec.Format()
+
+			Expect(result).To(Equal(expected))
+		})
+
+		It("expects good formatting for a big network disruption", func() {
+			disruptionSpec := NetworkDisruptionSpec{
+				Hosts: []NetworkDisruptionHostSpec{
+					{
+						Host: "1.2.3.4",
+						Port: 9000,
+					},
+					{
+						Host: "2.2.3.4",
+						Port: 8000,
+						Flow: "ingress",
+					},
+				},
+				Services: []NetworkDisruptionServiceSpec{
+					{
+						Name:      "demo-service",
+						Namespace: "demo-namespace",
+					},
+					{
+						Name:      "demo-worker",
+						Namespace: "demo-namespace",
+					},
+				},
+				Cloud: &NetworkDisruptionCloudSpec{
+					AWSServiceList: &[]NetworkDisruptionCloudServiceSpec{
+						{
+							ServiceName: "S3",
+						},
+					},
+					DatadogServiceList: &[]NetworkDisruptionCloudServiceSpec{
+						{
+							ServiceName: "synthetics",
+						},
+					},
+				},
+				Corrupt: 100,
+			}
+
+			expected := "Network disruption corrupting 100% of the traffic going to 1.2.3.4:9000, coming from 2.2.3.4:8000, going to demo-service/demo-namespace, going to demo-worker/demo-namespace, going to S3 and going to synthetics"
+			result := disruptionSpec.Format()
+
+			Expect(result).To(Equal(expected))
+		})
+
+		It("expects no formatting for empty network disruption", func() {
+			disruptionSpec := NetworkDisruptionSpec{
+				Hosts:    []NetworkDisruptionHostSpec{},
+				Services: []NetworkDisruptionServiceSpec{},
+			}
+
+			expected := ""
+			result := disruptionSpec.Format()
+
+			Expect(result).To(Equal(expected))
+		})
+	})
+})

--- a/api/v1beta1/network_disruption_test.go
+++ b/api/v1beta1/network_disruption_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
 package v1beta1
 
 import (


### PR DESCRIPTION
## What does this PR do?

- [x] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Have a description of a Network Disruption.

For:

```
apiVersion: chaos.datadoghq.com/v1beta1
kind: Disruption
metadata:
  name: network-filters
  namespace: chaos-demo
spec:
  level: pod
  selector:
    app: demo-curl
  count: 1
  network:
    drop: 100
    hosts: # filter on hosts (an IP, a port, a protocol, or a combination of those)
      - host: 1.2.3.4 # optional, the destination host to filter on (can be an IP, a CIDR or a hostname)
        port: 80 # optional, the destination port to filter on
        protocol: tcp # optional, the protocol to filter on (can be tcp or udp)
        connState: new # optional, the connection state to filter on (can be new or est (established))
    services: # filter on Kubernetes services; this will correctly handle the port differences in node vs. pod-level disruptions
      - name: demo # service name
        namespace: chaos-demo # service namespace
```

We have : `Network disruption dropping 100% of the traffic going to 1.2.3.4:80 with protocol tcp and going to demo/chaos-demo`



## Code Quality Checklist

- [ ] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
