### PR TITLE
CHAOS-451: Fix - Target reinjection is creating additional netem qdiscs in network disruptions

### DIFF
--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -325,7 +325,7 @@ func initPodWatch(resourceVersion string) (<-chan watch.Event, error) {
 	return podWatcher.ResultChan(), err
 }
 
-// inject inject all the disruptions using the list of injectors
+// inject all the disruptions using the list of injectors
 // returns true if injection succeeded, false otherwise
 func inject(kind string, sendToMetrics bool, reinjection bool) bool {
 	errOnInject := false

--- a/docs/network_disruption/prio.md
+++ b/docs/network_disruption/prio.md
@@ -117,7 +117,7 @@ spec:
 #### (Step 1) Add a fourth band
 
 <p align="center"><kbd>
-    <img src="../docs/img/network_prio/1-4.png" height=220 width=650 />
+    <img src="../../docs/img/network_prio/1-4.png" height=220 width=650 />
 </kbd></p>
 
 The disruption should only affect packets leaving our target node. On top of the three default bands, chaos-controller creates a fourth band (class `1:4`) to which it will send packets identified as candidates for the disruptions. In this step, the filter on handle `1:` to route traffic to class `1:4` has not been set up. We will see the specific criteria in `Step 3` after setting up the fourth band completely.

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -952,6 +952,9 @@ func (i *networkDisruptionInjector) clearOperations() error {
 		return fmt.Errorf("error deleting root qdisc: %w", err)
 	}
 
+	// clear operations to avoid them to stack up
+	i.operations = []linkOperation{}
+
 	return nil
 }
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Fix typo errors.
- Fix network disruption to create additional netem qdis by remove all operations of the network disruption during the Clean step. 

## How to reproduce

- Clone the chaos-controlle and checkout to the main branch
- inject the network drop disruption example
- look at tc rules injected in the target container: it should contain a single netem qdisc:
``` bash
root@lima-default:~# nsenter --net=/proc/6976/ns/net tc qdisc
qdisc noqueue 0: dev lo root refcnt 2
qdisc prio 1: dev eth0 root refcnt 5 bands 4 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
qdisc prio 2: dev eth0 parent 1:4 bands 2 priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
qdisc netem 3: dev eth0 parent 2:2 limit 1000 loss 100%
```
- wait for the reinjection to happen (usually less than a minute, look at injector logs for that).
- look at tc rules again and you’ll not see an additional netem qdisc chained to the first one:
``` bash
root@lima-default:~# nsenter --net=/proc/6976/ns/net tc qdisc
qdisc noqueue 0: dev lo root refcnt 2
qdisc prio 1: dev eth0 root refcnt 5 bands 4 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
qdisc prio 2: dev eth0 parent 1:4 bands 2 priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
qdisc netem 4: dev eth0 parent 3: limit 1000 loss 100%
qdisc netem 3: dev eth0 parent 2:2 limit 1000 loss 100%
```

After the fix the `qdisc netem 4: dev eth0 parent 3: limit 1000 loss 100%` should neither be created so the result should stay the following:
``` bash
root@lima-default:~# nsenter --net=/proc/6976/ns/net tc qdisc
qdisc noqueue 0: dev lo root refcnt 2
qdisc prio 1: dev eth0 root refcnt 5 bands 4 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
qdisc prio 2: dev eth0 parent 1:4 bands 2 priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
qdisc netem 3: dev eth0 parent 2:2 limit 1000 loss 100%
```

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
