### PR TITLE
CHAOS-448: Initial working cgroups v2 library, functioning CPU pressure disruption

### DIFF
--- a/cgroup/cgroup_linux.go
+++ b/cgroup/cgroup_linux.go
@@ -40,7 +40,7 @@ func cgroupManager(cgroupFile string, cgroupMount string) (cgroups.Manager, erro
 	// cgroup paths, so the resulting map will have a single element where the key
 	// is empty string ("") and the value is the cgroup path the <pid> is in.
 	if cgroups.IsCgroup2UnifiedMode() {
-		return fs2.NewManager(cg, cgroupPaths[""])
+		return fs2.NewManager(cg, cgroupPaths[cgroupMount])
 	}
 
 	// cgroup v1 manager
@@ -129,17 +129,18 @@ func NewManager(dryRun bool, pid uint32, cgroupMount string, log *zap.SugaredLog
 		return nil, err
 	}
 
-	isCgroupV2 := cgroups.PathExists("/sys/fs/cgroup/cgroup.controllers")
-	if isCgroupV2 {
-		return cgroupV2{
-			manager: &manager,
-			log:     log,
-		}, nil
-	}
-
-	return cgroup{
+	cg := cgroup{
 		manager: &manager,
 		dryRun:  dryRun,
 		log:     log,
-	}, nil
+	}
+
+	isCgroupV2 := cgroups.PathExists("/sys/fs/cgroup/cgroup.controllers")
+	if isCgroupV2 {
+		return cgroupV2{
+			cgroup: cg,
+		}, nil
+	}
+
+	return cg, nil
 }

--- a/cgroup/cgroup_linux.go
+++ b/cgroup/cgroup_linux.go
@@ -138,7 +138,7 @@ func NewManager(dryRun bool, pid uint32, cgroupMount string, log *zap.SugaredLog
 	isCgroupV2 := cgroups.PathExists("/sys/fs/cgroup/cgroup.controllers")
 	if isCgroupV2 {
 		return cgroupV2{
-			cgroup: cg,
+			cg: cg,
 		}, nil
 	}
 

--- a/cgroup/cgroup_v2_linux.go
+++ b/cgroup/cgroup_v2_linux.go
@@ -5,46 +5,37 @@
 
 package cgroup
 
-import (
-	"fmt"
-
-	"github.com/opencontainers/runc/libcontainer/cgroups"
-
-	"go.uber.org/zap"
-)
-
 type cgroupV2 struct {
-	manager *cgroups.Manager
-	log     *zap.SugaredLogger
+	cgroup
 }
 
 // Read reads the given cgroup file data and returns the content as a string
 func (cg cgroupV2) Read(controller, file string) (string, error) {
-	return "", fmt.Errorf("not implemented")
+	return cg.Read(controller, file)
 }
 
 // Write writes the given data to the given cgroup kind
 func (cg cgroupV2) Write(controller, file, data string) error {
-	return fmt.Errorf("not implemented")
+	return cg.Write(controller, file, data)
 }
 
 // Exists returns true if the given cgroup exists, false otherwise
 func (cg cgroupV2) Exists(controller string) bool {
-	return false
+	return cg.Exists(controller)
 }
 
 func (cg cgroupV2) Join(controller string, pid int, inherit bool) error {
-	return fmt.Errorf("not implemented")
+	return cg.Join(controller, pid, inherit)
 }
 
 // DiskThrottleRead adds a disk throttle on read operations to the given disk identifier
 func (cg cgroupV2) DiskThrottleRead(identifier, bps int) error {
-	return fmt.Errorf("not implemented")
+	return cg.DiskThrottleRead(identifier, bps)
 }
 
 // DiskThrottleWrite adds a disk throttle on write operations to the given disk identifier
 func (cg cgroupV2) DiskThrottleWrite(identifier, bps int) error {
-	return fmt.Errorf("not implemented")
+	return cg.DiskThrottleRead(identifier, bps)
 }
 
 func (cg cgroupV2) IsCgroupV2() bool {

--- a/cgroup/cgroup_v2_linux.go
+++ b/cgroup/cgroup_v2_linux.go
@@ -6,36 +6,36 @@
 package cgroup
 
 type cgroupV2 struct {
-	cgroup
+	cg cgroup
 }
 
 // Read reads the given cgroup file data and returns the content as a string
 func (cg cgroupV2) Read(controller, file string) (string, error) {
-	return cg.Read(controller, file)
+	return cg.cg.Read(controller, file)
 }
 
 // Write writes the given data to the given cgroup kind
 func (cg cgroupV2) Write(controller, file, data string) error {
-	return cg.Write(controller, file, data)
+	return cg.cg.Write(controller, file, data)
 }
 
 // Exists returns true if the given cgroup exists, false otherwise
 func (cg cgroupV2) Exists(controller string) bool {
-	return cg.Exists(controller)
+	return cg.cg.Exists(controller)
 }
 
 func (cg cgroupV2) Join(controller string, pid int, inherit bool) error {
-	return cg.Join(controller, pid, inherit)
+	return cg.cg.Join(controller, pid, inherit)
 }
 
 // DiskThrottleRead adds a disk throttle on read operations to the given disk identifier
 func (cg cgroupV2) DiskThrottleRead(identifier, bps int) error {
-	return cg.DiskThrottleRead(identifier, bps)
+	return cg.cg.DiskThrottleRead(identifier, bps)
 }
 
 // DiskThrottleWrite adds a disk throttle on write operations to the given disk identifier
 func (cg cgroupV2) DiskThrottleWrite(identifier, bps int) error {
-	return cg.DiskThrottleRead(identifier, bps)
+	return cg.cg.DiskThrottleRead(identifier, bps)
 }
 
 func (cg cgroupV2) IsCgroupV2() bool {

--- a/controllers/cache_handler_test.go
+++ b/controllers/cache_handler_test.go
@@ -7,6 +7,7 @@ package controllers
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -46,6 +47,12 @@ var _ = Describe("Cache Handler verifications", func() {
 	})
 
 	JustBeforeEach(func() {
+		if os.Getenv("CGROUPS") == "v2" {
+			if disruption.Spec.Network != nil {
+				Skip("can't run this test in cgroups v2")
+			}
+		}
+
 		By("Creating disruption resource and waiting for injection to be done")
 		Expect(k8sClient.Create(context.Background(), disruption)).To(BeNil())
 

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -270,7 +270,7 @@ var _ = Describe("Disruption Controller", func() {
 		})
 	})
 
-	Context("node level", func() {
+	FContext("node level", func() {
 		BeforeEach(func() {
 			disruption = &chaosv1beta1.Disruption{
 				ObjectMeta: metav1.ObjectMeta{
@@ -283,20 +283,9 @@ var _ = Describe("Disruption Controller", func() {
 					Unsafemode: &chaosv1beta1.UnsafemodeSpec{
 						DisableAll: true,
 					},
-					Selector: map[string]string{"kubernetes.io/hostname": clusterName},
-					Level:    chaostypes.DisruptionLevelNode,
-					Network: &chaosv1beta1.NetworkDisruptionSpec{
-						Hosts: []chaosv1beta1.NetworkDisruptionHostSpec{
-							{
-								Host:     "127.0.0.1",
-								Port:     80,
-								Protocol: "tcp",
-							},
-						},
-						Drop:    0,
-						Corrupt: 0,
-						Delay:   1,
-					},
+					Selector:    map[string]string{"kubernetes.io/hostname": clusterName},
+					Level:       chaostypes.DisruptionLevelNode,
+					CPUPressure: &chaosv1beta1.CPUPressureSpec{},
 				},
 			}
 		})
@@ -425,19 +414,10 @@ var _ = Describe("Disruption Controller", func() {
 				Unsafemode: &chaosv1beta1.UnsafemodeSpec{
 					DisableAll: true,
 				},
-				Selector:   map[string]string{"foo": "bar"},
-				Containers: []string{"ctn1"},
-				Duration:   "10m",
-				Network: &chaosv1beta1.NetworkDisruptionSpec{
-					Hosts: []chaosv1beta1.NetworkDisruptionHostSpec{
-						{
-							Host:     "127.0.0.1",
-							Port:     80,
-							Protocol: "tcp",
-						},
-					},
-					Drop: 100,
-				},
+				Selector:    map[string]string{"foo": "bar"},
+				Containers:  []string{"ctn1"},
+				Duration:    "10m",
+				CPUPressure: &chaosv1beta1.CPUPressureSpec{},
 			}
 
 		})

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -226,6 +226,12 @@ var _ = Describe("Disruption Controller", func() {
 	})
 
 	JustBeforeEach(func() {
+		if os.Getenv("CGROUPS") == "v2" {
+			if disruption.Spec.Network != nil {
+				Skip("can't run this test in cgroups v2")
+			}
+		}
+
 		By("Creating disruption resource and waiting for injection to be done")
 		Expect(k8sClient.Create(context.Background(), disruption)).To(BeNil())
 

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -270,7 +270,7 @@ var _ = Describe("Disruption Controller", func() {
 		})
 	})
 
-	FContext("node level", func() {
+	Context("node level", func() {
 		BeforeEach(func() {
 			disruption = &chaosv1beta1.Disruption{
 				ObjectMeta: metav1.ObjectMeta{
@@ -283,9 +283,20 @@ var _ = Describe("Disruption Controller", func() {
 					Unsafemode: &chaosv1beta1.UnsafemodeSpec{
 						DisableAll: true,
 					},
-					Selector:    map[string]string{"kubernetes.io/hostname": clusterName},
-					Level:       chaostypes.DisruptionLevelNode,
-					CPUPressure: &chaosv1beta1.CPUPressureSpec{},
+					Selector: map[string]string{"kubernetes.io/hostname": clusterName},
+					Level:    chaostypes.DisruptionLevelNode,
+					Network: &chaosv1beta1.NetworkDisruptionSpec{
+						Hosts: []chaosv1beta1.NetworkDisruptionHostSpec{
+							{
+								Host:     "127.0.0.1",
+								Port:     80,
+								Protocol: "tcp",
+							},
+						},
+						Drop:    0,
+						Corrupt: 0,
+						Delay:   1,
+					},
 				},
 			}
 		})
@@ -414,10 +425,19 @@ var _ = Describe("Disruption Controller", func() {
 				Unsafemode: &chaosv1beta1.UnsafemodeSpec{
 					DisableAll: true,
 				},
-				Selector:    map[string]string{"foo": "bar"},
-				Containers:  []string{"ctn1"},
-				Duration:    "10m",
-				CPUPressure: &chaosv1beta1.CPUPressureSpec{},
+				Selector:   map[string]string{"foo": "bar"},
+				Containers: []string{"ctn1"},
+				Duration:   "10m",
+				Network: &chaosv1beta1.NetworkDisruptionSpec{
+					Hosts: []chaosv1beta1.NetworkDisruptionHostSpec{
+						{
+							Host:     "127.0.0.1",
+							Port:     80,
+							Protocol: "tcp",
+						},
+					},
+					Drop: 100,
+				},
 			}
 
 		})

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -321,22 +321,10 @@ var _ = Describe("Disruption Controller", func() {
 				Unsafemode: &chaosv1beta1.UnsafemodeSpec{
 					DisableAll: true,
 				},
-				Selector:   map[string]string{"foo": "bar"},
-				Containers: []string{"ctn1"},
-				Duration:   "30s",
-				Network: &chaosv1beta1.NetworkDisruptionSpec{
-					Hosts: []chaosv1beta1.NetworkDisruptionHostSpec{
-						{
-							Host:     "127.0.0.1",
-							Port:     80,
-							Protocol: "tcp",
-						},
-					},
-					Drop:           0,
-					Corrupt:        0,
-					Delay:          1000,
-					BandwidthLimit: 10000,
-				},
+				Selector:    map[string]string{"foo": "bar"},
+				Containers:  []string{"ctn1"},
+				Duration:    "30s",
+				CPUPressure: &chaosv1beta1.CPUPressureSpec{},
 			}
 		})
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Include the v1 manager in the v2 manager, so we can delegate any identical calls of the libcontainer/cgroups library
- Make some changes in the tests so that we don't run disruptions that would fail on cgroups v2 
- Change one test to only use cpu pressure so I can confirm that works
- Pass the cgroup mount to the manager so that it prefixes the paths correctly

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- I've tested this locally on v2 and confirmed we can now read, join, and write to the cpuset controller.
- I can confirm net_cls disruptions explode, as expected
- W/o a larger testing environment, I can't speak to much more
- We still only have v1 CI. I would like to add v2 CI in a separate PR, if that's ok
