### PR TITLE
Fix the filename used to read cpuset in cgroups

### DIFF
--- a/cgroup/cgroup_darwin.go
+++ b/cgroup/cgroup_darwin.go
@@ -31,10 +31,8 @@ func (cg cgroup) Exists(controller string) bool {
 	return false
 }
 
-// Join adds the given PID to the given cgroup
-// If inherit is set to true, all PID of the same group will be moved to the cgroup (writing to cgroup.procs file)
-// Otherwise, only the given PID will be moved to the cgroup (writing to tasks file)
-func (cg cgroup) Join(controller string, pid int, inherit bool) error {
+// Join adds the given PID to all available controllers of the cgroup
+func (cg cgroup) Join(pid int) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/cgroup/cgroup_manager.go
+++ b/cgroup/cgroup_manager.go
@@ -7,7 +7,7 @@ package cgroup
 
 // Manager represents a cgroup manager able to join the given cgroup
 type Manager interface {
-	Join(controller string, pid int, inherit bool) error
+	Join(pid int) error
 	Read(controller, file string) (string, error)
 	Write(controller, file, data string) error
 	Exists(controller string) bool

--- a/cgroup/cgroup_v2_linux.go
+++ b/cgroup/cgroup_v2_linux.go
@@ -24,8 +24,8 @@ func (cg cgroupV2) Exists(controller string) bool {
 	return cg.cg.Exists(controller)
 }
 
-func (cg cgroupV2) Join(controller string, pid int, inherit bool) error {
-	return cg.cg.Join(controller, pid, inherit)
+func (cg cgroupV2) Join(pid int) error {
+	return cg.cg.Join(pid)
 }
 
 // DiskThrottleRead adds a disk throttle on read operations to the given disk identifier

--- a/cgroup/mocks/Manager.go
+++ b/cgroup/mocks/Manager.go
@@ -69,12 +69,12 @@ func (_m *ManagerMock) IsCgroupV2() bool {
 }
 
 // Join provides a mock function with given fields: kind, pid, inherit
-func (_m *ManagerMock) Join(controller string, pid int, inherit bool) error {
-	ret := _m.Called(controller, pid, inherit)
+func (_m *ManagerMock) Join(pid int) error {
+	ret := _m.Called(pid)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, int, bool) error); ok {
-		r0 = rf(controller, pid, inherit)
+	if rf, ok := ret.Get(0).(func(int) error); ok {
+		r0 = rf(pid)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/injector/cpu_pressure_test.go
+++ b/injector/cpu_pressure_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Failure", func() {
 	BeforeEach(func() {
 		// cgroup
 		cgroupManager = &mocks.ManagerMock{}
-		cgroupManager.On("Join", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		cgroupManager.On("Join", mock.Anything).Return(nil)
 
 		// container
 		ctn = &container.ContainerMock{}
@@ -50,6 +50,7 @@ var _ = Describe("Failure", func() {
 		manager = &process.ManagerMock{}
 		manager.On("Prioritize").Return(nil)
 		manager.On("ThreadID").Return(666)
+		manager.On("ProcessID").Return(42)
 
 		stresserManager = &stress.StresserManagerMock{}
 		stresserManager.On("TrackCoreAlreadyStressed", mock.Anything, mock.Anything).Return(nil)
@@ -105,10 +106,8 @@ var _ = Describe("Failure", func() {
 				stresserManager.On("TrackInjectorCores", mock.Anything, mock.Anything).Return(cpuset.NewCPUSet(0, 1), nil)
 			})
 
-			It("should join the cpu and cpuset cgroups for the unstressed core", func() {
-				cgroupManager.AssertCalled(GinkgoT(), "Join", "cpu", 666, false)
-				cgroupManager.AssertCalled(GinkgoT(), "Join", "cpuset", 666, false)
-				cgroupManager.AssertNumberOfCalls(GinkgoT(), "Join", 2)
+			It("should join target cgroup subsystems from the main process", func() {
+				cgroupManager.AssertCalled(GinkgoT(), "Join", 42)
 			})
 
 			It("should prioritize the current process", func() {

--- a/process/process.go
+++ b/process/process.go
@@ -11,6 +11,7 @@ import "os"
 type Manager interface {
 	Prioritize() error
 	ThreadID() int
+	ProcessID() int
 	Find(pid int) (*os.Process, error)
 	Signal(process *os.Process, signal os.Signal) error
 }

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -42,6 +42,11 @@ func (p manager) ThreadID() int {
 	return syscall.Gettid()
 }
 
+// ProcessID returns the caller PID
+func (p manager) ProcessID() int {
+	return syscall.Getpid()
+}
+
 // Find looks for a running process by its pid
 func (p manager) Find(pid int) (*os.Process, error) {
 	proc, err := os.FindProcess(pid)

--- a/process/process_mock.go
+++ b/process/process_mock.go
@@ -31,6 +31,13 @@ func (f *ManagerMock) ThreadID() int {
 }
 
 //nolint:golint
+func (f *ManagerMock) ProcessID() int {
+	args := f.Called()
+
+	return args.Int(0)
+}
+
+//nolint:golint
 func (f *ManagerMock) Find(pid int) (*os.Process, error) {
 	args := f.Called(pid)
 

--- a/process/process_other.go
+++ b/process/process_other.go
@@ -32,6 +32,11 @@ func (p manager) ThreadID() int {
 	return -1
 }
 
+// ProcessID returns the caller PID
+func (p manager) ProcessID() int {
+	return -1
+}
+
 // Find looks for a running process by its pid
 func (p manager) Find(pid int) (*os.Process, error) {
 	return nil, errors.New("unsupported")

--- a/scripts/lima_start.sh
+++ b/scripts/lima_start.sh
@@ -12,7 +12,7 @@ if [[ ${LIMA_CGROUPS} == "v1" ]]; then
   limactl shell default sudo update-grub
   limactl shell default sudo reboot
   echo "Waiting for instance to reboot, it might take a while"
-  sleep 5
+  sleep 10
   limactl stop default
   limactl start default
 fi

--- a/stress/cpuset_manager_test.go
+++ b/stress/cpuset_manager_test.go
@@ -89,7 +89,8 @@ var _ = Describe("StresserManager Test", func() {
 
 func cgroupManager() *mocks.ManagerMock {
 	cgroup := &mocks.ManagerMock{}
-	cgroup.On("Read", "cpuset", "cpuset.cpus").Return("0-1", nil)
+	cgroup.On("IsCgroupV2").Return(false)
+	cgroup.On("Read", "cpuset", "cpuset.effective_cpus").Return("0-1", nil)
 
 	return cgroup
 }


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The file used by cpu pressure stressers to get cpuset identifiers was not working for cpu pressure, leading to no errors but no stressers being created.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
