### PR TITLE
feat(injector): reuse DisruptionArgs

### DIFF
--- a/cli/injector/dns_disruption.go
+++ b/cli/injector/dns_disruption.go
@@ -48,10 +48,7 @@ var dnsDisruptionCmd = &cobra.Command{
 			inj, err := injector.NewDNSDisruptionInjector(
 				hostRecordPairs,
 				injector.DNSDisruptionInjectorConfig{
-					Config:              config,
-					DisruptionName:      disruptionName,
-					DisruptionNamespace: disruptionNamespace,
-					TargetName:          targetName,
+					Config: config,
 				},
 			)
 			if err != nil {

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -276,7 +276,7 @@ func initConfig() {
 
 		deadline, err = time.Parse(time.RFC3339, deadlineRaw)
 		if err != nil {
-			deadline = time.Now().Add(time.Hour)
+			deadline = time.Now().Add(time.Minute * 5)
 
 			log.Errorw("unable to determine disruption deadline, will self-terminate in one hour instead", "err", err)
 		}

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	chaosapi "github.com/DataDog/chaos-controller/api"
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/cgroup"
 	"github.com/DataDog/chaos-controller/container"
@@ -51,32 +52,19 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	log                  *zap.SugaredLogger
-	dryRun               bool
-	ms                   metrics.Sink
-	sink                 string
-	level                string
-	rawTargetContainers  []string // contains name:id containers
-	targetContainers     map[string]string
-	targetPodIP          string
-	disruptionName       string
-	disruptionNamespace  string
-	chaosNamespace       string
-	targetName           string
-	targetNodeName       string
-	onInit               bool
-	pulseInitialDelay    time.Duration
-	pulseActiveDuration  time.Duration
-	pulseDormantDuration time.Duration
-	deadlineRaw          string
-	handlerPID           uint32
-	configs              []injector.Config
-	signals              chan os.Signal
-	injectors            []injector.Injector
-	readyToInject        bool
-	dnsServer            string
-	kubeDNS              string
-	clientset            *kubernetes.Clientset
+	disruptionArgs      chaosapi.DisruptionArgs
+	disruptionLevelRaw  string
+	log                 *zap.SugaredLogger
+	ms                  metrics.Sink
+	rawTargetContainers []string // contains name:id containers
+	deadlineRaw         string
+	deadline            time.Time
+	handlerPID          uint32
+	configs             []injector.Config
+	signals             chan os.Signal
+	injectors           []injector.Injector
+	readyToInject       bool
+	clientset           *kubernetes.Clientset
 )
 
 func init() {
@@ -90,25 +78,25 @@ func init() {
 	rootCmd.AddCommand(grpcDisruptionCmd)
 
 	// basic args
-	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Enable dry-run mode")
-	rootCmd.PersistentFlags().StringVar(&sink, "metrics-sink", "noop", "Metrics sink (datadog, or noop)")
-	rootCmd.PersistentFlags().StringVar(&level, "level", "", "Level of injection (either pod or node)")
+	rootCmd.PersistentFlags().BoolVar(&disruptionArgs.DryRun, "dry-run", false, "Enable dry-run mode")
+	rootCmd.PersistentFlags().StringVar(&disruptionArgs.MetricsSink, "metrics-sink", "noop", "Metrics sink (datadog, or noop)")
+	rootCmd.PersistentFlags().StringVar(&disruptionLevelRaw, "level", "", "Level of injection (either pod or node)")
 	rootCmd.PersistentFlags().StringSliceVar(&rawTargetContainers, "target-containers", []string{}, "Targeted containers")
-	rootCmd.PersistentFlags().StringVar(&targetPodIP, "target-pod-ip", "", "Pod IP of targeted pod")
-	rootCmd.PersistentFlags().BoolVar(&onInit, "on-init", false, "Apply the disruption on initialization, requiring a synchronization with the chaos-handler container")
-	rootCmd.PersistentFlags().DurationVar(&pulseInitialDelay, "pulse-initial-delay", time.Duration(0), "Duration to wait after injector starts before beginning the activeDuration")
-	rootCmd.PersistentFlags().DurationVar(&pulseActiveDuration, "pulse-active-duration", time.Duration(0), "Duration of the disruption being active in a pulsing disruption (empty if the disruption is not pulsing)")
-	rootCmd.PersistentFlags().DurationVar(&pulseDormantDuration, "pulse-dormant-duration", time.Duration(0), "Duration of the disruption being dormant in a pulsing disruption (empty if the disruption is not pulsing)")
+	rootCmd.PersistentFlags().StringVar(&disruptionArgs.TargetPodIP, "target-pod-ip", "", "Pod IP of targeted pod")
+	rootCmd.PersistentFlags().BoolVar(&disruptionArgs.OnInit, "on-init", false, "Apply the disruption on initialization, requiring a synchronization with the chaos-handler container")
+	rootCmd.PersistentFlags().DurationVar(&disruptionArgs.PulseInitialDelay, "pulse-initial-delay", time.Duration(0), "Duration to wait after injector starts before beginning the activeDuration")
+	rootCmd.PersistentFlags().DurationVar(&disruptionArgs.PulseActiveDuration, "pulse-active-duration", time.Duration(0), "Duration of the disruption being active in a pulsing disruption (empty if the disruption is not pulsing)")
+	rootCmd.PersistentFlags().DurationVar(&disruptionArgs.PulseDormantDuration, "pulse-dormant-duration", time.Duration(0), "Duration of the disruption being dormant in a pulsing disruption (empty if the disruption is not pulsing)")
 	rootCmd.PersistentFlags().StringVar(&deadlineRaw, "deadline", "", "Timestamp at which the disruption must be over by")
-	rootCmd.PersistentFlags().StringVar(&dnsServer, "dns-server", "8.8.8.8", "IP address of the upstream DNS server")
-	rootCmd.PersistentFlags().StringVar(&kubeDNS, "kube-dns", "off", "Whether to use kube-dns for DNS resolution (off, internal, all)")
-	rootCmd.PersistentFlags().StringVar(&chaosNamespace, "chaos-namespace", "chaos-engineering", "Namespace that contains this chaos pod")
+	rootCmd.PersistentFlags().StringVar(&disruptionArgs.DNSServer, "dns-server", "8.8.8.8", "IP address of the upstream DNS server")
+	rootCmd.PersistentFlags().StringVar(&disruptionArgs.KubeDNS, "kube-dns", "off", "Whether to use kube-dns for DNS resolution (off, internal, all)")
+	rootCmd.PersistentFlags().StringVar(&disruptionArgs.ChaosNamespace, "chaos-namespace", "chaos-engineering", "Namespace that contains this chaos pod")
 
 	// log context args
-	rootCmd.PersistentFlags().StringVar(&disruptionName, "log-context-disruption-name", "", "Log value: current disruption name")
-	rootCmd.PersistentFlags().StringVar(&disruptionNamespace, "log-context-disruption-namespace", "", "Log value: current disruption namespace")
-	rootCmd.PersistentFlags().StringVar(&targetName, "log-context-target-name", "", "Log value: current target name")
-	rootCmd.PersistentFlags().StringVar(&targetNodeName, "log-context-target-node-name", "", "Log value: node hosting the current target pod")
+	rootCmd.PersistentFlags().StringVar(&disruptionArgs.DisruptionName, "log-context-disruption-name", "", "Log value: current disruption name")
+	rootCmd.PersistentFlags().StringVar(&disruptionArgs.DisruptionNamespace, "log-context-disruption-namespace", "", "Log value: current disruption namespace")
+	rootCmd.PersistentFlags().StringVar(&disruptionArgs.TargetName, "log-context-target-name", "", "Log value: current target name")
+	rootCmd.PersistentFlags().StringVar(&disruptionArgs.TargetNodeName, "log-context-target-node-name", "", "Log value: node hosting the current target pod")
 
 	_ = cobra.MarkFlagRequired(rootCmd.PersistentFlags(), "level")
 	cobra.OnInitialize(initLogger)
@@ -145,10 +133,10 @@ func initLogger() {
 	}
 
 	log = log.With(
-		"disruptionName", disruptionName,
-		"disruptionNamespace", disruptionNamespace,
-		"targetName", targetName,
-		"targetNodeName", targetNodeName,
+		"disruptionName", disruptionArgs.DisruptionName,
+		"disruptionNamespace", disruptionArgs.DisruptionNamespace,
+		"targetName", disruptionArgs.TargetName,
+		"targetNodeName", disruptionArgs.TargetNodeName,
 	)
 }
 
@@ -156,7 +144,7 @@ func initLogger() {
 func initMetricsSink() {
 	var err error
 
-	ms, err = metrics.GetSink(types.SinkDriver(sink), types.SinkAppInjector)
+	ms, err = metrics.GetSink(types.SinkDriver(disruptionArgs.MetricsSink), types.SinkAppInjector)
 	if err != nil {
 		log.Errorw("error while creating metric sink, switching to noop sink", "error", err)
 
@@ -167,7 +155,7 @@ func initMetricsSink() {
 func initManagers(pid uint32) (netns.Manager, cgroup.Manager, error) {
 	netnsMgr, err := netns.NewManager(log, pid)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating network namespace manager: %s", err.Error())
+		return nil, nil, fmt.Errorf("error creating network namespace manager: %w", err)
 	}
 
 	// retrieve cgroup mount path set in env or fallback to the default value
@@ -182,9 +170,9 @@ func initManagers(pid uint32) (netns.Manager, cgroup.Manager, error) {
 	}
 
 	// create cgroups manager
-	cgroupMgr, err := cgroup.NewManager(dryRun, pid, cgroupMount, log)
+	cgroupMgr, err := cgroup.NewManager(disruptionArgs.DryRun, pid, cgroupMount, log)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating cgroup manager: %s", err.Error())
+		return nil, nil, fmt.Errorf("error creating cgroup manager: %w", err)
 	}
 
 	return netnsMgr, cgroupMgr, nil
@@ -194,34 +182,37 @@ func initManagers(pid uint32) (netns.Manager, cgroup.Manager, error) {
 func initConfig() {
 	pids := []uint32{}
 	ctns := []container.Container{}
-	dnsConfig := network.DNSConfig{DNSServer: dnsServer, KubeDNS: kubeDNS}
+	dnsConfig := network.DNSConfig{DNSServer: disruptionArgs.DNSServer, KubeDNS: disruptionArgs.KubeDNS}
 
 	// log when dry-run mode is enabled
-	if dryRun {
+	if disruptionArgs.DryRun {
 		log.Warn("dry run mode enabled, no disruption will be injected but most of the commands will still be executed to simulate it as much as possible")
 	}
 
-	targetContainers = map[string]string{}
+	disruptionArgs.TargetContainers = map[string]string{}
 
 	// parse target-containers
 	for _, cnt := range rawTargetContainers {
 		splittedCntInfo := strings.SplitN(cnt, ";", 2)
 
 		if len(splittedCntInfo) == 2 {
-			targetContainers[splittedCntInfo[0]] = splittedCntInfo[1]
+			disruptionArgs.TargetContainers[splittedCntInfo[0]] = splittedCntInfo[1]
 		}
 	}
 
-	switch level {
+	// assign to the pointer to level the new value to persist it after this method
+	*(&disruptionArgs.Level) = chaostypes.DisruptionLevel(disruptionLevelRaw)
+
+	switch disruptionArgs.Level {
 	case chaostypes.DisruptionLevelPod:
 		// check for container ID flag
-		if len(targetContainers) == 0 {
+		if len(disruptionArgs.TargetContainers) == 0 {
 			log.Error("--target-containers flag must be passed when --level=pod")
 
 			return
 		}
 
-		for _, containerID := range targetContainers {
+		for _, containerID := range disruptionArgs.TargetContainers {
 			// retrieve container info
 			ctn, err := container.New(containerID)
 			if err != nil {
@@ -235,7 +226,7 @@ func initConfig() {
 			pid := ctn.PID()
 
 			// keep pid for later if this is a chaos handler container
-			if onInit && ctn.Name() == chaosInitContName {
+			if disruptionArgs.OnInit && ctn.Name() == chaosInitContName {
 				handlerPID = pid
 			}
 
@@ -244,7 +235,7 @@ func initConfig() {
 		}
 
 		// check for pod IP flag
-		if targetPodIP == "" {
+		if disruptionArgs.TargetPodIP == "" {
 			log.Error("--target-pod-ip flag must be passed when --level=pod")
 
 			return
@@ -253,7 +244,7 @@ func initConfig() {
 		pids = []uint32{1}
 		ctns = []container.Container{nil}
 	default:
-		log.Errorf("unknown level: %s", level)
+		log.Errorf("unknown level: %s", disruptionArgs.Level)
 
 		return
 	}
@@ -283,20 +274,24 @@ func initConfig() {
 			return
 		}
 
+		deadline, err = time.Parse(time.RFC3339, deadlineRaw)
+		if err != nil {
+			deadline = time.Now().Add(time.Hour)
+
+			log.Errorw("unable to determine disruption deadline, will self-terminate in one hour instead", "err", err)
+		}
+
 		// generate injector config
 		config := injector.Config{
-			DryRun:          dryRun,
-			OnInit:          onInit,
-			Log:             log,
-			MetricsSink:     ms,
-			Level:           chaostypes.DisruptionLevel(level),
-			TargetContainer: ctns[i],
-			TargetPodIP:     targetPodIP,
-			TargetNodeName:  targetNodeName,
-			Cgroup:          cgroupMgr,
-			Netns:           netnsMgr,
-			K8sClient:       clientset,
-			DNS:             dnsConfig,
+			Log:                log,
+			MetricsSink:        ms,
+			TargetContainer:    ctns[i],
+			DisruptionDeadline: deadline,
+			Cgroup:             cgroupMgr,
+			Netns:              netnsMgr,
+			K8sClient:          clientset,
+			DNS:                dnsConfig,
+			Disruption:         disruptionArgs,
 		}
 
 		configs = append(configs, config)
@@ -317,8 +312,8 @@ func initExitSignalsHandler() {
 
 // initPodWatch initializes the target pod watcher
 func initPodWatch(resourceVersion string) (<-chan watch.Event, error) {
-	podWatcher, err := clientset.CoreV1().Pods(disruptionNamespace).Watch(context.Background(), metav1.ListOptions{
-		FieldSelector:       "metadata.name=" + targetName,
+	podWatcher, err := clientset.CoreV1().Pods(disruptionArgs.DisruptionNamespace).Watch(context.Background(), metav1.ListOptions{
+		FieldSelector:       "metadata.name=" + disruptionArgs.TargetName,
 		ResourceVersion:     resourceVersion,
 		AllowWatchBookmarks: true,
 	})
@@ -380,8 +375,8 @@ func reinject(cmdName string) error {
 	}
 
 	// We rebuild and update the configuration
-	for ctnName, ctnID := range targetContainers {
-		if ctnName == chaosInitContName && onInit {
+	for ctnName, ctnID := range disruptionArgs.TargetContainers {
+		if ctnName == chaosInitContName && disruptionArgs.OnInit {
 			continue
 		}
 
@@ -465,11 +460,11 @@ func pulse(isInjected *bool, sleepDuration *time.Duration, action func(string, b
 	if !*isInjected {
 		action = inject
 		actionName = "inject"
-		*sleepDuration = pulseDormantDuration
+		*sleepDuration = disruptionArgs.PulseDormantDuration
 	} else {
 		action = clean
 		actionName = "clean"
-		*sleepDuration = pulseActiveDuration
+		*sleepDuration = disruptionArgs.PulseActiveDuration
 	}
 
 	if ok := action(cmdName, true, true); !ok {
@@ -492,10 +487,10 @@ func injectAndWait(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if pulseInitialDelay > 0 {
-		log.Infow("waiting for initialDelay to pass", "initialDelay", pulseInitialDelay)
+	if disruptionArgs.PulseInitialDelay > 0 {
+		log.Infow("waiting for initialDelay to pass", "initialDelay", disruptionArgs.PulseInitialDelay)
 		select {
-		case <-time.After(pulseInitialDelay):
+		case <-time.After(disruptionArgs.PulseInitialDelay):
 			break
 		case sig := <-signals:
 			log.Infow("an exit signal has been received", "signal", sig.String())
@@ -512,13 +507,13 @@ func injectAndWait(cmd *cobra.Command, args []string) {
 	if injectSuccess {
 		log.Infof("disruption(s) injected, now waiting for an exit signal")
 
-		if err := ioutil.WriteFile(readinessProbeFile, []byte("1"), 0400); err != nil {
+		if err := ioutil.WriteFile(readinessProbeFile, []byte("1"), 0o400); err != nil {
 			log.Errorw("error writing readiness probe file", "error", err)
 		}
 	}
 
 	// once injected, send a signal to the handler container so it can exit and let other containers go on
-	if onInit {
+	if disruptionArgs.OnInit {
 		log.Info("notifying the handler container that injection is now done")
 
 		// ensure a handler container was found
@@ -538,24 +533,20 @@ func injectAndWait(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	deadline, err := time.Parse(time.RFC3339, deadlineRaw)
-	if err != nil {
-		deadline = time.Now().Add(time.Hour)
-
-		log.Errorw("unable to determine disruption deadline, will self-terminate in one hour instead", "err", err)
-	}
-
 	switch {
 	case !injectSuccess:
 		break
 	// those disruptions should not watch target to re-inject on container restart
 	case v1beta1.DisruptionIsNotReinjectable((chaostypes.DisruptionKindName)(cmd.Name())):
-	case level == chaostypes.DisruptionLevelNode:
-		if pulseActiveDuration > 0 && pulseDormantDuration > 0 {
-			var action func(string, bool, bool) bool
+	case disruptionArgs.Level == chaostypes.DisruptionLevelNode:
+		if disruptionArgs.PulseActiveDuration > 0 && disruptionArgs.PulseDormantDuration > 0 {
+			var (
+				action func(string, bool, bool) bool
+				err    error
+			)
 
 			isInjected := true
-			sleepDuration := pulseActiveDuration
+			sleepDuration := disruptionArgs.PulseActiveDuration
 
 			// using a label for the loop to be able to break out of it
 		pulsingLoop:
@@ -581,14 +572,12 @@ func injectAndWait(cmd *cobra.Command, args []string) {
 			}
 		}
 	default:
-		if onInit {
+		if disruptionArgs.OnInit {
 			log.Debugw("the init container will not get restarted on container restart")
 		}
 
 		// we watch for targeted pod containers restart to reinject
-		err := watchTargetAndReinject(deadline, cmd.Name(), pulseActiveDuration, pulseDormantDuration)
-
-		if err != nil {
+		if err := watchTargetAndReinject(deadline, cmd.Name(), disruptionArgs.PulseActiveDuration, disruptionArgs.PulseDormantDuration); err != nil {
 			log.Errorw("couldn't continue watching targeted pod", "err", err)
 		} else {
 			return
@@ -716,7 +705,7 @@ func watchTargetAndReinject(deadline time.Time, commandName string, pulseActiveD
 			// We wait for the pod to have all containers ready.
 			for _, status := range pod.Status.ContainerStatuses {
 				// we don't control the state of the init container
-				if targetContainers[status.Name] == "" || (onInit && status.Name == chaosInitContName) {
+				if disruptionArgs.TargetContainers[status.Name] == "" || (disruptionArgs.OnInit && status.Name == chaosInitContName) {
 					continue
 				}
 
@@ -768,7 +757,7 @@ func cleanFinalizer() error {
 		return err
 	}
 
-	pod, err := configs[0].K8sClient.CoreV1().Pods(chaosNamespace).Get(context.Background(), os.Getenv(env.InjectorPodName), metav1.GetOptions{})
+	pod, err := configs[0].K8sClient.CoreV1().Pods(disruptionArgs.ChaosNamespace).Get(context.Background(), os.Getenv(env.InjectorPodName), metav1.GetOptions{})
 	if err != nil {
 		log.Warnw("couldn't GET this pod in order to remove its finalizer", "pod", os.Getenv(env.InjectorPodName), "err", err)
 		return err
@@ -776,7 +765,7 @@ func cleanFinalizer() error {
 
 	controllerutil.RemoveFinalizer(pod, chaostypes.ChaosPodFinalizer)
 
-	_, err = configs[0].K8sClient.CoreV1().Pods(chaosNamespace).Update(context.Background(), pod, metav1.UpdateOptions{})
+	_, err = configs[0].K8sClient.CoreV1().Pods(disruptionArgs.ChaosNamespace).Update(context.Background(), pod, metav1.UpdateOptions{})
 	if err != nil {
 		log.Warnw("couldn't remove this pod's finalizer", "pod", os.Getenv(env.InjectorPodName), "err", err)
 		return err
@@ -807,7 +796,7 @@ func getDuration(deadline time.Time) time.Duration {
 
 // getPodResourceVersion get the resource version of the targeted pod
 func getPodResourceVersion() (string, error) {
-	target, err := clientset.CoreV1().Pods(disruptionNamespace).Get(context.Background(), targetName, metav1.GetOptions{})
+	target, err := clientset.CoreV1().Pods(disruptionArgs.DisruptionNamespace).Get(context.Background(), disruptionArgs.TargetName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -822,12 +811,12 @@ func updateTargetContainersAndDetectChange(pod *v1.Pod) (bool, error) {
 
 	// transform map of targetContainer info (name, id) to only an array of names
 	targetContainerNames := []string{}
-	for name := range targetContainers {
+	for name := range disruptionArgs.TargetContainers {
 		targetContainerNames = append(targetContainerNames, name)
 	}
 
 	// update map of targetContainer info (name, id)
-	targetContainers, err = utils.GetTargetedContainersInfo(pod, targetContainerNames)
+	disruptionArgs.TargetContainers, err = utils.GetTargetedContainersInfo(pod, targetContainerNames)
 	if err != nil {
 		log.Warnw("couldn't get containers info. Waiting for next change to reinject", "err", err)
 
@@ -835,9 +824,9 @@ func updateTargetContainersAndDetectChange(pod *v1.Pod) (bool, error) {
 	}
 
 	// Determine if reinjection is needed
-	for ctnName, ctnID := range targetContainers {
+	for ctnName, ctnID := range disruptionArgs.TargetContainers {
 		// we don't check for init containers
-		if ctnName == chaosInitContName && onInit {
+		if ctnName == chaosInitContName && disruptionArgs.OnInit {
 			continue
 		}
 

--- a/injector/container_failure.go
+++ b/injector/container_failure.go
@@ -32,7 +32,7 @@ type ContainerFailureInjectorConfig struct {
 // missing fields being initialized with the defaults
 func NewContainerFailureInjector(spec v1beta1.ContainerFailureSpec, config ContainerFailureInjectorConfig) Injector {
 	if config.ProcessManager == nil {
-		config.ProcessManager = process.NewManager(config.DryRun)
+		config.ProcessManager = process.NewManager(config.Disruption.DryRun)
 	}
 
 	return &containerFailureInjector{
@@ -47,11 +47,9 @@ func (i *containerFailureInjector) GetDisruptionKind() types.DisruptionKindName 
 
 // Inject sends a SIGKILL/SIGTERM signal to the container's PID
 func (i *containerFailureInjector) Inject() error {
-	var err error
-
 	containerPid := int(i.config.TargetContainer.PID())
-	proc, err := i.config.ProcessManager.Find(containerPid)
 
+	proc, err := i.config.ProcessManager.Find(containerPid)
 	if err != nil {
 		return fmt.Errorf("error while finding the process: %w", err)
 	}
@@ -66,7 +64,7 @@ func (i *containerFailureInjector) Inject() error {
 	// Send signal
 	i.config.Log.Infow("injecting a container failure", "signal", sig, "container", containerPid)
 
-	if err = i.config.ProcessManager.Signal(proc, sig); err != nil {
+	if err := i.config.ProcessManager.Signal(proc, sig); err != nil {
 		return fmt.Errorf("error while sending the %s signal to container with PID %d: %w", sig, containerPid, err)
 	}
 

--- a/injector/cpu_pressure.go
+++ b/injector/cpu_pressure.go
@@ -35,7 +35,7 @@ type CPUPressureInjectorConfig struct {
 func NewCPUPressureInjector(spec v1beta1.CPUPressureSpec, config CPUPressureInjectorConfig) (Injector, error) {
 	// create stresser
 	if config.Stresser == nil {
-		config.Stresser = stress.NewCPU(config.DryRun)
+		config.Stresser = stress.NewCPU(config.Disruption.DryRun)
 	}
 
 	if config.StresserExit == nil {
@@ -44,7 +44,7 @@ func NewCPUPressureInjector(spec v1beta1.CPUPressureSpec, config CPUPressureInje
 
 	// create process manager
 	if config.ProcessManager == nil {
-		config.ProcessManager = process.NewManager(config.DryRun)
+		config.ProcessManager = process.NewManager(config.Disruption.DryRun)
 	}
 
 	if config.StresserManager == nil {

--- a/injector/disk_failure.go
+++ b/injector/disk_failure.go
@@ -86,7 +86,7 @@ func (i *DiskFailureInjector) GetDisruptionKind() types.DisruptionKindName {
 
 func (i *DiskFailureInjector) Inject() (err error) {
 	pid := 0
-	if i.config.Level == types.DisruptionLevelPod {
+	if i.config.Disruption.Level == types.DisruptionLevelPod {
 		pid = int(i.config.Config.TargetContainer.PID())
 	}
 

--- a/injector/disk_failure_test.go
+++ b/injector/disk_failure_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/DataDog/chaos-controller/api"
 	v1beta1 "github.com/DataDog/chaos-controller/api/v1beta1"
 	. "github.com/DataDog/chaos-controller/injector"
 	"github.com/DataDog/chaos-controller/mocks"
@@ -41,9 +42,11 @@ var _ = Describe("Failure", func() {
 
 		config = DiskFailureInjectorConfig{
 			Config: Config{
-				Log:             log,
-				MetricsSink:     ms,
-				Level:           level,
+				Log:         log,
+				MetricsSink: ms,
+				Disruption: api.DisruptionArgs{
+					Level: level,
+				},
 				TargetContainer: containerMock,
 			},
 			Cmd: commandMock,

--- a/injector/disk_pressure.go
+++ b/injector/disk_pressure.go
@@ -51,7 +51,7 @@ func NewDiskPressureInjector(spec v1beta1.DiskPressureSpec, config DiskPressureI
 	}
 
 	// get path from container info if we target a pod
-	if config.Level == types.DisruptionLevelPod {
+	if config.Disruption.Level == types.DisruptionLevelPod {
 		// get host path from mount path
 		path, err = config.TargetContainer.Runtime().HostPath(config.TargetContainer.ID(), spec.Path)
 		if err != nil {

--- a/injector/dns_disruption_test.go
+++ b/injector/dns_disruption_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 
+	"github.com/DataDog/chaos-controller/api"
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/env"
 	. "github.com/DataDog/chaos-controller/injector"
@@ -72,7 +73,9 @@ var _ = Describe("Failure", func() {
 				MetricsSink:     ms,
 				Netns:           netnsManagerMock,
 				Cgroup:          cgroupManagerMock,
-				Level:           chaostypes.DisruptionLevelNode,
+				Disruption: api.DisruptionArgs{
+					Level: chaostypes.DisruptionLevelNode,
+				},
 			},
 			IPTables:     iptablesMock,
 			PythonRunner: pythonRunner,
@@ -175,12 +178,12 @@ var _ = Describe("Failure", func() {
 
 		Context("disruption is pod-level", func() {
 			BeforeEach(func() {
-				config.Level = chaostypes.DisruptionLevelPod
+				config.Disruption.Level = chaostypes.DisruptionLevelPod
 			})
 
 			Context("on init", func() {
 				BeforeEach(func() {
-					config.OnInit = true
+					config.Disruption.OnInit = true
 				})
 
 				It("should not call cgroup functions", func() {

--- a/injector/grpc_disruption.go
+++ b/injector/grpc_disruption.go
@@ -44,7 +44,7 @@ func NewGRPCDisruptionInjector(spec v1beta1.GRPCDisruptionSpec, config GRPCDisru
 	return &GRPCDisruptionInjector{
 		spec:       spec,
 		config:     config,
-		serverAddr: config.TargetPodIP + ":" + strconv.Itoa(spec.Port),
+		serverAddr: config.Disruption.TargetPodIP + ":" + strconv.Itoa(spec.Port),
 		timeout:    connectionTimeout,
 	}
 }
@@ -57,7 +57,7 @@ func (i *GRPCDisruptionInjector) GetDisruptionKind() types.DisruptionKindName {
 func (i *GRPCDisruptionInjector) Inject() error {
 	i.config.Log.Infow("connecting to " + i.serverAddr + "...")
 
-	if i.config.DryRun {
+	if i.config.Disruption.DryRun {
 		i.config.Log.Infow("adding dry run mode grpc disruption", "spec", i.spec)
 		return nil
 	}
@@ -95,7 +95,7 @@ func (i *GRPCDisruptionInjector) Clean() error {
 
 	i.config.Log.Infow("connecting to " + i.serverAddr + "...")
 
-	if i.config.DryRun {
+	if i.config.Disruption.DryRun {
 		i.config.Log.Infow("removing dry run mode grpc disruption", "spec", i.spec)
 		return nil
 	}
@@ -130,7 +130,6 @@ func (i *GRPCDisruptionInjector) connectToServer() (*grpc.ClientConn, error) {
 	defer cancel()
 
 	conn, err := grpc.DialContext(ctx, i.serverAddr, opts...)
-
 	if err != nil {
 		return nil, errors.New("fail to dial: " + i.serverAddr)
 	}

--- a/injector/injector.go
+++ b/injector/injector.go
@@ -6,6 +6,9 @@
 package injector
 
 import (
+	"time"
+
+	chaosapi "github.com/DataDog/chaos-controller/api"
 	"github.com/DataDog/chaos-controller/cgroup"
 	"github.com/DataDog/chaos-controller/container"
 	"github.com/DataDog/chaos-controller/metrics"
@@ -34,17 +37,13 @@ type Injector interface {
 
 // Config represents a generic injector config
 type Config struct {
-	DryRun          bool
-	OnInit          bool
-	Log             *zap.SugaredLogger
-	MetricsSink     metrics.Sink
-	Kind            types.DisruptionKindName
-	Level           types.DisruptionLevel
-	TargetContainer container.Container
-	TargetPodIP     string
-	TargetNodeName  string
-	Cgroup          cgroup.Manager
-	Netns           netns.Manager
-	K8sClient       kubernetes.Interface
-	DNS             network.DNSConfig
+	Log                *zap.SugaredLogger
+	MetricsSink        metrics.Sink
+	TargetContainer    container.Container
+	DisruptionDeadline time.Time
+	Cgroup             cgroup.Manager
+	Netns              netns.Manager
+	K8sClient          kubernetes.Interface
+	DNS                network.DNSConfig
+	Disruption         chaosapi.DisruptionArgs
 }

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -95,14 +95,14 @@ func NewNetworkDisruptionInjector(spec v1beta1.NetworkDisruptionSpec, config Net
 	var err error
 
 	if config.IPTables == nil {
-		config.IPTables, err = network.NewIPTables(config.Log, config.DryRun)
+		config.IPTables, err = network.NewIPTables(config.Log, config.Disruption.DryRun)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if config.TrafficController == nil {
-		config.TrafficController = network.NewTrafficController(config.Log, config.DryRun)
+		config.TrafficController = network.NewTrafficController(config.Log, config.Disruption.DryRun)
 	}
 
 	if config.NetlinkAdapter == nil {
@@ -180,7 +180,7 @@ func (i *networkDisruptionInjector) Inject() error {
 	}
 
 	// mark all packets created by the targeted container with the classifying mark
-	if i.config.Level == types.DisruptionLevelPod && !i.config.OnInit {
+	if i.config.Disruption.Level == types.DisruptionLevelPod && !i.config.Disruption.OnInit {
 		if i.config.Cgroup.IsCgroupV2() { // cgroup v2 can rely on the single cgroup hierarchy relative path to mark packets
 			if err := i.config.IPTables.MarkCgroupPath(i.config.Cgroup.RelativePath(""), types.InjectorCgroupClassID); err != nil {
 				return fmt.Errorf("error injecting packet marking iptables rule: %w", err)
@@ -360,7 +360,7 @@ func (i *networkDisruptionInjector) applyOperations() error {
 	// create a second qdisc to filter packets coming from this specific pod processes only
 	// if the disruption is applied on init, we consider that some more containers may be created within
 	// the pod so we can't scope the disruption to a specific set of containers
-	if i.config.Level == types.DisruptionLevelPod && !i.config.OnInit {
+	if i.config.Disruption.Level == types.DisruptionLevelPod && !i.config.Disruption.OnInit {
 		// create second prio with only 2 bands to filter traffic with a specific mark
 		if err := i.config.TrafficController.AddPrio(interfaces, "1:4", "2:", 2, [16]uint32{}); err != nil {
 			return fmt.Errorf("can't create a new qdisc: %w", err)
@@ -393,7 +393,7 @@ func (i *networkDisruptionInjector) applyOperations() error {
 	// depending on the network configuration, only one of those filters can be useful but we must add all of them
 	// those filters are only added if the related interface has been impacted by a disruption so far
 	// NOTE: those filters must be added after every other filters applied to the interface so they are used first
-	if i.config.Level == types.DisruptionLevelPod {
+	if i.config.Disruption.Level == types.DisruptionLevelPod {
 		// this filter allows the pod to communicate with the default route gateway IP
 		for _, defaultRoute := range defaultRoutes {
 			gatewayIP := &net.IPNet{
@@ -410,7 +410,7 @@ func (i *networkDisruptionInjector) applyOperations() error {
 		if _, err := i.config.TrafficController.AddFilter(interfaces, "1:0", "", nil, nodeIPNet, 0, 0, network.TCP, network.ConnStateUndefined, "1:1"); err != nil {
 			return fmt.Errorf("can't add the target pod node IP filter: %w", err)
 		}
-	} else if i.config.Level == types.DisruptionLevelNode {
+	} else if i.config.Disruption.Level == types.DisruptionLevelNode {
 		// GENERIC SAFEGUARDS
 		// allow SSH connections on all interfaces (port 22/tcp)
 		if _, err := i.config.TrafficController.AddFilter(interfaces, "1:0", "", nil, nil, 22, 0, network.TCP, network.ConnStateUndefined, "1:1"); err != nil {

--- a/injector/network_disruption_test.go
+++ b/injector/network_disruption_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/DataDog/chaos-controller/api"
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/env"
 	. "github.com/DataDog/chaos-controller/injector"
@@ -176,8 +177,10 @@ var _ = Describe("Failure", func() {
 				MetricsSink:     ms,
 				Netns:           netnsManager,
 				Cgroup:          cgroupManager,
-				Level:           chaostypes.DisruptionLevelPod,
-				K8sClient:       k8sClient,
+				Disruption: api.DisruptionArgs{
+					Level: chaostypes.DisruptionLevelPod,
+				},
+				K8sClient: k8sClient,
 			},
 			TrafficController: tc,
 			IPTables:          iptables,
@@ -376,7 +379,7 @@ var _ = Describe("Failure", func() {
 
 		Context("node level safeguards", func() {
 			BeforeEach(func() {
-				config.Level = chaostypes.DisruptionLevelNode
+				config.Disruption.Level = chaostypes.DisruptionLevelNode
 			})
 
 			It("should add a filter to redirect SSH traffic on a non-disrupted band", func() {
@@ -409,7 +412,7 @@ var _ = Describe("Failure", func() {
 
 		Context("on pod initialization", func() {
 			BeforeEach(func() {
-				config.OnInit = true
+				config.Disruption.OnInit = true
 			})
 
 			It("should not add a second prio band with the cgroup filter", func() {

--- a/injector/node_failure.go
+++ b/injector/node_failure.go
@@ -36,7 +36,7 @@ type NodeFailureInjectorConfig struct {
 func NewNodeFailureInjector(spec v1beta1.NodeFailureSpec, config NodeFailureInjectorConfig) (Injector, error) {
 	if config.FileWriter == nil {
 		config.FileWriter = standardFileWriter{
-			dryRun: config.DryRun,
+			dryRun: config.Disruption.DryRun,
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [x] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- This PR aims to use `chaosapi.DisruptionArgs` instead of isolated fields in order to be able to re-create a command from inside the `injector`
  - it's a preparative work to enable `cpu_pressure` changes to be made, they will launch a process with 99% the same configuration than `injector`
  - it also eases the usage of disruption related fields inside injector(s) implementations  

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
