### PR TITLE
Rework the iptables module

### DIFF
--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -165,13 +165,6 @@ func (i *networkDisruptionInjector) Inject() error {
 
 	// apply operations if any
 	if len(i.operations) > 0 {
-		// add a conntrack reference to enable it
-		// it consists of adding a noop iptables rule loading the conntrack module so it enables connection tracking in the targeted network namespace
-		// cf. https://thermalcircle.de/doku.php?id=blog:linux:connection_tracking_1_modules_and_hooks for more information on how conntrack works outside of the main network namespace
-		if err := i.config.Iptables.PrependRuleSpec("OUTPUT", "-m", "state", "--state", "new,established", "-j", "LOG"); err != nil {
-			return fmt.Errorf("error injecting the conntrack reference iptables rule: %w", err)
-		}
-
 		if err := i.applyOperations(); err != nil {
 			return fmt.Errorf("error applying tc operations: %w", err)
 		}
@@ -179,9 +172,18 @@ func (i *networkDisruptionInjector) Inject() error {
 		i.config.Log.Debug("operations applied successfully")
 	}
 
-	// inject an iptables rule to mark all packets going out from the container using its cgroup path
-	if err := i.config.Iptables.AddCgroupFilterRule("mangle", "OUTPUT", i.config.Cgroup.RelativePath(""), "-j", "MARK", "--set-mark", types.InjectorCgroupClassID); err != nil {
-		return fmt.Errorf("error injecting cgroup packet marking iptables rule: %w", err)
+	// add a conntrack reference to enable it
+	// it consists of adding a noop iptables rule loading the conntrack module so it enables connection tracking in the targeted network namespace
+	// cf. https://thermalcircle.de/doku.php?id=blog:linux:connection_tracking_1_modules_and_hooks for more information on how conntrack works outside of the main network namespace
+	if err := i.config.Iptables.LogConntrack(); err != nil {
+		return fmt.Errorf("error injecting the conntrack reference iptables rule: %w", err)
+	}
+
+	// mark all packets created by the targeted container with the classifying mark
+	if i.config.Level == types.DisruptionLevelPod && !i.config.OnInit {
+		if err := i.config.Iptables.Mark(i.config.Cgroup.RelativePath(""), types.InjectorCgroupClassID); err != nil {
+			return fmt.Errorf("error injecting packet marking iptables rule: %w", err)
+		}
 	}
 
 	// exit target network namespace
@@ -222,12 +224,8 @@ func (i *networkDisruptionInjector) Clean() error {
 	}
 
 	// remove the conntrack reference to disable conntrack in the network namespace
-	if err := i.config.Iptables.DeleteRuleSpec("OUTPUT", "-m", "state", "--state", "new,established", "-j", "LOG"); err != nil {
-		return fmt.Errorf("error cleaning the conntrack reference iptables rule: %w", err)
-	}
-
-	if err := i.config.Iptables.DeleteCgroupFilterRule("mangle", "OUTPUT", i.config.Cgroup.RelativePath(""), "-j", "MARK", "--set-mark", types.InjectorCgroupClassID); err != nil {
-		return fmt.Errorf("error cleaning the cgroup packet marking iptables rule: %w", err)
+	if err := i.config.Iptables.Clear(); err != nil {
+		return fmt.Errorf("error cleaning iptables rules and chain: %w", err)
 	}
 
 	// exit target network namespace

--- a/injector/network_disruption_test.go
+++ b/injector/network_disruption_test.go
@@ -72,15 +72,9 @@ var _ = Describe("Failure", func() {
 
 		// iptables
 		iptables = &network.IptablesMock{}
-		iptables.On("CreateChain", mock.Anything).Return(nil)
-		iptables.On("ClearAndDeleteChain", mock.Anything).Return(nil)
-		iptables.On("AddRuleWithIP", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		iptables.On("AddWideFilterRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		iptables.On("AddCgroupFilterRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		iptables.On("PrependRuleSpec", mock.Anything, mock.Anything).Return(nil)
-		iptables.On("DeleteRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		iptables.On("DeleteRuleSpec", mock.Anything, mock.Anything).Return(nil)
-		iptables.On("DeleteCgroupFilterRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		iptables.On("Clear").Return(nil)
+		iptables.On("Mark", mock.Anything, mock.Anything).Return(nil)
+		iptables.On("LogConntrack").Return(nil)
 
 		// netlink
 		nllink1 = &network.NetlinkLinkMock{}
@@ -226,7 +220,7 @@ var _ = Describe("Failure", func() {
 		})
 
 		It("should mark packets going out from the identified (container or host) cgroup for the tc fw filter", func() {
-			iptables.AssertCalled(GinkgoT(), "AddCgroupFilterRule", "mangle", "OUTPUT", "/kubepod.slice/foo", []string{"-j", "MARK", "--set-mark", chaostypes.InjectorCgroupClassID})
+			iptables.AssertCalled(GinkgoT(), "Mark", "/kubepod.slice/foo", chaostypes.InjectorCgroupClassID)
 		})
 
 		// qlen cases
@@ -430,8 +424,8 @@ var _ = Describe("Failure", func() {
 			netnsManager.AssertCalled(GinkgoT(), "Exit")
 		})
 
-		It("should remove the cgroup iptables packet marking rule", func() {
-			iptables.AssertCalled(GinkgoT(), "DeleteCgroupFilterRule", "mangle", "OUTPUT", "/kubepod.slice/foo", []string{"-j", "MARK", "--set-mark", chaostypes.InjectorCgroupClassID})
+		It("should remove iptables rules", func() {
+			iptables.AssertCalled(GinkgoT(), "Clear")
 		})
 
 		Context("qdisc cleanup should happen", func() {

--- a/network/iptables.go
+++ b/network/iptables.go
@@ -14,152 +14,189 @@ import (
 
 // Iptables is an interface for interacting with target nat firewall/iptables rules
 type Iptables interface {
-	CreateChain(name string) error
-	ClearAndDeleteChain(name string) error
-	AddRuleWithIP(chain string, protocol string, port string, jump string, destinationIP string) error
-	AddWideFilterRule(chain string, protocol string, port string, jump string) error
-	AddCgroupFilterRule(table string, chain string, cgroupPath string, rulespec ...string) error
-	PrependRuleSpec(chain string, rulespec ...string) error
-	DeleteRule(chain string, protocol string, port string, jump string) error
-	DeleteRuleSpec(chain string, rulespec ...string) error
-	DeleteCgroupFilterRule(table string, chain string, cgroupPath string, rulespec ...string) error
-	ListRules(table string, chain string) ([]string, error)
+	Clear() error
+	LogConntrack() error
+	RedirectTo(protocol string, port string, destinationIP string) error
+	Intercept(protocol string, port string, cgroupPath string, injectorPodIP string) error
+	Mark(cgroupPath string, mark string) error
 }
 
 type iptables struct {
-	log    *zap.SugaredLogger
-	dryRun bool
-	ip     *goiptables.IPTables
+	log           *zap.SugaredLogger
+	dryRun        bool
+	ip            *goiptables.IPTables
+	injectedRules []rule
 }
+
+type rule struct {
+	table    string
+	chain    string
+	rulespec []string
+}
+
+const (
+	chaosChainName = "CHAOS-DNS"
+)
 
 // NewIptables returns an implementation of the Iptables interface that can log
 func NewIptables(log *zap.SugaredLogger, dryRun bool) (Iptables, error) {
 	ip, err := goiptables.New()
 
-	return iptables{
-		log:    log,
-		dryRun: dryRun,
-		ip:     ip,
+	return &iptables{
+		log:           log,
+		dryRun:        dryRun,
+		ip:            ip,
+		injectedRules: []rule{},
 	}, err
 }
 
-func (i iptables) CreateChain(name string) error {
+// Clear removes any previously injected rules in any chain and table
+func (i *iptables) Clear() error {
+	i.log.Infow("deleting injected iptables rules", "chain", chaosChainName)
+
 	if i.dryRun {
 		return nil
 	}
 
-	if res, _ := i.ip.ChainExists("nat", name); res {
-		return nil
+	// remove previously injected rules
+	for _, r := range i.injectedRules {
+		i.log.Infow("deleting injected iptables rule", "chain", r.chain, "table", r.table, "rulespec", r.rulespec)
+
+		// skip if it does not exist anymore for idempotency
+		exists, err := i.ip.Exists(r.table, r.chain, r.rulespec...)
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			i.log.Infow("iptables rule doesn't exist anymore, skipping cleaning", "table", r.table, "chain", r.chain, "rulespec", r.rulespec)
+
+			continue
+		}
+
+		// delete rule
+		if err := i.ip.Delete(r.table, r.chain, r.rulespec...); err != nil {
+			return err
+		}
 	}
 
-	i.log.Infow("creating new iptables chain", "chain name", name)
+	// eventually delete the injector dedicated chain
+	// the error is ignored here as any remaining rules in the chain, or any remaining
+	// jumping rules to that chain, coming from any remaining injector would cause it to error
+	_ = i.ip.DeleteChain("nat", chaosChainName)
 
-	return i.ip.NewChain("nat", name)
+	return nil
 }
 
-func (i iptables) ClearAndDeleteChain(name string) error {
+// LogConntrack creates a rule logging packets with a new or established connection state,
+// usually used to enable the conntrack tracking in non-root network namespaces
+func (i *iptables) LogConntrack() error {
+	return i.insert("nat", "OUTPUT", "-m", "state", "--state", "new,established", "-j", "LOG")
+}
+
+// RedirectTo redirects the matching packets to the given destination IP
+func (i *iptables) RedirectTo(protocol string, port string, destinationIP string) error {
+	return i.insert("nat", chaosChainName, "-p", protocol, "--dport", port, "-j", "DNAT", "--to-destination", destinationIP+":"+port)
+}
+
+// Intercept jumps the matching packets to the injector dedicated chain except for
+// packets coming from the injector itself
+func (i *iptables) Intercept(protocol string, port string, cgroupPath string, injectorPodIP string) error {
+	rulespec := []string{}
+
+	// add protocol
+	if protocol != "" {
+		rulespec = append(rulespec, "-p", protocol)
+	}
+
+	// add port
+	if port != "" {
+		rulespec = append(rulespec, "--dport", port)
+	}
+
+	// exclude injector pod IP
+	if injectorPodIP != "" {
+		rulespec = append(rulespec, "!", "-s", injectorPodIP)
+	}
+
+	// add cgroup path
+	if cgroupPath != "" {
+		rulespec = append(rulespec, "-m", "cgroup", "--path", cgroupPath)
+	}
+
+	rulespec = append(rulespec, "-j", chaosChainName)
+
+	// inject output rule
+	if err := i.insert("nat", "OUTPUT", rulespec...); err != nil {
+		return err
+	}
+
+	// inject prerouting rule only if there's no cgroup path filtering
+	// packets going through prerouting chain are not yet associated
+	// to a process so there's no possibility to filter on a cgroup at this stage
+	if cgroupPath == "" {
+		if err := i.insert("nat", "PREROUTING", rulespec...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Mark marks the packets in the injector dedicated chain with the given mark
+func (i *iptables) Mark(cgroupPath string, mark string) error {
+	return i.insert("mangle", "OUTPUT", "-m", "cgroup", "--path", cgroupPath, "-j", "MARK", "--set-mark", mark)
+}
+
+// insert creates a new iptables rule definition, stores it
+// for further cleanup and inserts the rule in the given table and chain
+// at the first position
+func (i *iptables) insert(table string, chain string, rulespec ...string) error {
+	i.log.Infow("injecting iptables rule", "table", table, "chain", chain, "rulespec", rulespec)
+
 	if i.dryRun {
 		return nil
 	}
 
-	i.log.Infow("deleting iptables chain", "chain name", name)
+	// create the injector chain if it does not exist yet and is used here
+	if chain == chaosChainName {
+		chainExists, err := i.ip.ChainExists(table, chain)
+		if err != nil {
+			return err
+		}
 
-	return i.ip.ClearAndDeleteChain("nat", name)
-}
+		if !chainExists {
+			if err := i.ip.NewChain(table, chain); err != nil {
+				return fmt.Errorf("error creating chain %s: %w", chain, err)
+			}
+		}
+	}
 
-func (i iptables) AddRuleWithIP(chain string, protocol string, port string, jump string, destinationIP string) error {
-	if i.dryRun {
+	// check if the rule already exists before trying to insert it
+	exists, err := i.ip.Exists(table, chain, rulespec...)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		i.log.Infow("iptables rule already exists, skipping", "table", table, "chain", chain, "rulespec", rulespec)
+
 		return nil
 	}
 
-	i.log.Infow("creating new iptables rule", "chain name", chain, "protocol", protocol, "port", port, "jump target", jump, "destination", destinationIP)
-
-	return i.ip.AppendUnique("nat", chain, "-p", protocol, "--dport", port, "-j", jump, "--to-destination", fmt.Sprintf("%s:%s", destinationIP, port))
-}
-
-func (i iptables) PrependRuleSpec(chain string, rulespec ...string) error {
-	if i.dryRun {
-		return nil
+	// inject rule
+	if err := i.ip.Insert(table, chain, 1, rulespec...); err != nil {
+		return fmt.Errorf("error injecting rule: %w", err)
 	}
 
-	i.log.Infow("creating new iptables rule", "chain name", chain, "rulespec", rulespec)
-
-	// 1 is the first position, not 0
-	return i.ip.Insert("nat", chain, 1, rulespec...)
-}
-
-// Add a rule with cgroup filter
-func (i iptables) AddCgroupFilterRule(table string, chain string, cgroupPath string, rulespec ...string) error {
-	if i.dryRun {
-		return nil
+	r := rule{
+		table:    table,
+		chain:    chain,
+		rulespec: rulespec,
 	}
 
-	i.log.Infow("creating new iptables rule", "table", table, "chain", chain, "cgroup path", cgroupPath, "rulespec", rulespec)
+	// store rule for further cleanup
+	i.injectedRules = append(i.injectedRules, r)
 
-	rulespec = append([]string{"-m", "cgroup", "--path", cgroupPath}, rulespec...)
-
-	return i.ip.AppendUnique(table, chain, rulespec...)
-}
-
-func (i iptables) AddWideFilterRule(chain string, protocol string, port string, jump string) error {
-	if i.dryRun {
-		return nil
-	}
-
-	i.log.Infow("creating new iptables rule", "chain name", chain, "protocol", protocol, "port", port, "jump target", jump)
-
-	return i.ip.AppendUnique("nat", chain, "-p", protocol, "--dport", port, "-j", jump)
-}
-
-func (i iptables) DeleteRule(chain string, protocol string, port string, jump string) error {
-	if i.dryRun {
-		return nil
-	}
-
-	// Why do we check if the jump target exists? A command of the form
-	// iptables -t nat -C OUTPUT -p udp --dport 53 -j CHAOS-DNS
-	// will actually error if the jump target does not exist. However, you are unable
-	// to delete a chain if there are rules that jump to it, so if the target does not exist
-	// we can be sure that the rule does not exist.
-	if exists, _ := i.ip.ChainExists("nat", jump); !exists {
-		return nil
-	}
-
-	return i.DeleteRuleSpec("nat", chain, "-p", protocol, "--dport", port, "-j", jump)
-}
-
-func (i iptables) DeleteRuleSpec(chain string, rulespec ...string) error {
-	if i.dryRun {
-		return nil
-	}
-
-	i.log.Infow("deleting iptables rule", "chain name", chain, "rulespec", rulespec)
-
-	if exists, _ := i.ip.ChainExists("nat", chain); !exists {
-		return nil
-	}
-
-	return i.ip.DeleteIfExists("nat", chain, rulespec...)
-}
-
-// Delete a rule with cgroup filter
-func (i iptables) DeleteCgroupFilterRule(table string, chain string, cgroupPath string, rulespec ...string) error {
-	if i.dryRun {
-		return nil
-	}
-
-	i.log.Infow("deleting iptables rule", "chain name", chain, "cgroup path", cgroupPath, "rulespec", rulespec)
-
-	if exists, _ := i.ip.ChainExists(table, chain); !exists {
-		return nil
-	}
-
-	rulespec = append([]string{"-m", "cgroup", "--path", cgroupPath}, rulespec...)
-
-	return i.ip.DeleteIfExists(table, chain, rulespec...)
-}
-
-// ListRules lists the rules of the given table and chain
-func (i iptables) ListRules(table string, chain string) ([]string, error) {
-	return i.ip.List(table, chain)
+	return nil
 }

--- a/network/iptables_mock.go
+++ b/network/iptables_mock.go
@@ -13,71 +13,36 @@ type IptablesMock struct {
 }
 
 //nolint:golint
-func (f *IptablesMock) CreateChain(name string) error {
-	args := f.Called(name)
+func (f *IptablesMock) Clear() error {
+	args := f.Called()
 
 	return args.Error(0)
 }
 
 //nolint:golint
-func (f *IptablesMock) ClearAndDeleteChain(name string) error {
-	args := f.Called(name)
+func (f *IptablesMock) RedirectTo(protocol string, port string, destinationIP string) error {
+	args := f.Called(protocol, port, destinationIP)
 
 	return args.Error(0)
 }
 
 //nolint:golint
-func (f *IptablesMock) AddRuleWithIP(chain string, protocol string, port string, jump string, destinationIP string) error {
-	args := f.Called(chain, protocol, port, jump, destinationIP)
+func (f *IptablesMock) Intercept(protocol string, port string, cgroupPath string, injectorPodIP string) error {
+	args := f.Called(protocol, port, cgroupPath, injectorPodIP)
 
 	return args.Error(0)
 }
 
 //nolint:golint
-func (f *IptablesMock) PrependRuleSpec(chain string, rulespec ...string) error {
-	args := f.Called(chain, rulespec)
+func (f *IptablesMock) Mark(cgroupPath string, mark string) error {
+	args := f.Called(cgroupPath, mark)
 
 	return args.Error(0)
 }
 
 //nolint:golint
-func (f *IptablesMock) DeleteRule(chain string, protocol string, port string, jump string) error {
-	args := f.Called(chain, protocol, port, jump)
+func (f *IptablesMock) LogConntrack() error {
+	args := f.Called()
 
 	return args.Error(0)
-}
-
-//nolint:golint
-func (f *IptablesMock) DeleteRuleSpec(chain string, rulespec ...string) error {
-	args := f.Called(chain, rulespec)
-
-	return args.Error(0)
-}
-
-//nolint:golint
-func (f *IptablesMock) AddWideFilterRule(chain string, protocol string, port string, jump string) error {
-	args := f.Called(chain, protocol, port, jump)
-
-	return args.Error(0)
-}
-
-//nolint:golint
-func (f *IptablesMock) AddCgroupFilterRule(table string, chain string, cgroupPath string, rulespec ...string) error {
-	args := f.Called(table, chain, cgroupPath, rulespec)
-
-	return args.Error(0)
-}
-
-//nolint:golint
-func (f *IptablesMock) DeleteCgroupFilterRule(table string, chain string, cgroupPath string, rulespec ...string) error {
-	args := f.Called(table, chain, cgroupPath, rulespec)
-
-	return args.Error(0)
-}
-
-//nolint:golint
-func (f *IptablesMock) ListRules(table string, chain string) ([]string, error) {
-	args := f.Called(table, chain)
-
-	return args.Get(0).([]string), args.Error(1)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -73,9 +73,6 @@ const (
 	// This value should NEVER be changed without changing the Network Disruption TC tree.
 	InjectorCgroupClassID = "0x00020002"
 
-	// iptables chain name used by the injector to filter and redirect DNS packets in the DNS disruption
-	InjectorIptablesChaosDNSChainName = "CHAOS-DNS"
-
 	// DDMarkChaoslibPrefix allows to consistently name the chaos-imported API in ddmark.
 	// It's arbitrary but needs to be consistent across multiple files.
 	DDMarkChaoslibPrefix = "chaos-api"


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The iptables module from the network package has been totally revamped
- Functions now contains more business logic adapted to their use case instead of being extensions of existing iptables commands
- The module now tracks the injected rules to clean them up all at once in the `Clear` function
- It does not change any of the existing injection logic, only the code is reshaped to be easier to maintain

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - I applied and verified dns and network disruptions
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
