### PR TITLE
CI: update linter and linter tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,9 +101,7 @@ jobs:
             source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools ${ENVTEST_ASSETS_DIR}; setup_envtest_env ${ENVTEST_ASSETS_DIR};
       - run:
           name: Install golangci-lint tool
-          command: |
-            cd /usr/local
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v${GOLANGCI_LINT_VERSION}
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v${GOLANGCI_LINT_VERSION}
       - run:
           name: Install helm
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ executors:
     environment:
       KUBEBUILDER_VERSION: 3.1.0
       KUBEBUILDER_ARCH: amd64
-      GOLANGCI_LINT_VERSION: 1.45.2
+      GOLANGCI_LINT_VERSION: 1.52.2
       HELM_VERSION: 3.5.4
   golang_large:
     <<: *working_directory
@@ -61,7 +61,7 @@ executors:
     environment:
       KUBEBUILDER_VERSION: 3.1.0
       KUBEBUILDER_ARCH: amd64
-      GOLANGCI_LINT_VERSION: 1.45.2
+      GOLANGCI_LINT_VERSION: 1.52.2
       HELM_VERSION: 3.5.4
   python:
     <<: *working_directory

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,12 +49,16 @@ issues:
     - weak random number generator
     - memory aliasing in for loop
     - file inclusion via variable
-    # stylecheck
-    - at least one file in a package should have a package comment
     # golint
     - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
-    # revive
-    - and that stutters
-    - unexported-return
+
+  exclude-rules:
+    - linters:
+        - revive
+      text: "unused-parameter:|and that stutters;|unexported-return:"
+    - linters:
+        - stylecheck
+      text: at least one file in a package should have a package comment
+
 output:
   sort-results: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@
 # Copyright 2023 Datadog, Inc.
 
 run:
+  timeout: 5m
   skip-files:
     - api/v1beta1/zz_generated.deepcopy.go
     - ".*_test.go"
@@ -55,3 +56,5 @@ issues:
     # revive
     - and that stutters
     - unexported-return
+output:
+  sort-results: true

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ endif
 
 ## Run golangci-lint against code
 lint: lint-deps
+	$(shell golangci-lint version)
 	golangci-lint run
 
 ## Generate code

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ LIMA_CONFIG ?= lima
 KUBECTL ?= limactl shell default sudo kubectl
 UNZIP_BINARY ?= sudo unzip
 KUBERNETES_VERSION ?= v1.26.0
+GOLANGCI_LINT_VERSION ?= 1.52.2
 
 # expired disruption gc delay enable to speed up chaos controller disruption removal for e2e testing
 # it's used to check if disruptions are deleted as expected as soon as the expiration delay occurs
@@ -122,9 +123,24 @@ fmt:
 vet:
 	go vet ./...
 
+## install golangci-lint at the correct version if not
+lint-deps:
+ifeq (, $(shell which golangci-lint))
+	@{ \
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v${GOLANGCI_LINT_VERSION} ;\
+	}
+else
+ifneq (${GOLANGCI_LINT_VERSION}, $(shell golangci-lint version --format short))
+	@{ \
+	echo "warning: this projects expects golangci-lint v${GOLANGCI_LINT_VERSION}; it's currently at version" $(shell golangci-lint version --format short) ;\
+	echo "\nresult may differ from CI; fix this by uninstalling golangci-lint and run 'make lint' again\n";\
+	}
+endif
+endif
+
 ## Run golangci-lint against code
-lint:
-	golangci-lint run --timeout 5m0s
+lint: lint-deps
+	golangci-lint run
 
 ## Generate code
 generate: controller-gen

--- a/cli/chaosli/cmd/explain.go
+++ b/cli/chaosli/cmd/explain.go
@@ -153,7 +153,7 @@ func explainDiskPressure(spec v1beta1.DisruptionSpec) {
 func explainDNS(spec v1beta1.DisruptionSpec) {
 	dns := spec.DNS
 
-	if dns == nil || len(dns) == 0 {
+	if len(dns) == 0 {
 		return
 	}
 

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -459,6 +459,7 @@ func clean(kind string, sendToMetrics bool, reinjectionClean bool) bool {
 }
 
 // pulse pulse disruptions (injection and cleaning)
+// nolint: unparam,staticcheck
 func pulse(isInjected *bool, sleepDuration *time.Duration, action func(string, bool, bool) bool, cmdName string) (func(string, bool, bool) bool, error) {
 	actionName := ""
 

--- a/cloudservice/manager.go
+++ b/cloudservice/manager.go
@@ -220,5 +220,14 @@ func (s *CloudServicesProvidersManager) requestIPRangesFromProvider(url string) 
 		return nil, err
 	}
 
-	return io.ReadAll(response.Body)
+	byteResp, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := response.Body.Close(); err != nil {
+		return nil, err
+	}
+
+	return byteResp, nil
 }

--- a/ddmark/libtools.go
+++ b/ddmark/libtools.go
@@ -75,11 +75,9 @@ func (c client) initLibrary(embeddedFS embed.FS, apiname string) error {
 				return err
 			}
 
-			if err = fout.Close(); err != nil {
-				return err
-			}
+			err = fout.Close()
 
-			return nil
+			return err
 		})
 
 	if err != nil {

--- a/dogfood/client/dogfood_client.go
+++ b/dogfood/client/dogfood_client.go
@@ -15,6 +15,7 @@ import (
 
 	pb "github.com/DataDog/chaos-controller/dogfood/chaosdogfood"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -109,7 +110,7 @@ func main() {
 	fmt.Printf("connecting to %v...\n", serverAddr)
 
 	var opts []grpc.DialOption
-	opts = append(opts, grpc.WithInsecure())
+	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	opts = append(opts, grpc.WithBlock())
 
 	conn, err := grpc.Dial(serverAddr, opts...)

--- a/dogfood/server/dogfood_server.go
+++ b/dogfood/server/dogfood_server.go
@@ -95,8 +95,8 @@ func main() {
 	if chaosEnabled == true {
 		fmt.Println("CHAOS ENABLED")
 
-		disruptionLogger, error := zaplog.NewZapLogger()
-		if error != nil {
+		disruptionLogger, err := zaplog.NewZapLogger()
+		if err != nil {
 			log.Fatal("error creating controller logger")
 			return
 		}

--- a/eventbroadcaster/notifiersink.go
+++ b/eventbroadcaster/notifiersink.go
@@ -30,8 +30,6 @@ type NotifierSink struct {
 
 // RegisterNotifierSinks builds notifiers sinks and registers them on the given broadcaster
 func RegisterNotifierSinks(mgr ctrl.Manager, broadcaster record.EventBroadcaster, notifiersConfig eventnotifier.NotifiersConfig, logger *zap.SugaredLogger) (err error) {
-	err = nil
-
 	client := mgr.GetClient()
 
 	notifiers, err := eventnotifier.GetNotifiers(notifiersConfig, logger)

--- a/eventnotifier/http/http.go
+++ b/eventnotifier/http/http.go
@@ -165,5 +165,9 @@ func (n *Notifier) Notify(dis v1beta1.Disruption, event corev1.Event, notifType 
 		return fmt.Errorf("http notifier: receiving %d status code from sent notification", res.StatusCode)
 	}
 
+	if err = res.Body.Close(); err != nil {
+		return fmt.Errorf("http notifier: error when sending notification: %s", err.Error())
+	}
+
 	return nil
 }

--- a/injector/grpc_disruption.go
+++ b/injector/grpc_disruption.go
@@ -16,6 +16,7 @@ import (
 	pb "github.com/DataDog/chaos-controller/grpc/disruptionlistener"
 	"github.com/DataDog/chaos-controller/types"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // Five Seconds timeout before aborting the attempt to connect to server
@@ -122,7 +123,7 @@ func (i *GRPCDisruptionInjector) Clean() error {
 
 func (i *GRPCDisruptionInjector) connectToServer() (*grpc.ClientConn, error) {
 	opts := []grpc.DialOption{
-		grpc.WithInsecure(), // Future Work: make secure
+		grpc.WithTransportCredentials(insecure.NewCredentials()), // Future Work: make secure
 		grpc.WithBlock(),
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), i.timeout)

--- a/stress/cpu.go
+++ b/stress/cpu.go
@@ -37,6 +37,7 @@ func (c cpu) Stress(exit <-chan struct{}) {
 			return
 		default:
 			// eat cpu
+			// nolint: revive
 			for i := uint64(0); i < 18446744073709551615; i++ {
 				// noop
 			}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [X] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Our CI linter is outdated and our local env versions (more up to date) are showing multiple errors the CI version doesn't. This is painful and should be eased. This PR provides:
  - a `make` command to install the linter at the correct version, and explicits any differences. 
  - small QOL changes in the `golangci-lint` config file
  - an update of the linter version in CircleCI
  - various fixes (or the absence of patches) for all the different errors new standards in go have found in the codebase

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - run `make lint`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
