### PR TITLE
CHAOS-493: Dont error on cleanup if we can't find target cgroup file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ lima-redeploy: lima-build-all lima-install lima-restart
 ## Install cert-manager chart
 lima-install-cert-manager:
 	$(KUBECTL) apply -f https://github.com/jetstack/cert-manager/releases/download/v1.9.1/cert-manager.yaml
+	$(KUBECTL) -n cert-manager rollout status deployment/cert-manager-webhook --timeout=180s
 
 ## Install CRDs and controller into a lima k3s cluster
 ## In order to use already built images inside the containerd runtime

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -419,7 +419,7 @@ func reinject(cmdName string) error {
 	return nil
 }
 
-// clean clean all the disruptions using the list of injectors
+// clean will remove or undo all the disruptions using the list of injectors
 // returns true if cleanup succeeded, false otherwise
 func clean(kind string, sendToMetrics bool, reinjectionClean bool) bool {
 	errOnClean := false

--- a/examples/container_failure_forced.yaml
+++ b/examples/container_failure_forced.yaml
@@ -13,8 +13,8 @@ metadata:
 spec:
   selector:
     app: demo-curl
-  containers: # only target the dummy container, you can specify multiple containers here (all containers are targeted by default)
-    - dummy
+  containers: # only target the curl container, you can specify multiple containers here (all containers are targeted by default)
+    - curl
   count: 1
   containerFailure:
     forced: true # send a SIGKILL signal to the specified containers

--- a/examples/container_failure_graceful.yaml
+++ b/examples/container_failure_graceful.yaml
@@ -13,8 +13,8 @@ metadata:
 spec:
   selector:
     app: demo-curl
-  containers: # only target the dummy container, you can specify multiple containers here (all containers are targeted by default)
-    - dummy
+  containers: # only target the curl container, you can specify multiple containers here (all containers are targeted by default)
+    - curl
   count: 1
   containerFailure:
     forced: false # send a SIGTERM signal to the specified containers

--- a/examples/containers_targeting.yaml
+++ b/examples/containers_targeting.yaml
@@ -14,8 +14,8 @@ spec:
   level: pod
   selector:
     app: demo-curl
-  containers: # only target the dummy container, you can specify multiple containers here (all containers are targeted by default)
-    - dummy
+  containers: # only target the curl container, you can specify multiple containers here (all containers are targeted by default)
+    - curl
   count: 1
   network:
     drop: 10

--- a/injector/dns_disruption.go
+++ b/injector/dns_disruption.go
@@ -206,7 +206,12 @@ func (i *DNSDisruptionInjector) Clean() error {
 	// Remove the net_cls classid for cgroup v1
 	if !i.config.Cgroup.IsCgroupV2() {
 		if err := i.config.Cgroup.Write("net_cls", "net_cls.classid", "0"); err != nil {
-			return fmt.Errorf("unable to write net_cls classid: %w", err)
+			if os.IsNotExist(err) {
+				i.config.Log.Warnw("unable to find target container's net_cls.classid file, we will assume we cannot find the cgroup path because it is gone", "targetContainerID", i.config.TargetContainer.ID(), "err, err")
+				return nil
+			}
+
+			return fmt.Errorf("error cleaning net_cls classid: %w", err)
 		}
 	}
 

--- a/injector/dns_disruption.go
+++ b/injector/dns_disruption.go
@@ -207,7 +207,7 @@ func (i *DNSDisruptionInjector) Clean() error {
 	if !i.config.Cgroup.IsCgroupV2() {
 		if err := i.config.Cgroup.Write("net_cls", "net_cls.classid", "0"); err != nil {
 			if os.IsNotExist(err) {
-				i.config.Log.Warnw("unable to find target container's net_cls.classid file, we will assume we cannot find the cgroup path because it is gone", "targetContainerID", i.config.TargetContainer.ID(), "err, err")
+				i.config.Log.Warnw("unable to find target container's net_cls.classid file, we will assume we cannot find the cgroup path because it is gone", "targetContainerID", i.config.TargetContainer.ID(), "err", err)
 				return nil
 			}
 

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -242,6 +242,11 @@ func (i *networkDisruptionInjector) Clean() error {
 	// remove the net_cls classid used for cgroup v1
 	if !i.config.Cgroup.IsCgroupV2() {
 		if err := i.config.Cgroup.Write("net_cls", "net_cls.classid", "0"); err != nil {
+			if os.IsNotExist(err) {
+				i.config.Log.Warnw("unable to find target container's net_cls.classid file, we will assume we cannot find the cgroup path because it is gone", "targetContainerID", i.config.TargetContainer.ID(), "err, err")
+				return nil
+			}
+
 			return fmt.Errorf("error cleaning net_cls classid: %w", err)
 		}
 	}

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -243,7 +243,7 @@ func (i *networkDisruptionInjector) Clean() error {
 	if !i.config.Cgroup.IsCgroupV2() {
 		if err := i.config.Cgroup.Write("net_cls", "net_cls.classid", "0"); err != nil {
 			if os.IsNotExist(err) {
-				i.config.Log.Warnw("unable to find target container's net_cls.classid file, we will assume we cannot find the cgroup path because it is gone", "targetContainerID", i.config.TargetContainer.ID(), "err, err")
+				i.config.Log.Warnw("unable to find target container's net_cls.classid file, we will assume we cannot find the cgroup path because it is gone", "targetContainerID", i.config.TargetContainer.ID(), "err", err)
 				return nil
 			}
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- @luphaz this is not done, but what do you think of this approach? In `cli/injector/main.go`'s clean, we don't have enough information about the injectors or targets to skip cleaning. I also think its smart to skip as little of `clean` as possible, just in case. I am thinking we should change the `if !exists {` at L250 in `network_disruption.go` to confirm that our `Write` error was also a not found error?

I'll need to read through all the other injectors to see if we should put similar checks in there, but users are typically only hitting this on network for now.

- Has two unrelated changes. One is to block on `make lima-install-cert-manager`, because `make lima-all` kept failing for me because my laptop was a little slow in pulling the cert-manager image. Second is that we removed the `dummy` container from the `demo-curl` pod six months ago but didn't update the container failure examples.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
