### PR TITLE
Fix dry run mode not being applied on cgroup operations

### DIFF
--- a/cgroup/cgroup_linux.go
+++ b/cgroup/cgroup_linux.go
@@ -57,11 +57,23 @@ func (cg cgroup) Read(controller, file string) (string, error) {
 func (cg cgroup) Write(controller, file, data string) error {
 	controllerDir := (*cg.manager).Path(controller)
 
+	cg.log.Infow("writing to cgroup file", "path", filepath.Join(controllerDir, file), "data", data)
+
+	if cg.dryRun {
+		return nil
+	}
+
 	return cgroups.WriteFile(controllerDir, file, data)
 }
 
 // Join adds the given PID to all available controllers of the cgroup
 func (cg cgroup) Join(pid int) error {
+	cg.log.Infow("moving the pid to cgroup", "pid", pid)
+
+	if cg.dryRun {
+		return nil
+	}
+
 	return cgroups.EnterPid((*cg.manager).GetPaths(), pid)
 }
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- dry run mode was not taken in account in cgroup operations anymore, mistakenly removed during cgroups v2 work

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - applied all cgroup related disruptions with the dry run mode enabled to verify it was actually NOT applying the disruption
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
