### PR TITLE
Fix: add auth to build:make job to avoid rate-limiting

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ ci-image:
 
 # main make build
 build:make:
-  <<: *docker-runner
+  <<: *docker-hub-login
   stage: build
   when: always
   variables:


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [X] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- With the addition of a docker job to the gitlab build:make job, we need to call the docker-hub-login job prior to avoid rate-limiting.

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [X] I manually tested the following steps:
    - [X] Looking at CI Build logs
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
