### PR TITLE
Include ebpf artifacts in gitlab after make

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ build:make:
     - curl -O https://dl.google.com/go/${GO_FILENAME}
     - rm -rf /usr/local/go && tar -C /usr/local -xzf ${GO_FILENAME}
     - export PATH=$PATH:/usr/local/go/bin
-    - make
+    - make all docker-build-ebpf
   artifacts:
     paths:
       - bin/injector/injector_amd64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,7 @@ build:make:
       - bin/injector/injector_arm64
       - bin/manager/manager_arm64
       - bin/handler/handler_arm64
+      - bin/injector/ebpf/*
 
 # build the target from the local Dockerfile and push it to the registry
 # replication will depend on the TARGET_LABEL set by parent job


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Our gitlab CI couldn't release because we weren't building or including ebpf

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
