### PR TITLE
Correct typo in function name; update docs

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -311,8 +311,8 @@ func (s *DisruptionSpec) validateGlobalDisruptionScope() (retErr error) {
 
 	// Rule: pulse compatibility
 	if s.Pulse != nil {
-		if s.NodeFailure != nil || s.ContainerFailure != nil {
-			retErr = multierror.Append(retErr, errors.New("pulse is only compatible with network, cpu pressure, disk pressure, dns and grpc disruptions"))
+		if s.NodeFailure != nil {
+			retErr = multierror.Append(retErr, errors.New("pulse is not compatible with node failure disruptions"))
 		}
 
 		if s.Pulse.ActiveDuration.Duration() < chaostypes.PulsingDisruptionMinimumDuration {

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -492,6 +492,7 @@ func (status *DisruptionStatus) HasTarget(searchTarget string) bool {
 
 var NonReinjectableDisruptions = map[chaostypes.DisruptionKindName]struct{}{
 	chaostypes.DisruptionKindGRPCDisruption: {},
+	chaostypes.DisruptionKindNodeFailure:    {},
 }
 
 func DisruptionIsNotReinjectable(kind chaostypes.DisruptionKindName) bool {

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -494,7 +494,7 @@ var NonReinjectableDisruptions = map[chaostypes.DisruptionKindName]struct{}{
 	chaostypes.DisruptionKindGRPCDisruption: {},
 }
 
-func DisruptionIsReinjectable(kind chaostypes.DisruptionKindName) bool {
+func DisruptionIsNotReinjectable(kind chaostypes.DisruptionKindName) bool {
 	_, found := NonReinjectableDisruptions[kind]
 
 	return found

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -311,8 +311,8 @@ func (s *DisruptionSpec) validateGlobalDisruptionScope() (retErr error) {
 
 	// Rule: pulse compatibility
 	if s.Pulse != nil {
-		if s.NodeFailure != nil {
-			retErr = multierror.Append(retErr, errors.New("pulse is not compatible with node failure disruptions"))
+		if s.NodeFailure != nil || s.ContainerFailure != nil {
+			retErr = multierror.Append(retErr, errors.New("pulse is only compatible with network, cpu pressure, disk pressure, dns and grpc disruptions"))
 		}
 
 		if s.Pulse.ActiveDuration.Duration() < chaostypes.PulsingDisruptionMinimumDuration {

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -534,7 +534,7 @@ func injectAndWait(cmd *cobra.Command, args []string) {
 	case !injectSuccess:
 		break
 	// those disruptions should not watch target to re-inject on container restart
-	case v1beta1.DisruptionIsReinjectable((chaostypes.DisruptionKindName)(cmd.Name())):
+	case v1beta1.DisruptionIsNotReinjectable((chaostypes.DisruptionKindName)(cmd.Name())):
 	case level == chaostypes.DisruptionLevelNode:
 		if pulseActiveDuration > 0 && pulseDormantDuration > 0 {
 			var action func(string, bool, bool) bool

--- a/docs/container_disruption.md
+++ b/docs/container_disruption.md
@@ -4,4 +4,7 @@ The `containerFailure` field sends the SIGTERM/SIGKILL signal to a pod's contain
 
 The signal to be sent is controlled through the `containerFailure.forced` field. By default, this is set to `false` which will send the `SIGTERM` signal. If this is enabled the `SIGKILL` signal will be sent.
 
+If those containers are restarted during the duration of the disruption, we will find their new PIDs and send the signal again.
+This can achieve an effect of "continually restarting" containers within a pod.
+
 By default, all containers within a pod will be targeted. However, you can target a predefined set of containers by setting the `containers` field.


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Adds Node failures to the list of disruptions that can't be reinjected
- Renames the function that checks if a disruption cant be reinjected
- Adds to the container failure documentation
- Does _not_ allow for pulsing container failure disruptions, as that actually doesn't work well w/o a significant change to pulsing

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
