### PR TITLE
Fix another chaosli sigsev on chaosli --help

### DIFF
--- a/cli/chaosli/cmd/root.go
+++ b/cli/chaosli/cmd/root.go
@@ -44,6 +44,10 @@ func Execute() {
 	_ = rootCmd.Execute()
 
 	defer func() {
+		if ddMarkClient == nil {
+			return
+		}
+
 		if err := ddMarkClient.CleanupLibraries(); err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Sigsev on `chaosli --help` due to the non initialization of ddmark. Fixing it by verifying ddmark is not nil before cleaning ddmark.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
