### PR TITLE
Fix cgroup v1 network disruptions injection

### DIFF
--- a/network/iptables_mock.go
+++ b/network/iptables_mock.go
@@ -27,15 +27,22 @@ func (f *IptablesMock) RedirectTo(protocol string, port string, destinationIP st
 }
 
 //nolint:golint
-func (f *IptablesMock) Intercept(protocol string, port string, cgroupPath string, injectorPodIP string) error {
-	args := f.Called(protocol, port, cgroupPath, injectorPodIP)
+func (f *IptablesMock) Intercept(protocol string, port string, cgroupPath string, cgroupClassID string, injectorPodIP string) error {
+	args := f.Called(protocol, port, cgroupPath, cgroupClassID, injectorPodIP)
 
 	return args.Error(0)
 }
 
 //nolint:golint
-func (f *IptablesMock) Mark(cgroupPath string, mark string) error {
+func (f *IptablesMock) MarkCgroupPath(cgroupPath string, mark string) error {
 	args := f.Called(cgroupPath, mark)
+
+	return args.Error(0)
+}
+
+//nolint:golint
+func (f *IptablesMock) MarkClassID(classID string, mark string) error {
+	args := f.Called(classID, mark)
 
 	return args.Error(0)
 }


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Network disruptions injection for cgroups v1 now relies on a combination of net_cls classid marking and iptables marking as suggested in the official man.
- The reason for that is that cgroup path matching in iptables was made, as a first intent, for cgroups v2. While it is working fine on our local environment, we discovered some differences in how the cgroup root is handled in linux when using cgroups v1 leading to iptables being unable to match the correct path, breaking the disruptions in some environments.
- The solution remains unchanged for cgroups v2 where there's a common root for all controllers.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - Applying dns and network disruptions on both cgroups v1 and cgroups v2 environments.
    - [x] locally.
    - [x] as a canary deployment to a cluster.
