### PR TITLE
Adapt network and dns disruptions to work with cgroups v2

### DIFF
--- a/cgroup/cgroup_darwin.go
+++ b/cgroup/cgroup_darwin.go
@@ -50,6 +50,10 @@ func (cg cgroup) IsCgroupV2() bool {
 	return false
 }
 
+func (cg cgroup) RelativePath(controller string) string {
+	return ""
+}
+
 // NewManager creates a new cgroup manager from the given cgroup root path
 func NewManager(dryRun bool, pid uint32, cgroupMount string, log *zap.SugaredLogger) (Manager, error) {
 	return cgroup{

--- a/cgroup/cgroup_linux.go
+++ b/cgroup/cgroup_linux.go
@@ -45,15 +45,15 @@ func cgroupManager(cgroupFile string, cgroupMount string) (cgroups.Manager, erro
 }
 
 type cgroup struct {
-	manager *cgroups.Manager
-	dryRun  bool
-	log     *zap.SugaredLogger
+	manager   *cgroups.Manager
+	mountPath string
+	dryRun    bool
+	log       *zap.SugaredLogger
 }
 
 // Read reads the given cgroup file data and returns the content as a string
 func (cg cgroup) Read(controller, file string) (string, error) {
-	manager := *cg.manager
-	controllerDir := manager.Path(controller)
+	controllerDir := (*cg.manager).Path(controller)
 	content, err := cgroups.ReadFile(controllerDir, file)
 
 	if err != nil {
@@ -65,16 +65,14 @@ func (cg cgroup) Read(controller, file string) (string, error) {
 
 // Write writes the given data to the given cgroup kind
 func (cg cgroup) Write(controller, file, data string) error {
-	manager := *cg.manager
-	controllerDir := manager.Path(controller)
+	controllerDir := (*cg.manager).Path(controller)
 
 	return cgroups.WriteFile(controllerDir, file, data)
 }
 
 // Exists returns true if the given cgroup exists, false otherwise
 func (cg cgroup) Exists(controller string) bool {
-	manager := *cg.manager
-	controllerDir := manager.Path(controller)
+	controllerDir := (*cg.manager).Path(controller)
 
 	return cgroups.PathExists(fmt.Sprintf("%s/cgroup.procs", controllerDir))
 }
@@ -86,8 +84,7 @@ func (cg cgroup) Join(pid int) error {
 
 // DiskThrottleRead adds a disk throttle on read operations to the given disk identifier
 func (cg cgroup) DiskThrottleRead(identifier, bps int) error {
-	manager := *cg.manager
-	controllerDir := manager.Path("blkio")
+	controllerDir := (*cg.manager).Path("blkio")
 	file := "blkio.throttle.read_bps_device"
 	data := fmt.Sprintf("%d:0 %d", identifier, bps)
 
@@ -96,8 +93,7 @@ func (cg cgroup) DiskThrottleRead(identifier, bps int) error {
 
 // DiskThrottleWrite adds a disk throttle on write operations to the given disk identifier
 func (cg cgroup) DiskThrottleWrite(identifier, bps int) error {
-	manager := *cg.manager
-	controllerDir := manager.Path("blkio")
+	controllerDir := (*cg.manager).Path("blkio")
 	file := "blkio.throttle.write_bps_device"
 	data := fmt.Sprintf("%d:0 %d", identifier, bps)
 
@@ -108,6 +104,11 @@ func (cg cgroup) IsCgroupV2() bool {
 	return false
 }
 
+// RelativePath returns the cgroup relative path (without the mount path)
+func (cg cgroup) RelativePath(controller string) string {
+	return strings.TrimPrefix((*cg.manager).Path(controller), cg.mountPath)
+}
+
 // NewManager creates a new cgroup manager from the given cgroup root path
 func NewManager(dryRun bool, pid uint32, cgroupMount string, log *zap.SugaredLogger) (Manager, error) {
 	manager, err := cgroupManager(fmt.Sprintf("/proc/%d/cgroup", pid), cgroupMount)
@@ -116,9 +117,10 @@ func NewManager(dryRun bool, pid uint32, cgroupMount string, log *zap.SugaredLog
 	}
 
 	cg := cgroup{
-		manager: &manager,
-		dryRun:  dryRun,
-		log:     log,
+		manager:   &manager,
+		mountPath: cgroupMount,
+		dryRun:    dryRun,
+		log:       log,
 	}
 
 	isCgroupV2 := cgroups.PathExists("/sys/fs/cgroup/cgroup.controllers")

--- a/cgroup/cgroup_manager.go
+++ b/cgroup/cgroup_manager.go
@@ -14,4 +14,5 @@ type Manager interface {
 	DiskThrottleRead(identifier, bps int) error
 	DiskThrottleWrite(identifier, bps int) error
 	IsCgroupV2() bool
+	RelativePath(controller string) string
 }

--- a/cgroup/cgroup_v2_darwin.go
+++ b/cgroup/cgroup_v2_darwin.go
@@ -47,3 +47,7 @@ func (cg cgroupV2) DiskThrottleWrite(identifier, bps int) error {
 func (cg cgroupV2) IsCgroupV2() bool {
 	return true
 }
+
+func (cg cgroupV2) RelativePath(controller string) string {
+	return ""
+}

--- a/cgroup/cgroup_v2_linux.go
+++ b/cgroup/cgroup_v2_linux.go
@@ -41,3 +41,8 @@ func (cg cgroupV2) DiskThrottleWrite(identifier, bps int) error {
 func (cg cgroupV2) IsCgroupV2() bool {
 	return true
 }
+
+// RelativePath returns the cgroup relative path (without the mount path)
+func (cg cgroupV2) RelativePath(controller string) string {
+	return cg.cg.RelativePath(controller)
+}

--- a/cgroup/mocks/Manager.go
+++ b/cgroup/mocks/Manager.go
@@ -117,6 +117,20 @@ func (_m *ManagerMock) Write(controller string, file string, data string) error 
 	return r0
 }
 
+// RelativePath provides a mock function with given fields: controller
+func (_m *ManagerMock) RelativePath(controller string) string {
+	ret := _m.Called(controller)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(controller)
+	} else {
+		r0 = ret.String(0)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewManager interface {
 	mock.TestingT
 	Cleanup(func())

--- a/injector/dns_disruption_test.go
+++ b/injector/dns_disruption_test.go
@@ -99,15 +99,15 @@ var _ = Describe("Failure", func() {
 		})
 
 		It("should create and set the CHAOS-DNS Chain", func() {
-			iptables.AssertCalled(GinkgoT(), "CreateChain", "CHAOS-DNS")
-			iptables.AssertCalled(GinkgoT(), "AddRuleWithIP", "CHAOS-DNS", "udp", "53", "DNAT", "10.0.0.2")
+			iptables.AssertCalled(GinkgoT(), "CreateChain", chaostypes.InjectorIptablesChaosDNSChainName)
+			iptables.AssertCalled(GinkgoT(), "AddRuleWithIP", chaostypes.InjectorIptablesChaosDNSChainName, "udp", "53", "DNAT", "10.0.0.2")
 		})
 
 		Context("disruption is node-level", func() {
 			It("creates node-level iptable filter rules", func() {
-				iptables.AssertCalled(GinkgoT(), "PrependRuleSpec", "CHAOS-DNS", []string{"-s", "10.0.0.2", "-j", "RETURN"})
-				iptables.AssertCalled(GinkgoT(), "PrependRuleSpec", "OUTPUT", []string{"-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"})
-				iptables.AssertCalled(GinkgoT(), "PrependRuleSpec", "PREROUTING", []string{"-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"})
+				iptables.AssertCalled(GinkgoT(), "PrependRuleSpec", chaostypes.InjectorIptablesChaosDNSChainName, []string{"-s", "10.0.0.2", "-j", "RETURN"})
+				iptables.AssertCalled(GinkgoT(), "PrependRuleSpec", "OUTPUT", []string{"-p", "udp", "--dport", "53", "-j", chaostypes.InjectorIptablesChaosDNSChainName})
+				iptables.AssertCalled(GinkgoT(), "PrependRuleSpec", "PREROUTING", []string{"-p", "udp", "--dport", "53", "-j", chaostypes.InjectorIptablesChaosDNSChainName})
 			})
 		})
 
@@ -116,7 +116,7 @@ var _ = Describe("Failure", func() {
 				config.Level = chaostypes.DisruptionLevelPod
 			})
 			It("creates pod-level iptable filter rules", func() {
-				iptables.AssertCalled(GinkgoT(), "AddCgroupFilterRule", "nat", "OUTPUT", "/kubepod.slice/foo", []string{"-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"})
+				iptables.AssertCalled(GinkgoT(), "AddCgroupFilterRule", "nat", "OUTPUT", "/kubepod.slice/foo", []string{"-p", "udp", "--dport", "53", "-j", chaostypes.InjectorIptablesChaosDNSChainName})
 			})
 		})
 	})
@@ -132,13 +132,13 @@ var _ = Describe("Failure", func() {
 		})
 
 		It("should clear and delete the CHAOS-DNS Chain", func() {
-			iptables.AssertCalled(GinkgoT(), "ClearAndDeleteChain", "CHAOS-DNS")
+			iptables.AssertCalled(GinkgoT(), "ClearAndDeleteChain", chaostypes.InjectorIptablesChaosDNSChainName)
 		})
 
 		Context("disruption is node-level", func() {
 			It("should clear the node-level iptable rules", func() {
-				iptables.AssertCalled(GinkgoT(), "DeleteRule", "OUTPUT", "udp", "53", "CHAOS-DNS")
-				iptables.AssertCalled(GinkgoT(), "DeleteRule", "PREROUTING", "udp", "53", "CHAOS-DNS")
+				iptables.AssertCalled(GinkgoT(), "DeleteRule", "OUTPUT", "udp", "53", chaostypes.InjectorIptablesChaosDNSChainName)
+				iptables.AssertCalled(GinkgoT(), "DeleteRule", "PREROUTING", "udp", "53", chaostypes.InjectorIptablesChaosDNSChainName)
 			})
 		})
 
@@ -147,7 +147,7 @@ var _ = Describe("Failure", func() {
 				config.Level = chaostypes.DisruptionLevelPod
 			})
 			It("should clear the pod-level iptables rules", func() {
-				iptables.AssertCalled(GinkgoT(), "DeleteCgroupFilterRule", "nat", "OUTPUT", "/kubepod.slice/foo", []string{"-p", "udp", "--dport", "53", "-j", "CHAOS-DNS"})
+				iptables.AssertCalled(GinkgoT(), "DeleteCgroupFilterRule", "nat", "OUTPUT", "/kubepod.slice/foo", []string{"-p", "udp", "--dport", "53", "-j", chaostypes.InjectorIptablesChaosDNSChainName})
 			})
 		})
 

--- a/injector/network_disruption_test.go
+++ b/injector/network_disruption_test.go
@@ -6,10 +6,11 @@
 package injector_test
 
 import (
-	"github.com/DataDog/chaos-controller/cgroup/mocks"
 	"net"
 	"os"
 	"time"
+
+	"github.com/DataDog/chaos-controller/cgroup/mocks"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -37,7 +38,6 @@ var _ = Describe("Failure", func() {
 		config                                                  NetworkDisruptionInjectorConfig
 		spec                                                    v1beta1.NetworkDisruptionSpec
 		cgroupManager                                           *mocks.ManagerMock
-		cgroupManagerExistsCall                                 *mock.Call
 		tc                                                      *network.TcMock
 		iptables                                                *network.IptablesMock
 		nl                                                      *network.NetlinkAdapterMock
@@ -54,8 +54,7 @@ var _ = Describe("Failure", func() {
 	BeforeEach(func() {
 		// cgroup
 		cgroupManager = &mocks.ManagerMock{}
-		cgroupManagerExistsCall = cgroupManager.On("Exists", "net_cls").Return(true, nil)
-		cgroupManager.On("Write", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		cgroupManager.On("RelativePath", mock.Anything).Return("/kubepod.slice/foo")
 
 		// netns
 		netnsManager = &netns.ManagerMock{}
@@ -67,7 +66,7 @@ var _ = Describe("Failure", func() {
 		tc.On("AddNetem", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		tc.On("AddPrio", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		tc.On("AddFilter", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		tc.On("AddCgroupFilter", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		tc.On("AddFwFilter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		tc.On("AddOutputLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		tc.On("DeleteFilter", mock.Anything, mock.Anything).Return(nil)
 		tc.On("ClearQdisc", mock.Anything).Return(nil)
@@ -213,22 +212,22 @@ var _ = Describe("Failure", func() {
 			netnsManager.AssertCalled(GinkgoT(), "Exit")
 		})
 
-		It("should write the custom classid to the target net_cls cgroup", func() {
-			cgroupManager.AssertCalled(GinkgoT(), "Write", "net_cls", "net_cls.classid", "0x00020002")
-		})
-
 		It("should create 2 prio qdiscs on main interfaces", func() {
-			tc.AssertCalled(GinkgoT(), "AddPrio", []string{"lo", "eth0", "eth1"}, "root", uint32(1), uint32(4), mock.Anything)
-			tc.AssertCalled(GinkgoT(), "AddPrio", []string{"lo", "eth0", "eth1"}, "1:4", uint32(2), uint32(2), mock.Anything)
+			tc.AssertCalled(GinkgoT(), "AddPrio", []string{"lo", "eth0", "eth1"}, "root", "1:", uint32(4), mock.Anything)
+			tc.AssertCalled(GinkgoT(), "AddPrio", []string{"lo", "eth0", "eth1"}, "1:4", "2:", uint32(2), mock.Anything)
 		})
 
-		It("should add a cgroup filter to classify packets according to their classid", func() {
-			tc.AssertCalled(GinkgoT(), "AddCgroupFilter", []string{"lo", "eth0", "eth1"}, "2:0", mock.Anything)
+		It("should add an fw filter to classify packets according to their classid set by iptables mark", func() {
+			tc.AssertCalled(GinkgoT(), "AddFwFilter", []string{"lo", "eth0", "eth1"}, "2:0", "0x00020002", "2:2")
 		})
 
 		It("should apply disruptions to main interfaces 2nd band", func() {
 			tc.AssertCalled(GinkgoT(), "AddNetem", []string{"lo", "eth0", "eth1"}, "2:2", mock.Anything, time.Second, time.Second, spec.Drop, spec.Corrupt, spec.Duplicate)
 			tc.AssertCalled(GinkgoT(), "AddOutputLimit", []string{"lo", "eth0", "eth1"}, "3:", mock.Anything, uint(spec.BandwidthLimit))
+		})
+
+		It("should mark packets going out from the identified (container or host) cgroup for the tc fw filter", func() {
+			iptables.AssertCalled(GinkgoT(), "AddCgroupFilterRule", "mangle", "OUTPUT", "/kubepod.slice/foo", []string{"-j", "MARK", "--set-mark", chaostypes.InjectorCgroupClassID})
 		})
 
 		// qlen cases
@@ -398,8 +397,7 @@ var _ = Describe("Failure", func() {
 			})
 
 			It("should not add a second prio band with the cgroup filter", func() {
-				tc.AssertNotCalled(GinkgoT(), "AddPrio", []string{"lo", "eth0", "eth1"}, "1:4", uint32(2), uint32(2), mock.Anything)
-				tc.AssertNotCalled(GinkgoT(), "AddCgroupFilter", []string{"lo", "eth0", "eth1"}, "2:0", mock.Anything)
+				tc.AssertNotCalled(GinkgoT(), "AddPrio", []string{"lo", "eth0", "eth1"}, "1:4", "2:", uint32(2), mock.Anything)
 			})
 
 			It("should apply tc filters to block traffic", func() {
@@ -433,25 +431,13 @@ var _ = Describe("Failure", func() {
 			netnsManager.AssertCalled(GinkgoT(), "Exit")
 		})
 
+		It("should remove the cgroup iptables packet marking rule", func() {
+			iptables.AssertCalled(GinkgoT(), "DeleteCgroupFilterRule", "mangle", "OUTPUT", "/kubepod.slice/foo", []string{"-j", "MARK", "--set-mark", chaostypes.InjectorCgroupClassID})
+		})
+
 		Context("qdisc cleanup should happen", func() {
 			It("should clear the interfaces qdisc", func() {
 				tc.AssertCalled(GinkgoT(), "ClearQdisc", []string{"lo", "eth0", "eth1"})
-			})
-		})
-
-		Context("with an existing net_cls cgroup", func() {
-			It("should erase the classid value", func() {
-				cgroupManager.AssertCalled(GinkgoT(), "Write", "net_cls", "net_cls.classid", "0x0")
-			})
-		})
-
-		Context("with a non-existing net_cls cgroup", func() {
-			BeforeEach(func() {
-				cgroupManagerExistsCall.Return(false, nil)
-			})
-
-			It("should not try to erase the classid value", func() {
-				cgroupManager.AssertNotCalled(GinkgoT(), "Write", "net_cls", "net_cls.classid", mock.Anything)
 			})
 		})
 	})

--- a/network/iptables_mock.go
+++ b/network/iptables_mock.go
@@ -62,15 +62,22 @@ func (f *IptablesMock) AddWideFilterRule(chain string, protocol string, port str
 }
 
 //nolint:golint
-func (f *IptablesMock) AddCgroupFilterRule(chain string, cgroupid string, protocol string, port string, jump string) error {
-	args := f.Called(chain, cgroupid, protocol, port, jump)
+func (f *IptablesMock) AddCgroupFilterRule(table string, chain string, cgroupPath string, rulespec ...string) error {
+	args := f.Called(table, chain, cgroupPath, rulespec)
 
 	return args.Error(0)
 }
 
 //nolint:golint
-func (f *IptablesMock) DeleteCgroupFilterRule(chain string, cgroupid string, protocol string, port string, jump string) error {
-	args := f.Called(chain, cgroupid, protocol, port, jump)
+func (f *IptablesMock) DeleteCgroupFilterRule(table string, chain string, cgroupPath string, rulespec ...string) error {
+	args := f.Called(table, chain, cgroupPath, rulespec)
 
 	return args.Error(0)
+}
+
+//nolint:golint
+func (f *IptablesMock) ListRules(table string, chain string) ([]string, error) {
+	args := f.Called(table, chain)
+
+	return args.Get(0).([]string), args.Error(1)
 }

--- a/network/tc_mock.go
+++ b/network/tc_mock.go
@@ -25,21 +25,21 @@ func NewTcMock() *TcMock {
 }
 
 //nolint:golint
-func (f *TcMock) AddNetem(ifaces []string, parent string, handle uint32, delay time.Duration, delayJitter time.Duration, drop int, corrupt int, duplicate int) error {
+func (f *TcMock) AddNetem(ifaces []string, parent string, handle string, delay time.Duration, delayJitter time.Duration, drop int, corrupt int, duplicate int) error {
 	args := f.Called(ifaces, parent, handle, delay, delayJitter, drop, corrupt, duplicate)
 
 	return args.Error(0)
 }
 
 //nolint:golint
-func (f *TcMock) AddPrio(ifaces []string, parent string, handle uint32, bands uint32, priomap [16]uint32) error {
+func (f *TcMock) AddPrio(ifaces []string, parent string, handle string, bands uint32, priomap [16]uint32) error {
 	args := f.Called(ifaces, parent, handle, bands, priomap)
 
 	return args.Error(0)
 }
 
 //nolint:golint
-func (f *TcMock) AddFilter(ifaces []string, parent string, handle uint32, srcIP, dstIP *net.IPNet, srcPort, dstPort int, protocol Protocol, connState connState, flowid string) (uint32, error) {
+func (f *TcMock) AddFilter(ifaces []string, parent string, handle string, srcIP, dstIP *net.IPNet, srcPort, dstPort int, protocol Protocol, connState connState, flowid string) (uint32, error) {
 	srcIPs := "nil"
 	dstIPs := "nil"
 
@@ -59,14 +59,14 @@ func (f *TcMock) AddFilter(ifaces []string, parent string, handle uint32, srcIP,
 }
 
 //nolint:golint
-func (f *TcMock) AddCgroupFilter(ifaces []string, parent string, handle uint32) error {
-	args := f.Called(ifaces, parent, handle)
+func (f *TcMock) AddFwFilter(ifaces []string, parent string, handle string, flowid string) error {
+	args := f.Called(ifaces, parent, handle, flowid)
 
 	return args.Error(0)
 }
 
 //nolint:golint
-func (f *TcMock) AddOutputLimit(ifaces []string, parent string, handle uint32, bytesPerSec uint) error {
+func (f *TcMock) AddOutputLimit(ifaces []string, parent string, handle string, bytesPerSec uint) error {
 	args := f.Called(ifaces, parent, handle, bytesPerSec)
 
 	return args.Error(0)

--- a/network/tc_test.go
+++ b/network/tc_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Tc", func() {
 		tcExecuterRunCall *mock.Call
 		ifaces            []string
 		parent            string
-		handle            uint32
+		handle            string
 		delay             time.Duration
 		delayJitter       time.Duration
 		drop              int
@@ -60,7 +60,7 @@ var _ = Describe("Tc", func() {
 		// injected variables
 		ifaces = []string{"lo", "eth0"}
 		parent = "root"
-		handle = 0
+		handle = ""
 		delay = time.Second
 		delayJitter = time.Second
 		drop = 5
@@ -96,7 +96,7 @@ var _ = Describe("Tc", func() {
 
 		Context("add delay and delayJitter with a handle", func() {
 			BeforeEach(func() {
-				handle = 1
+				handle = "1:"
 			})
 
 			It("should execute", func() {
@@ -161,14 +161,14 @@ var _ = Describe("Tc", func() {
 		})
 	})
 
-	Describe("AddCgroupFilter", func() {
+	Describe("AddFwFilter", func() {
 		JustBeforeEach(func() {
-			tcRunner.AddCgroupFilter(ifaces, parent, handle)
+			tcRunner.AddFwFilter(ifaces, parent, handle, flowid)
 		})
 
 		Context("add a cgroup filter", func() {
 			It("should execute", func() {
-				tcExecuter.AssertCalled(GinkgoT(), "Run", "filter add dev lo root cgroup")
+				tcExecuter.AssertCalled(GinkgoT(), "Run", "filter add dev lo protocol ip root fw flowid 1:2")
 			})
 		})
 	})

--- a/types/types.go
+++ b/types/types.go
@@ -73,6 +73,9 @@ const (
 	// This value should NEVER be changed without changing the Network Disruption TC tree.
 	InjectorCgroupClassID = "0x00020002"
 
+	// iptables chain name used by the injector to filter and redirect DNS packets in the DNS disruption
+	InjectorIptablesChaosDNSChainName = "CHAOS-DNS"
+
 	// DDMarkChaoslibPrefix allows to consistently name the chaos-imported API in ddmark.
 	// It's arbitrary but needs to be consistent across multiple files.
 	DDMarkChaoslibPrefix = "chaos-api"


### PR DESCRIPTION
## What does this PR do?

- [x] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Network disruptions don't rely on the cgroup tc filter anymore
  - Instead, packets are marked by iptables depending on their source cgroup and filtered later by tc with a `fw` filter classifying packets based on their mark
- The solution is cgroup version agnostic and works both with v1 and v2

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - deploying the controller on lima cgroups v1 and applying network and dns disruptions and validating the result on the demo apps
    - deploying the controller on lima cgroups v2 and applying network and dns disruptions and validating the result on the demo apps
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
