### PR TITLE
CHAOS-437: fix node failure examples, add new ddmark rule

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -20,6 +20,8 @@ IPs
 IgnoreName
 LICENSE-3rdparty
 LinkedFields
+LinkedFieldsValue
+LinkedFieldsValueWithTrigger
 Meowmix
 OnInit
 PIDs

--- a/api/grpc_disruption_test.go
+++ b/api/grpc_disruption_test.go
@@ -171,7 +171,7 @@ var _ = Describe("GRPCDisruption Validation", func() {
 
 				err := ddMarkClient.ValidateStructMultierror(spec, "grpc_test_suite")
 				Expect(err.Errors).To(HaveLen(1))
-				Expect(err.Errors[0].Error()).To(Equal("grpc_test_suite>Endpoints>>ErrorToReturn - ddmark:validation:Enum: field needs to be one of [OK CANCELED UNKNOWN INVALID_ARGUMENT DEADLINE_EXCEEDED NOT_FOUND ALREADY_EXISTS PERMISSION_DENIED RESOURCE_EXHAUSTED FAILED_PRECONDITION ABORTED OUT_OF_RANGE UNIMPLEMENTED INTERNAL UNAVAILABLE DATA_LOSS UNAUTHENTICATED], currently \"MEOW\""))
+				Expect(err.Errors[0].Error()).To(Equal("grpc_test_suite>Endpoints>>ErrorToReturn - ddmark:validation:Enum: field needs to be one of [OK CANCELED UNKNOWN INVALID_ARGUMENT DEADLINE_EXCEEDED NOT_FOUND ALREADY_EXISTS PERMISSION_DENIED RESOURCE_EXHAUSTED FAILED_PRECONDITION ABORTED OUT_OF_RANGE UNIMPLEMENTED INTERNAL UNAVAILABLE DATA_LOSS UNAUTHENTICATED]"))
 			})
 		})
 

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -32,6 +32,7 @@ import (
 // DisruptionSpec defines the desired state of Disruption
 // +ddmark:validation:ExclusiveFields={ContainerFailure,CPUPressure,DiskPressure,NodeFailure,Network,DNS,DiskFailure}
 // +ddmark:validation:ExclusiveFields={NodeFailure,CPUPressure,DiskPressure,ContainerFailure,Network,DNS,DiskFailure}
+// +ddmark:validation:LinkedFieldsValueWithTrigger={NodeFailure,Level=node}
 // +ddmark:validation:AtLeastOneOf={DNS,CPUPressure,Network,NodeFailure,ContainerFailure,DiskPressure,GRPC,DiskFailure}
 // +ddmark:validation:AtLeastOneOf={Selector,AdvancedSelector}
 type DisruptionSpec struct {

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -32,7 +32,7 @@ import (
 // DisruptionSpec defines the desired state of Disruption
 // +ddmark:validation:ExclusiveFields={ContainerFailure,CPUPressure,DiskPressure,NodeFailure,Network,DNS,DiskFailure}
 // +ddmark:validation:ExclusiveFields={NodeFailure,CPUPressure,DiskPressure,ContainerFailure,Network,DNS,DiskFailure}
-// +ddmark:validation:LinkedFieldsValueWithTrigger={NodeFailure,Level=node}
+// +ddmark:validation:LinkedFieldsValueWithTrigger={NodeFailure,Level}
 // +ddmark:validation:AtLeastOneOf={DNS,CPUPressure,Network,NodeFailure,ContainerFailure,DiskPressure,GRPC,DiskFailure}
 // +ddmark:validation:AtLeastOneOf={Selector,AdvancedSelector}
 type DisruptionSpec struct {

--- a/ddmark/README.md
+++ b/ddmark/README.md
@@ -52,10 +52,26 @@ It also allows us to define custom rules to apply to our structures, and focus t
   - `// +ddmark:validation:ExclusiveFields={<fieldName1>,<fieldName2>,...}`
   - Applies to: any `<struct>` type
   - Asserts that `<fieldname1>` can only be non-nil iff all of the other fields are `nil`
-- LinkedFields:
-  - `// +ddmark:validation:LinkedFields={<fieldName1>,<fieldName2>,...}`
-  - Applies to: any `<struct>` type
-  - Asserts the fields in the list are either all `nil` or all non-`nil`
+- LinkedFieldsValue:
+  - without values:
+    -  `// +ddmark:validation:LinkedFieldsValue={<fieldName1>,<fieldName2>,...}`
+    - Applies to: any `<struct>` type
+    - Asserts the fields in the list are either all `nil` or all non-`nil`
+  - with values:
+    - `// +ddmark:validation:LinkedFieldsValue={<fieldName1>=<value>,<fieldName2>,...}`
+    - Applies to: any `<struct>` type -- value checks are only for `string` and `int` subfields
+    - Asserts the fields in the list are either all `nil` (or are *specifically* set to the indicated value) or all non-`nil` (or are ***specifically not*** set to the given value)
+    - Fields with values and without values can be mixed
+- LinkedFieldsValueWithTrigger
+  - without values:
+    - `// +ddmark:validation:LinkedFieldsValueWithTrigger={<fieldName1>, <fieldName2>,...}`
+    - Applies to: any `<struct>` type
+    - Asserts the following: if the first field is non-`nil`, all the following fields have to also be non-`nil`
+  - with values:
+    - `// +ddmark:validation:LinkedFieldsValueWithTrigger={<fieldName1>=<value>, <fieldName2>,...}`
+    - Applies to: any `<struct>` type -- value checks are only for `string` and `int` subfields 
+    - Asserts the following: if the first field is non-`nil` OR is set to the given `<value>`, all the following fields have to also be non-`nil` OR set to their given `<value>`.
+    - Fields with values and without values can be mixed
 - AtLeastOneOf:
   - `// +ddmark:validation:AtLeastOneOf={<fieldName1>,<fieldName2>,...}`
   - Applies to: any `<struct>` type

--- a/ddmark/validation.go
+++ b/ddmark/validation.go
@@ -170,10 +170,15 @@ func (l LinkedFieldsValue) ApplyRule(fieldvalue reflect.Value) error {
 	}
 
 	if matchCount != 0 && matchCount != len(l) {
-		return fmt.Errorf("%v: all of the following fields need to be either nil of non-nil (currently unmatched): %v", ruleName(l), l)
+		return l.GenValueCheckError()
 	}
 
 	return nil
+}
+
+func (l LinkedFieldsValue) GenValueCheckError() error {
+	template := "%v: all of the following fields need to be either nil of non-nil (currently unmatched): %v"
+	return fmt.Errorf(template, ruleName(l), l)
 }
 
 func (l LinkedFieldsValueWithTrigger) ApplyRule(fieldvalue reflect.Value) error {
@@ -219,10 +224,15 @@ func (l LinkedFieldsValueWithTrigger) ApplyRule(fieldvalue reflect.Value) error 
 	}
 
 	if matchCount != 0 && matchCount != len(l) {
-		return fmt.Errorf("%v: all of the following fields need to be aligned; either at the given value, nil or non-nil (currently unmatched): %v", ruleName(l), l)
+		return l.GenValueCheckError()
 	}
 
 	return nil
+}
+
+func (l LinkedFieldsValueWithTrigger) GenValueCheckError() error {
+	template := "%v: all of the following fields need to be aligned; if the first value is valid / exists, all the following need to either exist or have the indicated value: %v"
+	return fmt.Errorf(template, ruleName(l), l)
 }
 
 func (r AtLeastOneOf) ApplyRule(fieldvalue reflect.Value) error {
@@ -305,7 +315,7 @@ func parseIntOrUInt(value reflect.Value) (int, bool) {
 }
 
 // checkValueExistOrIsValid checks if a given string marker item name value exist in a unmarshalled struct (converted to a map by structValueToMap)
-// it returns 1 if the value is found and -if applicable- the required value is valid, 0 otherwise
+// it returns true if the value is found and -if applicable- the required value is valid, false otherwise
 func checkValueExistsOrIsValid(markerItem string, structMap map[string]interface{}, ruleName string) (bool, error) {
 	// markerItem can either be a fieldName, or fieldName=fieldValue
 	markerSubfieldName, markerSubfieldValue, isValueField := strings.Cut(markerItem, "=")

--- a/ddmark/validation.go
+++ b/ddmark/validation.go
@@ -271,8 +271,8 @@ func (l LinkedFieldsValueWithTrigger) ApplyRule(fieldvalue reflect.Value) error 
 }
 
 func (l LinkedFieldsValueWithTrigger) GenValueCheckError() error {
-	template := "%v: all of the following fields need to be aligned; if the first value is valid / exists, all the following need to either exist or have the indicated value: %v"
-	return fmt.Errorf(template, ruleName(l), l)
+	template := "%v: all of the following fields need to be aligned; if %v is set, all the following need to either exist or have the indicated value: %v"
+	return fmt.Errorf(template, ruleName(l), l[0], l[1:])
 }
 
 func (a AtLeastOneOf) ApplyRule(fieldvalue reflect.Value) error {

--- a/ddmark/validation.go
+++ b/ddmark/validation.go
@@ -77,7 +77,7 @@ func (m Maximum) ValueCheckError() error {
 }
 
 func (m Maximum) TypeCheckError(fieldValue reflect.Value) error {
-	return GenericTypeCheckError(m, fieldValue, "int or uint")
+	return genericTypeCheckError(m, fieldValue, "int or uint")
 }
 
 func (m Minimum) ApplyRule(fieldvalue reflect.Value) error {
@@ -100,7 +100,7 @@ func (m Minimum) ValueCheckError() error {
 }
 
 func (m Minimum) TypeCheckError(fieldValue reflect.Value) error {
-	return GenericTypeCheckError(m, fieldValue, "int or uint")
+	return genericTypeCheckError(m, fieldValue, "int or uint")
 }
 
 func (e ExclusiveFields) ApplyRule(fieldvalue reflect.Value) error {
@@ -133,7 +133,7 @@ func (e ExclusiveFields) ValueCheckError() error {
 }
 
 func (e ExclusiveFields) TypeCheckError(fieldValue reflect.Value) error {
-	return GenericTypeCheckError(e, fieldValue, "struct")
+	return genericTypeCheckError(e, fieldValue, "struct")
 }
 
 func (e Enum) ApplyRule(fieldvalue reflect.Value) error {
@@ -222,7 +222,7 @@ func (l LinkedFieldsValue) ValueCheckError() error {
 }
 
 func (l LinkedFieldsValue) TypeCheckError(fieldValue reflect.Value) error {
-	return GenericTypeCheckError(l, fieldValue, "struct")
+	return genericTypeCheckError(l, fieldValue, "struct")
 }
 
 func (l LinkedFieldsValueWithTrigger) ApplyRule(fieldvalue reflect.Value) error {
@@ -280,7 +280,7 @@ func (l LinkedFieldsValueWithTrigger) ValueCheckError() error {
 }
 
 func (l LinkedFieldsValueWithTrigger) TypeCheckError(fieldValue reflect.Value) error {
-	return GenericTypeCheckError(l, fieldValue, "struct")
+	return genericTypeCheckError(l, fieldValue, "struct")
 }
 
 func (a AtLeastOneOf) ApplyRule(fieldvalue reflect.Value) error {
@@ -306,7 +306,7 @@ func (a AtLeastOneOf) ValueCheckError() error {
 }
 
 func (a AtLeastOneOf) TypeCheckError(fieldValue reflect.Value) error {
-	return GenericTypeCheckError(a, fieldValue, "struct")
+	return genericTypeCheckError(a, fieldValue, "struct")
 }
 
 func Register(reg *k8smarkers.Registry) error {
@@ -339,7 +339,7 @@ func ruleName(i interface{}) string {
 }
 
 // genericTypeError returns a generic error for wrong type marker attempt
-func GenericTypeCheckError(i interface{}, fieldValue reflect.Value, expectedTypes string) error {
+func genericTypeCheckError(i interface{}, fieldValue reflect.Value, expectedTypes string) error {
 	return fmt.Errorf("%s: marker applied to wrong type: currently %T, can only be %s", ruleName(i), fieldValue, expectedTypes)
 }
 
@@ -414,7 +414,7 @@ func checkValueExistsOrIsValid(markerItem string, structMap map[string]interface
 	// this marker uses string comparison so the underlying type has to be convertible to string
 	convertibleToString := vType.ConvertibleTo(stringType)
 	if !convertibleToString {
-		return false, fmt.Errorf("%v: wrong type for value field %v; only int and string are allowed", ruleName, markerSubfieldName)
+		return false, fmt.Errorf("%s: wrong type for value field %s; only int and string are allowed", ruleName, markerSubfieldName)
 	}
 
 	var vStr string
@@ -426,7 +426,7 @@ func checkValueExistsOrIsValid(markerItem string, structMap map[string]interface
 	case reflect.String:
 		vStr = v.Convert(vType).Interface().(string)
 	default:
-		return false, fmt.Errorf("%v: please do not apply this marker to anything else than int or string. Current type: %v", ruleName, v.Type().Name())
+		return false, fmt.Errorf("%s: please do not apply this marker to anything else than int or string. Current type: %T", ruleName, v)
 	}
 
 	return strings.EqualFold(markerSubfieldValue, vStr), nil

--- a/ddmark/validation.go
+++ b/ddmark/validation.go
@@ -255,7 +255,7 @@ func Register(reg *k8smarkers.Registry) error {
 // HELPERS
 
 // addDefinition creates and adds a definition to the package's AllDefinition object, containing all markers definitions
-func addDefinition(obj interface{}, targetType k8smarkers.TargetType) {
+func addDefinition(obj DDValidationMarker, targetType k8smarkers.TargetType) {
 	name := rulePrefix + reflect.TypeOf(obj).Name()
 	def, err := k8smarkers.MakeDefinition(name, targetType, obj)
 

--- a/ddmark/validation_integration_test.go
+++ b/ddmark/validation_integration_test.go
@@ -38,8 +38,8 @@ const (
 	LinkedFieldsValueTestError0 = "test_suite>LinkedFieldsValueTest - ddmark:validation:LinkedFieldsValue: all of the following fields need to be either nil/at the indicated value or non-nil/not at the indicated value; currently unmatched: [StrField=aaa IntField]"
 	LinkedFieldsValueTestError1 = "test_suite>LinkedFieldsValueTest - ddmark:validation:LinkedFieldsValue: all of the following fields need to be either nil/at the indicated value or non-nil/not at the indicated value; currently unmatched: [PStrField PIntField AIntField]"
 
-	LinkedFieldsValueWithTriggerTestError0 = "test_suite>LinkedFieldsValueWithTriggerTest - ddmark:validation:LinkedFieldsValueWithTrigger: all of the following fields need to be aligned; if the first value is valid / exists, all the following need to either exist or have the indicated value: [StrField=aaa IntField=2]"
-	LinkedFieldsValueWithTriggerTestError1 = "test_suite>LinkedFieldsValueWithTriggerTest - ddmark:validation:LinkedFieldsValueWithTrigger: all of the following fields need to be aligned; if the first value is valid / exists, all the following need to either exist or have the indicated value: [PStrField=bbb PIntField=12 AIntField]"
+	LinkedFieldsValueWithTriggerTestError0 = "test_suite>LinkedFieldsValueWithTriggerTest - ddmark:validation:LinkedFieldsValueWithTrigger: all of the following fields need to be aligned; if StrField=aaa is set, all the following need to either exist or have the indicated value: [IntField=2]"
+	LinkedFieldsValueWithTriggerTestError1 = "test_suite>LinkedFieldsValueWithTriggerTest - ddmark:validation:LinkedFieldsValueWithTrigger: all of the following fields need to be aligned; if PStrField=bbb is set, all the following need to either exist or have the indicated value: [PIntField=12 AIntField]"
 )
 
 var _ = Describe("Validation Integration Tests", func() {

--- a/ddmark/validation_integration_test.go
+++ b/ddmark/validation_integration_test.go
@@ -13,6 +13,35 @@ import (
 	k8syaml "sigs.k8s.io/yaml"
 )
 
+const (
+	MinMaxTestErr0 = "test_suite>MinMaxTest>IntField - ddmark:validation:Minimum: field has value 4, min is 5 (included)"
+	MinMaxTestErr1 = "test_suite>MinMaxTest>PIntField - ddmark:validation:Maximum: field has value 11, max is 10 (included)"
+
+	RequiredTestErr0 = "test_suite>RequiredTest>PIntField is required"
+	RequiredTestErr1 = "test_suite>RequiredTest>StrField - ddmark:validation:Required: field is required: currently missing"
+	RequiredTestErr2 = "test_suite>RequiredTest>PStrField is required"
+	RequiredTestErr3 = "test_suite>RequiredTest>StructField - ddmark:validation:Required: field is required: currently missing"
+	RequiredTestErr4 = "test_suite>RequiredTest>PStructField is required"
+	RequiredTestErr5 = "test_suite>RequiredTest>IntField - ddmark:validation:Required: field is required: currently missing"
+
+	EnumTestErr0 = "test_suite>EnumTest>StrField - ddmark:validation:Enum: field needs to be one of [aa bb 11], currently \"notinenum\""
+	EnumTestErr1 = "test_suite>EnumTest>PStrField - ddmark:validation:Enum: field needs to be one of [aa bb 11], currently \"notinenum\""
+	EnumTestErr2 = "test_suite>EnumTest>IntField - ddmark:validation:Enum: field needs to be one of [1 2 3], currently \"4\""
+	EnumTestErr3 = "test_suite>EnumTest>PIntField - ddmark:validation:Enum: field needs to be one of [1 2 3], currently \"4\""
+
+	AtLeastOneOfTestErr0 = "test_suite>AtLeastOneOfTest - ddmark:validation:AtLeastOneOf: at least one of the following fields need to be non-nil (currently all nil): [StrField IntField]"
+	AtLeastOneOfTestErr1 = "test_suite>AtLeastOneOfTest - ddmark:validation:AtLeastOneOf: at least one of the following fields need to be non-nil (currently all nil): [PStrField PIntField AIntField]"
+
+	ExclusiveFieldsTestErr0 = "test_suite>ExclusiveFieldsTest - ddmark:validation:ExclusiveFields: some fields are incompatible, PIntField can't be set alongside any of [PStrField]"
+	ExclusiveFieldsTestErr1 = "test_suite>ExclusiveFieldsTest - ddmark:validation:ExclusiveFields: some fields are incompatible, IntField can't be set alongside any of [StrField]"
+
+	LinkedFieldsValueTestError0 = "test_suite>LinkedFieldsValueTest - ddmark:validation:LinkedFieldsValue: all of the following fields need to be either nil/at the indicated value or non-nil/not at the indicated value; currently unmatched: [StrField=aaa IntField]"
+	LinkedFieldsValueTestError1 = "test_suite>LinkedFieldsValueTest - ddmark:validation:LinkedFieldsValue: all of the following fields need to be either nil/at the indicated value or non-nil/not at the indicated value; currently unmatched: [PStrField PIntField AIntField]"
+
+	LinkedFieldsValueWithTriggerTestError0 = "test_suite>LinkedFieldsValueWithTriggerTest - ddmark:validation:LinkedFieldsValueWithTrigger: all of the following fields need to be aligned; if the first value is valid / exists, all the following need to either exist or have the indicated value: [StrField=aaa IntField=2]"
+	LinkedFieldsValueWithTriggerTestError1 = "test_suite>LinkedFieldsValueWithTriggerTest - ddmark:validation:LinkedFieldsValueWithTrigger: all of the following fields need to be aligned; if the first value is valid / exists, all the following need to either exist or have the indicated value: [PStrField=bbb PIntField=12 AIntField]"
+)
+
 var _ = Describe("Validation Integration Tests", func() {
 	Context("Minimum/Maximum Markers", func() {
 		It("checks out valid values", func() {
@@ -50,6 +79,8 @@ minmaxtest:
 `
 			err := validateString(minmaxYaml)
 			Expect(err.Errors).To(HaveLen(2))
+			Expect(err.Errors[0]).To(MatchError(MinMaxTestErr0))
+			Expect(err.Errors[1]).To(MatchError(MinMaxTestErr1))
 		})
 	})
 
@@ -61,6 +92,11 @@ requiredtest:
 `
 			err := validateString(requiredYaml)
 			Expect(err.Errors).To(HaveLen(5))
+			Expect(err.Errors[0]).To(MatchError(RequiredTestErr0))
+			Expect(err.Errors[1]).To(MatchError(RequiredTestErr1))
+			Expect(err.Errors[2]).To(MatchError(RequiredTestErr2))
+			Expect(err.Errors[3]).To(MatchError(RequiredTestErr3))
+			Expect(err.Errors[4]).To(MatchError(RequiredTestErr4))
 		})
 		It("rejects on all but one missing fields", func() {
 			var requiredYaml string = `
@@ -70,6 +106,11 @@ requiredtest:
 `
 			err := validateString(requiredYaml)
 			Expect(err.Errors).To(HaveLen(5))
+			Expect(err.Errors[0]).To(MatchError(RequiredTestErr0))
+			Expect(err.Errors[1]).To(MatchError(RequiredTestErr1))
+			Expect(err.Errors[2]).To(MatchError(RequiredTestErr2))
+			Expect(err.Errors[3]).To(MatchError(RequiredTestErr3))
+			Expect(err.Errors[4]).To(MatchError(RequiredTestErr4))
 		})
 		It("rejects and counts all 4 missing fields", func() {
 			var requiredYaml string = `
@@ -79,6 +120,10 @@ requiredtest:
 `
 			err := validateString(requiredYaml)
 			Expect(err.Errors).To(HaveLen(4))
+			Expect(err.Errors[0]).To(MatchError(RequiredTestErr1))
+			Expect(err.Errors[1]).To(MatchError(RequiredTestErr2))
+			Expect(err.Errors[2]).To(MatchError(RequiredTestErr3))
+			Expect(err.Errors[3]).To(MatchError(RequiredTestErr4))
 		})
 		It("rejects and counts all 5 missing fields", func() {
 			var requiredYaml string = `
@@ -89,6 +134,10 @@ requiredtest:
 `
 			err := validateString(requiredYaml)
 			Expect(err.Errors).To(HaveLen(4))
+			Expect(err.Errors[0]).To(MatchError(RequiredTestErr5))
+			Expect(err.Errors[1]).To(MatchError(RequiredTestErr1))
+			Expect(err.Errors[2]).To(MatchError(RequiredTestErr2))
+			Expect(err.Errors[3]).To(MatchError(RequiredTestErr3))
 		})
 		It("checks out on valid file", func() {
 			var requiredYaml string = `
@@ -129,6 +178,10 @@ enumtest:
 `
 			err := validateString(enumCorrectYaml)
 			Expect(err.Errors).To(HaveLen(4))
+			Expect(err.Errors[0]).To(MatchError(EnumTestErr0))
+			Expect(err.Errors[1]).To(MatchError(EnumTestErr1))
+			Expect(err.Errors[2]).To(MatchError(EnumTestErr2))
+			Expect(err.Errors[3]).To(MatchError(EnumTestErr3))
 		})
 	})
 
@@ -143,6 +196,8 @@ exclusivefieldstest:
 `
 			err := validateString(exclusivefieldsYaml)
 			Expect(err.Errors).To(HaveLen(2))
+			Expect(err.Errors[0]).To(MatchError(ExclusiveFieldsTestErr0))
+			Expect(err.Errors[1]).To(MatchError(ExclusiveFieldsTestErr1))
 		})
 		It("checks out valid values", func() {
 			exclusivefieldsYaml := `
@@ -190,6 +245,7 @@ linkedfieldsvaluetest:
 `
 			err := validateString(linkedfieldsvalueYaml)
 			Expect(err.Errors).To(HaveLen(1))
+			Expect(err.Errors[0]).To(MatchError(LinkedFieldsValueTestError0))
 		})
 		It("checks out valid all-nil values", func() {
 			linkedfieldsvalueYaml := `
@@ -197,7 +253,7 @@ linkedfieldsvaluetest:
   randomintfield: 1
   strfield:
   pstrfield:
-  intfield: 0 # is nil
+  intfield: 0 # is zero / nil
   pintfield:  # is nil
   aintfield:
 `
@@ -215,6 +271,8 @@ linkedfieldsvaluetest:
 `
 			err := validateString(linkedfieldsvalueYaml)
 			Expect(err.Errors).To(HaveLen(2))
+			Expect(err.Errors[0]).To(MatchError(LinkedFieldsValueTestError0))
+			Expect(err.Errors[1]).To(MatchError(LinkedFieldsValueTestError1))
 		})
 		It("rejects both errors - second fields", func() {
 			linkedfieldsvalueYaml := `
@@ -227,6 +285,8 @@ linkedfieldsvaluetest:
 `
 			err := validateString(linkedfieldsvalueYaml)
 			Expect(err.Errors).To(HaveLen(2))
+			Expect(err.Errors[0]).To(MatchError(LinkedFieldsValueTestError0))
+			Expect(err.Errors[1]).To(MatchError(LinkedFieldsValueTestError1))
 		})
 		It("rejects one error - 0 value is nil on pointer", func() {
 			linkedfieldsvalueYaml := `
@@ -239,6 +299,7 @@ linkedfieldsvaluetest:
 `
 			err := validateString(linkedfieldsvalueYaml)
 			Expect(err.Errors).To(HaveLen(1))
+			Expect(err.Errors[0]).To(MatchError(LinkedFieldsValueTestError0))
 		})
 	})
 
@@ -246,8 +307,8 @@ linkedfieldsvaluetest:
 		It("is valid with incorrect triggers and incorrect other values", func() {
 			linkedfieldsvaluewithtriggerYaml := `
 linkedfieldsvaluewithtriggertest:
-  strfield: aa      # invalid
-  pstrfield: bb     # invalid
+  strfield: aa      # incorrect trigger
+  pstrfield: bb     # incorrect trigger
   intfield: 12
   pintfield: 1
   aintfield: [1,2]
@@ -279,6 +340,8 @@ linkedfieldsvaluewithtriggertest:
 `
 			err := validateString(linkedfieldsvaluewithtriggerYaml)
 			Expect(err.Errors).To(HaveLen(2))
+			Expect(err.Errors[0]).To(MatchError(LinkedFieldsValueWithTriggerTestError0))
+			Expect(err.Errors[1]).To(MatchError(LinkedFieldsValueWithTriggerTestError1))
 		})
 		It("rejects both errors - one second unfit, one second field missing", func() {
 			linkedfieldsvaluewithtriggerYaml := `
@@ -291,6 +354,8 @@ linkedfieldsvaluewithtriggertest:
 `
 			err := validateString(linkedfieldsvaluewithtriggerYaml)
 			Expect(err.Errors).To(HaveLen(2))
+			Expect(err.Errors[0]).To(MatchError(LinkedFieldsValueWithTriggerTestError0))
+			Expect(err.Errors[1]).To(MatchError(LinkedFieldsValueWithTriggerTestError1))
 		})
 		It("rejects one error - 0 value is nil on pointer", func() {
 			linkedfieldsvaluewithtriggerYaml := `
@@ -303,6 +368,8 @@ linkedfieldsvaluewithtriggertest:
 `
 			err := validateString(linkedfieldsvaluewithtriggerYaml)
 			Expect(err.Errors).To(HaveLen(2))
+			Expect(err.Errors[0]).To(MatchError(LinkedFieldsValueWithTriggerTestError0))
+			Expect(err.Errors[1]).To(MatchError(LinkedFieldsValueWithTriggerTestError1))
 		})
 	})
 
@@ -331,6 +398,8 @@ atleastoneoftest:
 `
 			err := validateString(atLeastOneOfYaml)
 			Expect(err.Errors).To(HaveLen(2))
+			Expect(err.Errors[0]).To(MatchError(AtLeastOneOfTestErr0))
+			Expect(err.Errors[1]).To(MatchError(AtLeastOneOfTestErr1))
 		})
 		It("rejects almost-all-nil values once", func() {
 			atLeastOneOfYaml := `
@@ -343,6 +412,7 @@ atleastoneoftest:
 `
 			err := validateString(atLeastOneOfYaml)
 			Expect(err.Errors).To(HaveLen(1))
+			Expect(err.Errors[0]).To(MatchError(AtLeastOneOfTestErr1))
 		})
 		It("accepts both valid value groups", func() {
 			atLeastOneOfYaml := `
@@ -385,13 +455,14 @@ func testStructFromYaml(yamlBytes []byte) (ddmark.Teststruct, error) {
 func validateString(yamlStr string) *multierror.Error {
 	// Teststruct is a test-dedicated struct built strictly for these integration tests
 	var marshalledStruct ddmark.Teststruct
+	var retErr *multierror.Error = &multierror.Error{}
 
 	marshalledStruct, err := testStructFromYaml([]byte(yamlStr))
-	retErr := client.ValidateStructMultierror(marshalledStruct, "test_suite")
-
 	if err != nil {
-		retErr = multierror.Append(retErr, err)
+		return multierror.Append(retErr, err)
 	}
+
+	retErr = multierror.Append(client.ValidateStructMultierror(marshalledStruct, "test_suite"))
 
 	return retErr
 }

--- a/ddmark/validation_integration_test.go
+++ b/ddmark/validation_integration_test.go
@@ -166,22 +166,22 @@ exclusivefieldstest:
 		})
 	})
 
-	Context("LinkedFields Marker", func() {
+	Context("LinkedFieldsValue Marker", func() {
 		It("checks out valid all-non-nil values", func() {
-			linkedfieldsYaml := `
-linkedfieldstest:
+			linkedfieldsvalueYaml := `
+linkedfieldsvaluetest:
   strfield: aa
   pstrfield: bb
   intfield: 1
   pintfield: 1
   aintfield: [1,2]
 `
-			err := validateString(linkedfieldsYaml)
+			err := validateString(linkedfieldsvalueYaml)
 			Expect(err.Errors).To(HaveLen(0))
 		})
 		It("checks out valid all-nil values", func() {
-			linkedfieldsYaml := `
-linkedfieldstest:
+			linkedfieldsvalueYaml := `
+linkedfieldsvaluetest:
   randomintfield: 1
   strfield:
   pstrfield:
@@ -189,43 +189,43 @@ linkedfieldstest:
   pintfield:  # is nil
   aintfield:
 `
-			err := validateString(linkedfieldsYaml)
+			err := validateString(linkedfieldsvalueYaml)
 			Expect(err.Errors).To(HaveLen(0))
 		})
 		It("rejects both errors - first fields", func() {
-			linkedfieldsYaml := `
-linkedfieldstest:
+			linkedfieldsvalueYaml := `
+linkedfieldsvaluetest:
   strfield: aa
   pstrfield: aa
   intfield:
   pintfield:
   aintfield:
 `
-			err := validateString(linkedfieldsYaml)
+			err := validateString(linkedfieldsvalueYaml)
 			Expect(err.Errors).To(HaveLen(2))
 		})
 		It("rejects both errors - second fields", func() {
-			linkedfieldsYaml := `
-linkedfieldstest:
+			linkedfieldsvalueYaml := `
+linkedfieldsvaluetest:
   strfield:
   pstrfield:
   intfield: 1  # is non-nil
   pintfield: 0 # is non-nil
   aintfield:
 `
-			err := validateString(linkedfieldsYaml)
+			err := validateString(linkedfieldsvalueYaml)
 			Expect(err.Errors).To(HaveLen(2))
 		})
 		It("rejects one error - 0 value is nil on pointer", func() {
-			linkedfieldsYaml := `
-linkedfieldstest:
+			linkedfieldsvalueYaml := `
+linkedfieldsvaluetest:
   strfield: aa
   pstrfield: aa
   intfield: 0 	# is nil
   pintfield: 0  # is non-nil
   aintfield: [1,2]
 `
-			err := validateString(linkedfieldsYaml)
+			err := validateString(linkedfieldsvalueYaml)
 			Expect(err.Errors).To(HaveLen(1))
 		})
 	})
@@ -234,7 +234,7 @@ linkedfieldstest:
 		// +ddmark:validation:LinkedFieldsValueWithTrigger={StrField=aaa,IntField=2}
 		// +ddmark:validation:LinkedFieldsValueWithTrigger={PStrField=bbb,PIntField=12,AIntField}
 		It("checks out valid all-incorrect initial values", func() {
-			linkedfieldsYaml := `
+			linkedfieldsvaluewithtriggerYaml := `
 linkedfieldsvaluewithtriggertest:
   strfield: aa      # invalid
   pstrfield: bb     # invalid
@@ -242,11 +242,11 @@ linkedfieldsvaluewithtriggertest:
   pintfield: 1
   aintfield: [1,2]
 `
-			err := validateString(linkedfieldsYaml)
+			err := validateString(linkedfieldsvaluewithtriggerYaml)
 			Expect(err.Errors).To(HaveLen(0))
 		})
 		It("checks out valid all-nil initial values", func() {
-			linkedfieldsYaml := `
+			linkedfieldsvaluewithtriggerYaml := `
 linkedfieldsvaluewithtriggertest:
   randomintfield: 1
   strfield:
@@ -255,11 +255,11 @@ linkedfieldsvaluewithtriggertest:
   pintfield:  # is nil
   aintfield:  # is nil
 `
-			err := validateString(linkedfieldsYaml)
+			err := validateString(linkedfieldsvaluewithtriggerYaml)
 			Expect(err.Errors).To(HaveLen(0))
 		})
 		It("rejects both errors - nil second fields", func() {
-			linkedfieldsYaml := `
+			linkedfieldsvaluewithtriggerYaml := `
 linkedfieldsvaluewithtriggertest:
   strfield: aaa
   pstrfield: bbb
@@ -267,11 +267,11 @@ linkedfieldsvaluewithtriggertest:
   pintfield: # is nil
   aintfield: # is nil
 `
-			err := validateString(linkedfieldsYaml)
+			err := validateString(linkedfieldsvaluewithtriggerYaml)
 			Expect(err.Errors).To(HaveLen(2))
 		})
 		It("rejects both errors - one second unfit, one second field missing", func() {
-			linkedfieldsYaml := `
+			linkedfieldsvaluewithtriggerYaml := `
 linkedfieldsvaluewithtriggertest:
   strfield: aaa
   pstrfield: bbb
@@ -279,11 +279,11 @@ linkedfieldsvaluewithtriggertest:
   pintfield: 0 # is non-nil
   aintfield:   # is nil
 `
-			err := validateString(linkedfieldsYaml)
+			err := validateString(linkedfieldsvaluewithtriggerYaml)
 			Expect(err.Errors).To(HaveLen(2))
 		})
 		It("rejects one error - 0 value is nil on pointer", func() {
-			linkedfieldsYaml := `
+			linkedfieldsvaluewithtriggerYaml := `
 linkedfieldsvaluewithtriggertest:
   strfield: aaa
   pstrfield: bbb
@@ -291,7 +291,7 @@ linkedfieldsvaluewithtriggertest:
   pintfield: 0     # is non-nil
   aintfield: [1,2] # is non-nil
 `
-			err := validateString(linkedfieldsYaml)
+			err := validateString(linkedfieldsvaluewithtriggerYaml)
 			Expect(err.Errors).To(HaveLen(2))
 		})
 	})

--- a/ddmark/validation_integration_test.go
+++ b/ddmark/validation_integration_test.go
@@ -243,9 +243,7 @@ linkedfieldsvaluetest:
 	})
 
 	Context("LinkedFieldsValueWithTrigger Marker", func() {
-		// +ddmark:validation:LinkedFieldsValueWithTrigger={StrField=aaa,IntField=2}
-		// +ddmark:validation:LinkedFieldsValueWithTrigger={PStrField=bbb,PIntField=12,AIntField}
-		It("checks out valid all-incorrect initial values", func() {
+		It("is valid with incorrect triggers and incorrect other values", func() {
 			linkedfieldsvaluewithtriggerYaml := `
 linkedfieldsvaluewithtriggertest:
   strfield: aa      # invalid

--- a/ddmark/validation_integration_test.go
+++ b/ddmark/validation_integration_test.go
@@ -170,7 +170,7 @@ exclusivefieldstest:
 		It("checks out valid all-non-nil values", func() {
 			linkedfieldsvalueYaml := `
 linkedfieldsvaluetest:
-  strfield: aa
+  strfield: aaa
   pstrfield: bb
   intfield: 1
   pintfield: 1
@@ -178,6 +178,18 @@ linkedfieldsvaluetest:
 `
 			err := validateString(linkedfieldsvalueYaml)
 			Expect(err.Errors).To(HaveLen(0))
+		})
+		It("rejects invalid requires value for StrField", func() {
+			linkedfieldsvalueYaml := `
+linkedfieldsvaluetest:
+  strfield: notaaa
+  pstrfield: bb
+  intfield: 1
+  pintfield: 1
+  aintfield: [1,2]
+`
+			err := validateString(linkedfieldsvalueYaml)
+			Expect(err.Errors).To(HaveLen(1))
 		})
 		It("checks out valid all-nil values", func() {
 			linkedfieldsvalueYaml := `
@@ -197,7 +209,7 @@ linkedfieldsvaluetest:
 linkedfieldsvaluetest:
   strfield: aa
   pstrfield: aa
-  intfield:
+  intfield: 1
   pintfield:
   aintfield:
 `
@@ -219,7 +231,7 @@ linkedfieldsvaluetest:
 		It("rejects one error - 0 value is nil on pointer", func() {
 			linkedfieldsvalueYaml := `
 linkedfieldsvaluetest:
-  strfield: aa
+  strfield: aaa
   pstrfield: aa
   intfield: 0 	# is nil
   pintfield: 0  # is non-nil

--- a/ddmark/validation_integration_test.go
+++ b/ddmark/validation_integration_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	MinMaxTestErr0 = "test_suite>MinMaxTest>IntField - ddmark:validation:Minimum: field has value 4, min is 5 (included)"
-	MinMaxTestErr1 = "test_suite>MinMaxTest>PIntField - ddmark:validation:Maximum: field has value 11, max is 10 (included)"
+	MinMaxTestErr0 = "test_suite>MinMaxTest>IntField - ddmark:validation:Minimum: min value for field is 5 (included)"
+	MinMaxTestErr1 = "test_suite>MinMaxTest>PIntField - ddmark:validation:Maximum: max value for field is 10 (included)"
 
 	RequiredTestErr0 = "test_suite>RequiredTest>PIntField is required"
 	RequiredTestErr1 = "test_suite>RequiredTest>StrField - ddmark:validation:Required: field is required: currently missing"
@@ -24,10 +24,10 @@ const (
 	RequiredTestErr4 = "test_suite>RequiredTest>PStructField is required"
 	RequiredTestErr5 = "test_suite>RequiredTest>IntField - ddmark:validation:Required: field is required: currently missing"
 
-	EnumTestErr0 = "test_suite>EnumTest>StrField - ddmark:validation:Enum: field needs to be one of [aa bb 11], currently \"notinenum\""
-	EnumTestErr1 = "test_suite>EnumTest>PStrField - ddmark:validation:Enum: field needs to be one of [aa bb 11], currently \"notinenum\""
-	EnumTestErr2 = "test_suite>EnumTest>IntField - ddmark:validation:Enum: field needs to be one of [1 2 3], currently \"4\""
-	EnumTestErr3 = "test_suite>EnumTest>PIntField - ddmark:validation:Enum: field needs to be one of [1 2 3], currently \"4\""
+	EnumTestErr0 = "test_suite>EnumTest>StrField - ddmark:validation:Enum: field needs to be one of [aa bb 11]"
+	EnumTestErr1 = "test_suite>EnumTest>PStrField - ddmark:validation:Enum: field needs to be one of [aa bb 11]"
+	EnumTestErr2 = "test_suite>EnumTest>IntField - ddmark:validation:Enum: field needs to be one of [1 2 3]"
+	EnumTestErr3 = "test_suite>EnumTest>PIntField - ddmark:validation:Enum: field needs to be one of [1 2 3]"
 
 	AtLeastOneOfTestErr0 = "test_suite>AtLeastOneOfTest - ddmark:validation:AtLeastOneOf: at least one of the following fields need to be non-nil (currently all nil): [StrField IntField]"
 	AtLeastOneOfTestErr1 = "test_suite>AtLeastOneOfTest - ddmark:validation:AtLeastOneOf: at least one of the following fields need to be non-nil (currently all nil): [PStrField PIntField AIntField]"

--- a/ddmark/validation_integration_test.go
+++ b/ddmark/validation_integration_test.go
@@ -230,6 +230,72 @@ linkedfieldstest:
 		})
 	})
 
+	Context("LinkedFieldsValueWithTrigger Marker", func() {
+		// +ddmark:validation:LinkedFieldsValueWithTrigger={StrField=aaa,IntField=2}
+		// +ddmark:validation:LinkedFieldsValueWithTrigger={PStrField=bbb,PIntField=12,AIntField}
+		It("checks out valid all-incorrect initial values", func() {
+			linkedfieldsYaml := `
+linkedfieldsvaluewithtriggertest:
+  strfield: aa      # invalid
+  pstrfield: bb     # invalid
+  intfield: 12
+  pintfield: 1
+  aintfield: [1,2]
+`
+			err := validateString(linkedfieldsYaml)
+			Expect(err.Errors).To(HaveLen(0))
+		})
+		It("checks out valid all-nil initial values", func() {
+			linkedfieldsYaml := `
+linkedfieldsvaluewithtriggertest:
+  randomintfield: 1
+  strfield:
+  pstrfield:
+  intfield: 0 # is nil
+  pintfield:  # is nil
+  aintfield:  # is nil
+`
+			err := validateString(linkedfieldsYaml)
+			Expect(err.Errors).To(HaveLen(0))
+		})
+		It("rejects both errors - nil second fields", func() {
+			linkedfieldsYaml := `
+linkedfieldsvaluewithtriggertest:
+  strfield: aaa
+  pstrfield: bbb
+  intfield:  # is nil
+  pintfield: # is nil
+  aintfield: # is nil
+`
+			err := validateString(linkedfieldsYaml)
+			Expect(err.Errors).To(HaveLen(2))
+		})
+		It("rejects both errors - one second unfit, one second field missing", func() {
+			linkedfieldsYaml := `
+linkedfieldsvaluewithtriggertest:
+  strfield: aaa
+  pstrfield: bbb
+  intfield: 12 # is non-nil
+  pintfield: 0 # is non-nil
+  aintfield:   # is nil
+`
+			err := validateString(linkedfieldsYaml)
+			Expect(err.Errors).To(HaveLen(2))
+		})
+		It("rejects one error - 0 value is nil on pointer", func() {
+			linkedfieldsYaml := `
+linkedfieldsvaluewithtriggertest:
+  strfield: aaa
+  pstrfield: bbb
+  intfield: 0 	 # is nil
+  pintfield: 0     # is non-nil
+  aintfield: [1,2] # is non-nil
+`
+			err := validateString(linkedfieldsYaml)
+			Expect(err.Errors).To(HaveLen(2))
+		})
+	})
+
 	Context("AtLeastOneOf Marker", func() {
 		It("no error on all-nil sub-fields (marker not run)", func() {
 			atLeastOneOfYaml := `

--- a/ddmark/validation_integration_test.go
+++ b/ddmark/validation_integration_test.go
@@ -22,7 +22,7 @@ minmaxtest:
   pintfield: 6
 `
 			err := validateString(minmaxYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 		It("rejects empty pointer value", func() {
 			var minmaxYaml string = `
@@ -31,7 +31,7 @@ minmaxtest:
   pintfield:
 `
 			err := validateString(minmaxYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 		It("checks out valid values", func() {
 			var minmaxYaml string = `
@@ -40,7 +40,7 @@ minmaxtest:
   pintfield: 10
 `
 			err := validateString(minmaxYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 		It("rejects invalid values", func() {
 			var minmaxYaml string = `
@@ -103,7 +103,7 @@ requiredtest:
     a: 1
 `
 			err := validateString(requiredYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 	})
 
@@ -117,7 +117,7 @@ enumtest:
   pintfield: 2
 `
 			err := validateString(enumCorrectYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 		It("rejects invalid values", func() {
 			var enumCorrectYaml string = `
@@ -153,7 +153,7 @@ exclusivefieldstest:
   pstrfield:
 `
 			err := validateString(exclusivefieldsYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 		It("allows latter fields to be set freely", func() {
 			exclusivefieldsYaml := `
@@ -162,7 +162,7 @@ exclusivefieldstest:
   cfield: 1
 `
 			err := validateString(exclusivefieldsYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 	})
 
@@ -177,7 +177,7 @@ linkedfieldsvaluetest:
   aintfield: [1,2]
 `
 			err := validateString(linkedfieldsvalueYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 		It("rejects invalid requires value for StrField", func() {
 			linkedfieldsvalueYaml := `
@@ -202,7 +202,7 @@ linkedfieldsvaluetest:
   aintfield:
 `
 			err := validateString(linkedfieldsvalueYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 		It("rejects both errors - first fields", func() {
 			linkedfieldsvalueYaml := `
@@ -255,7 +255,7 @@ linkedfieldsvaluewithtriggertest:
   aintfield: [1,2]
 `
 			err := validateString(linkedfieldsvaluewithtriggerYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 		It("checks out valid all-nil initial values", func() {
 			linkedfieldsvaluewithtriggerYaml := `
@@ -268,7 +268,7 @@ linkedfieldsvaluewithtriggertest:
   aintfield:  # is nil
 `
 			err := validateString(linkedfieldsvaluewithtriggerYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 		It("rejects both errors - nil second fields", func() {
 			linkedfieldsvaluewithtriggerYaml := `
@@ -319,7 +319,7 @@ atleastoneoftest:
   aintfield:   # is nil
 `
 			err := validateString(atLeastOneOfYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 		It("rejects out all-nil values twice", func() {
 			atLeastOneOfYaml := `
@@ -356,7 +356,7 @@ atleastoneoftest:
   aintfield:
 `
 			err := validateString(atLeastOneOfYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 		It("accepts both valid value groups", func() {
 			atLeastOneOfYaml := `
@@ -368,7 +368,7 @@ atleastoneoftest:
   aintfield: []
 `
 			err := validateString(atLeastOneOfYaml)
-			Expect(err.Errors).To(HaveLen(0))
+			Expect(err.Errors).To(BeEmpty())
 		})
 	})
 })

--- a/ddmark/validation_interface.go
+++ b/ddmark/validation_interface.go
@@ -11,4 +11,8 @@ import "reflect"
 type DDValidationMarker interface {
 	// ApplyRule asserts the marker's rule is checked and returns an error if it isn't (invalidating the config)
 	ApplyRule(reflect.Value) error
+	// ValueCheckError returns a marker's error message for an incorrect value/presence check
+	ValueCheckError() error
+	// TypeCheckError returns a marker's error message for an incorrect type check
+	TypeCheckError(reflect.Value) error
 }

--- a/ddmark/validation_teststruct.go
+++ b/ddmark/validation_teststruct.go
@@ -68,7 +68,7 @@ type ExclusiveFieldsTestStruct struct {
 	CField    int
 }
 
-// +ddmark:validation:LinkedFieldsValue={StrField,IntField}
+// +ddmark:validation:LinkedFieldsValue={StrField=aaa,IntField}
 // +ddmark:validation:LinkedFieldsValue={PStrField,PIntField,AIntField}
 type LinkedFieldsValueTestStruct struct {
 	RandomIntField int // allows to actually check all-empty structs

--- a/ddmark/validation_teststruct.go
+++ b/ddmark/validation_teststruct.go
@@ -12,7 +12,7 @@ type Teststruct struct {
 	RequiredTest                     RequiredTestStruct
 	EnumTest                         EnumTestStruct
 	ExclusiveFieldsTest              ExclusiveFieldsTestStruct
-	LinkedFieldsTest                 LinkedFieldsTestStruct
+	LinkedFieldsValueTest            LinkedFieldsValueTestStruct
 	LinkedFieldsValueWithTriggerTest LinkedFieldsValueWithTriggerTestStruct
 	AtLeastOneOfTest                 AtLeastOneOfTestStruct
 }
@@ -68,9 +68,9 @@ type ExclusiveFieldsTestStruct struct {
 	CField    int
 }
 
-// +ddmark:validation:LinkedFields={StrField,IntField}
-// +ddmark:validation:LinkedFields={PStrField,PIntField,AIntField}
-type LinkedFieldsTestStruct struct {
+// +ddmark:validation:LinkedFieldsValue={StrField,IntField}
+// +ddmark:validation:LinkedFieldsValue={PStrField,PIntField,AIntField}
+type LinkedFieldsValueTestStruct struct {
 	RandomIntField int // allows to actually check all-empty structs
 	StrField       string
 	PStrField      *string

--- a/ddmark/validation_teststruct.go
+++ b/ddmark/validation_teststruct.go
@@ -8,12 +8,13 @@
 package ddmark
 
 type Teststruct struct {
-	MinMaxTest          MinMaxTestStruct
-	RequiredTest        RequiredTestStruct
-	EnumTest            EnumTestStruct
-	ExclusiveFieldsTest ExclusiveFieldsTestStruct
-	LinkedFieldsTest    LinkedFieldsTestStruct
-	AtLeastOneOfTest    AtLeastOneOfTestStruct
+	MinMaxTest                       MinMaxTestStruct
+	RequiredTest                     RequiredTestStruct
+	EnumTest                         EnumTestStruct
+	ExclusiveFieldsTest              ExclusiveFieldsTestStruct
+	LinkedFieldsTest                 LinkedFieldsTestStruct
+	LinkedFieldsValueWithTriggerTest LinkedFieldsValueWithTriggerTestStruct
+	AtLeastOneOfTest                 AtLeastOneOfTestStruct
 }
 
 type MinMaxTestStruct struct {
@@ -70,6 +71,17 @@ type ExclusiveFieldsTestStruct struct {
 // +ddmark:validation:LinkedFields={StrField,IntField}
 // +ddmark:validation:LinkedFields={PStrField,PIntField,AIntField}
 type LinkedFieldsTestStruct struct {
+	RandomIntField int // allows to actually check all-empty structs
+	StrField       string
+	PStrField      *string
+	IntField       int
+	PIntField      *int
+	AIntField      []int
+}
+
+// +ddmark:validation:LinkedFieldsValueWithTrigger={StrField=aaa,IntField=2}
+// +ddmark:validation:LinkedFieldsValueWithTrigger={PStrField=bbb,PIntField=12,AIntField}
+type LinkedFieldsValueWithTriggerTestStruct struct {
 	RandomIntField int // allows to actually check all-empty structs
 	StrField       string
 	PStrField      *string

--- a/ddmark/validation_unit_test.go
+++ b/ddmark/validation_unit_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			Field3 *int
 		}
 
-		// fakeObj is a unit test object that will be filled with non-empty values
+		// fakeObj is a unit test object that will be filled with non-empty values by default
 		var fakeObj dummyStruct
 
 		BeforeEach(func() {
@@ -225,17 +225,17 @@ var _ = Describe("Validation Rules Cases", func() {
 
 			It("is invalid if given an empty string value (empty-value string is nil)", func() {
 				fakeObj.Field1 = ""
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 			})
 
 			It("is invalid if given one missing field (zero-int is nil)", func() {
 				fakeObj.Field2 = 0
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 			})
 
 			It("is invalid if given nil pointer (nil pointer is nil)", func() {
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 			})
 		})
 
@@ -264,31 +264,31 @@ var _ = Describe("Validation Rules Cases", func() {
 
 			It("is invalid if given empty string value (empty-value string is nil)", func() {
 				fakeObj.Field1 = ""
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 			})
 
 			It("is invalid if given one missing field (Field2 is 0/nil, expected value was 2)", func() {
 				fakeObj.Field2 = 0
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 			})
 
 			It("is invalid if given one incorrect field (Field2 is 3, expected value was 2)", func() {
 				fakeObj.Field2 = 3
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 			})
 
 			It("is invalid if given nil pointer (empty value for Field3)", func() {
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 			})
 		})
 
 		Context("given empty value requirements", func() {
 			arr := []string{"Field1=", "Field2="}
-			emptyLinked := LinkedFieldsValue(arr)
+			linked := LinkedFieldsValue(arr)
 
 			It("accepts non-empty values for both Field1 and Field2", func() {
-				Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 			})
 
 			Context("with empty string as a valid empty-required value for Field1", func() {
@@ -297,24 +297,25 @@ var _ = Describe("Validation Rules Cases", func() {
 				})
 				It("is valid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
 				It("is invalid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 				})
 			})
+
 			Context("with non-empty string as an invalid empty-required value for Field1", func() {
 				BeforeEach(func() {
 					fakeObj.Field1 = "notempty"
 				})
 				It("is valid if Field2 is not zero", func() {
 					fakeObj.Field2 = 1
-					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
 				It("is invalid if Field2 is zero", func() {
 					fakeObj.Field2 = 0
-					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 				})
 
 			})
@@ -322,10 +323,10 @@ var _ = Describe("Validation Rules Cases", func() {
 
 		Context("given empty value requirements on pointer field", func() {
 			arr := []string{"Field2=", "Field3="}
-			emptyPointerLinked := LinkedFieldsValue(arr)
+			linked := LinkedFieldsValue(arr)
 
 			It("accepts non-empty values for both Field2 and Field3", func() {
-				Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 			})
 
 			Context("with empty pointer as a valid empty-required value for Field3", func() {
@@ -335,12 +336,12 @@ var _ = Describe("Validation Rules Cases", func() {
 
 				It("is valid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
 
 				It("is invalid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 				})
 			})
 
@@ -354,12 +355,12 @@ var _ = Describe("Validation Rules Cases", func() {
 
 				It("is valid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
 
 				It("is invalid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 				})
 			})
 		})
@@ -372,9 +373,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			Field3 *int
 		}
 
-		// we expect that; if Field1 value is "aaa" then Field 2 value is 12 and Field3 is not nil
-		arr := []string{"Field1=aaa", "Field2=12", "Field3"}
-		linked := LinkedFieldsValueWithTrigger(arr)
+		// fakeObj is a unit test object that will be filled with valid/non-empty values by default
 		var fakeObj dummyStruct
 
 		BeforeEach(func() {
@@ -387,38 +386,134 @@ var _ = Describe("Validation Rules Cases", func() {
 				Field3: pi,
 			}
 		})
-		It("validates object with all correct fields", func() {
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+
+		Context("with non-pointer trigger value", func() {
+			// we expect that; if Field1 value is "aaa" then Field 2 value is 12 and Field3 is not nil
+			arr := []string{"Field1=aaa", "Field2=12", "Field3"}
+			linked := LinkedFieldsValueWithTrigger(arr)
+
+			Context("with valid trigger value ('Field1=aaa')", func() {
+				It("is valid if all other fields are correct", func() {
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
+
+				It("is invalid if one field is nil / missing (nil-value pointer int is nil)", func() {
+					fakeObj.Field3 = nil
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				})
+
+				It("is invalid if one value is nil / missing (expected value is value 12)", func() {
+					fakeObj.Field2 = 0
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				})
+
+				It("is invalid if one value is incorrect (expected value is value 12)", func() {
+					fakeObj.Field2 = 1
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				})
+
+				It("is valid if other fields are correct (incl. 0-value pointer-int -- it's not-nil)", func() {
+					i := 0
+					pi := &i
+
+					fakeObj.Field3 = pi
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
+			})
+
+			Context("with invalid trigger value ('Field1 = bbb')", func() {
+				BeforeEach(func() {
+					fakeObj.Field1 = "bbb"
+				})
+
+				It("is valid if all other fields (except the trigger) are correct", func() {
+					fakeObj.Field2 = 0
+					fakeObj.Field3 = nil
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
+
+				It("is valid if all other fields are incorrect", func() {
+					fakeObj.Field2 = 11
+					fakeObj.Field3 = nil
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
+
+				It("is valid if all other fields are nil", func() {
+					fakeObj.Field2 = 0
+					fakeObj.Field3 = nil
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
+			})
+
+			Context("with nil trigger value ('Field1 = \"\"')", func() {
+				BeforeEach(func() {
+					fakeObj.Field1 = "bbb"
+				})
+
+				It("is valid if all other fields (except the trigger) are correct", func() {
+					fakeObj.Field2 = 0
+					fakeObj.Field3 = nil
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
+
+				It("is valid if all other fields are incorrect", func() {
+					fakeObj.Field2 = 11
+					fakeObj.Field3 = nil
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
+
+				It("is valid if all other fields are nil", func() {
+					fakeObj.Field2 = 0
+					fakeObj.Field3 = nil
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
+			})
 		})
 
-		It("validates object with all nil fields", func() {
-			fakeObj.Field1 = ""
-			fakeObj.Field2 = 0
-			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
-		})
+		Context("with pointer trigger value (Field3 is the trigger)", func() {
+			// we expect that; if Field3 pointer value is 3 then Field1 is expected to be 'aaa' and Field 2 value is expected to be 12
+			arr := []string{"Field3=3", "Field1=aaa", "Field2=12"}
+			linked := LinkedFieldsValueWithTrigger(arr)
 
-		It("validates object with correct trigger, correct fields (incl. 0-value pointer-int -- it's not-nil)", func() {
-			i := 0
-			var pi *int = &i
+			Context("with valid trigger value ('Field3=3')", func() {
+				It("is valid if all other fields are correct", func() {
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
 
-			fakeObj.Field3 = pi
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
-		})
+				It("is invalid if one value is nil / missing(expected value is value 12)", func() {
+					fakeObj.Field2 = 0
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				})
 
-		It("rejects object with nil pointer value (nil-value pointer int is nil)", func() {
-			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
-		})
+				It("is invalid if one value is incorrect (expected value is value 12)", func() {
+					fakeObj.Field2 = 1
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				})
+			})
 
-		It("rejects object with one missing value (expected value is value 12)", func() {
-			fakeObj.Field2 = 0
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
-		})
+			Context("with nil trigger value ('Field3=nil') -- should work as invalid", func() {
+				BeforeEach(func() {
+					fakeObj.Field3 = nil
+				})
 
-		It("rejects object with one incorrect value (expected value is value 12)", func() {
-			fakeObj.Field2 = 1
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+				It("is valid if all other fields (except the trigger) are correct", func() {
+					fakeObj.Field2 = 0
+					fakeObj.Field3 = nil
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
+
+				It("is valid if all other fields are incorrect", func() {
+					fakeObj.Field2 = 11
+					fakeObj.Field3 = nil
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
+
+				It("is valid if all other fields are nil", func() {
+					fakeObj.Field2 = 0
+					fakeObj.Field3 = nil
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				})
+			})
 		})
 	})
 

--- a/ddmark/validation_unit_test.go
+++ b/ddmark/validation_unit_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Validation Rules Cases", func() {
 			Expect(max.ApplyRule(ValueOf(-1001))).To(Succeed())
 		})
 		It("rejects small string values", func() {
-			Expect(max.ApplyRule(ValueOf("0"))).ToNot(Succeed())
+			Expect(max.ApplyRule(ValueOf("0"))).To(MatchError(max.GenTypeCheckError(ValueOf("0"))))
 		})
 		It("rejects large string values", func() {
-			Expect(max.ApplyRule(ValueOf("1001"))).ToNot(Succeed())
+			Expect(max.ApplyRule(ValueOf("1001"))).To(MatchError(max.GenTypeCheckError(ValueOf("1001"))))
 		})
 		It("rejects superior values", func() {
-			Expect(max.ApplyRule(ValueOf(maxInt + 1))).ToNot(Succeed())
+			Expect(max.ApplyRule(ValueOf(maxInt + 1))).To(MatchError(max.GenValueCheckError(maxInt + 1)))
 		})
 		It("accepts exact value", func() {
 			Expect(max.ApplyRule(ValueOf(maxInt))).To(Succeed())
@@ -54,13 +54,13 @@ var _ = Describe("Validation Rules Cases", func() {
 		})
 
 		It("rejects large negative values", func() {
-			Expect(min.ApplyRule(ValueOf(-1001))).ToNot(Succeed())
+			Expect(min.ApplyRule(ValueOf(-1001))).To(MatchError(min.GenValueCheckError(-1001)))
 		})
 		It("rejects small string values", func() {
-			Expect(min.ApplyRule(ValueOf("0"))).ToNot(Succeed())
+			Expect(min.ApplyRule(ValueOf("0"))).To(MatchError(min.GenTypeCheckError(ValueOf("0"))))
 		})
 		It("rejects large string values", func() {
-			Expect(min.ApplyRule(ValueOf("1001"))).ToNot(Succeed())
+			Expect(min.ApplyRule(ValueOf("1001"))).To(MatchError(min.GenTypeCheckError(ValueOf("1001"))))
 		})
 		It("accepts superior value", func() {
 			Expect(min.ApplyRule(ValueOf(minInt + 1))).To(Succeed())
@@ -69,7 +69,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			Expect(min.ApplyRule(ValueOf(minInt))).To(Succeed())
 		})
 		It("rejects inferior value", func() {
-			Expect(min.ApplyRule(ValueOf(minInt - 1))).ToNot(Succeed())
+			Expect(min.ApplyRule(ValueOf(minInt - 1))).To(MatchError(min.GenValueCheckError(minInt - 1)))
 		})
 	})
 
@@ -84,25 +84,25 @@ var _ = Describe("Validation Rules Cases", func() {
 			Expect(validStrEnum.ApplyRule(ValueOf(arrStr[0]))).To(Succeed())
 		})
 		It("rejects an invalid string value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf("notavalue"))).ToNot(Succeed())
+			Expect(validStrEnum.ApplyRule(ValueOf("notavalue"))).To(MatchError(validStrEnum.GenValueCheckError(ValueOf("notavalue"))))
 		})
 		It("rejects an invalid int value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf(4))).ToNot(Succeed())
+			Expect(validStrEnum.ApplyRule(ValueOf(4))).To(MatchError(validStrEnum.GenTypeCheckError(ValueOf(4))))
 		})
 		It("rejects a combined str value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf("ab"))).ToNot(Succeed())
+			Expect(validStrEnum.ApplyRule(ValueOf("ab"))).To(MatchError(validStrEnum.GenValueCheckError(ValueOf("ab"))))
 		})
 		It("accepts a valid int value", func() {
 			Expect(validIntEnum.ApplyRule(ValueOf(arrInt[0]))).To(Succeed())
 		})
 		It("rejects an invalid int value", func() {
-			Expect(validIntEnum.ApplyRule(ValueOf(4))).ToNot(Succeed())
+			Expect(validIntEnum.ApplyRule(ValueOf(4))).To(MatchError(validIntEnum.GenValueCheckError(ValueOf(4))))
 		})
 		It("int enum rejects a fitting string value", func() {
-			Expect(validIntEnum.ApplyRule(ValueOf("1"))).ToNot(Succeed())
+			Expect(validIntEnum.ApplyRule(ValueOf("1"))).To(MatchError(validIntEnum.GenValueCheckError(ValueOf("1"))))
 		})
 		It("errors out if enum is empty", func() {
-			Expect(emptyEnum.ApplyRule(ValueOf("any"))).ToNot(Succeed())
+			Expect(emptyEnum.ApplyRule(ValueOf("any"))).To(MatchError(emptyEnum.GenValueCheckError(ValueOf("any"))))
 		})
 	})
 
@@ -111,13 +111,13 @@ var _ = Describe("Validation Rules Cases", func() {
 		const falseRequired Required = Required(false)
 
 		It("true errors given nil", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(nil))).ToNot(Succeed())
+			Expect(trueRequired.ApplyRule(ValueOf(nil))).To(MatchError(trueRequired.GenValueCheckError()))
 		})
 		It("true errors given empty string", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(""))).ToNot(Succeed())
+			Expect(trueRequired.ApplyRule(ValueOf(""))).To(MatchError(trueRequired.GenValueCheckError()))
 		})
 		It("true errors out given 0", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(0))).ToNot(Succeed())
+			Expect(trueRequired.ApplyRule(ValueOf(0))).To(MatchError(trueRequired.GenValueCheckError()))
 		})
 		It("true accepts regular values", func() {
 			Expect(trueRequired.ApplyRule(ValueOf("a"))).To(Succeed())
@@ -152,12 +152,12 @@ var _ = Describe("Validation Rules Cases", func() {
 		})
 
 		It("rejects object with 3+ fields", func() {
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(MatchError(excl.GenValueCheckError()))
 		})
 
 		It("rejects object with 2 fields", func() {
 			fakeObj.Field2 = 0
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(MatchError(excl.GenValueCheckError()))
 		})
 
 		It("validates object with 1 field", func() {
@@ -550,7 +550,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field2 = 0
 			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 		})
 
 		It("validates object with only 1 value (0-value int is nil, nil-value pointer int is nil)", func() {

--- a/ddmark/validation_unit_test.go
+++ b/ddmark/validation_unit_test.go
@@ -25,22 +25,22 @@ var _ = Describe("Validation Rules Cases", func() {
 		})
 
 		It("accept large negative values", func() {
-			Expect(max.ApplyRule(ValueOf(-1001))).To(Succeed())
+			markerSuccess(max, -1001)
 		})
 		It("rejects small string values", func() {
-			Expect(max.ApplyRule(ValueOf("0"))).To(MatchError(max.TypeCheckError(ValueOf("0"))))
+			expectTypeError(max, "0")
 		})
 		It("rejects large string values", func() {
-			Expect(max.ApplyRule(ValueOf("1001"))).To(MatchError(max.TypeCheckError(ValueOf("1001"))))
+			expectTypeError(max, "1001")
 		})
 		It("rejects superior values", func() {
-			Expect(max.ApplyRule(ValueOf(maxInt + 1))).To(MatchError(max.ValueCheckError()))
+			expectValueError(max, maxInt+1)
 		})
 		It("accepts exact value", func() {
-			Expect(max.ApplyRule(ValueOf(maxInt))).To(Succeed())
+			markerSuccess(max, maxInt)
 		})
 		It("accepts inferior value", func() {
-			Expect(max.ApplyRule(ValueOf(maxInt - 1))).To(Succeed())
+			markerSuccess(max, maxInt-1)
 		})
 	})
 
@@ -54,22 +54,22 @@ var _ = Describe("Validation Rules Cases", func() {
 		})
 
 		It("rejects large negative values", func() {
-			Expect(min.ApplyRule(ValueOf(-1001))).To(MatchError(min.ValueCheckError()))
+			expectValueError(min, -1001)
 		})
 		It("rejects small string values", func() {
-			Expect(min.ApplyRule(ValueOf("0"))).To(MatchError(min.TypeCheckError(ValueOf("0"))))
+			expectTypeError(min, "0")
 		})
 		It("rejects large string values", func() {
-			Expect(min.ApplyRule(ValueOf("1001"))).To(MatchError(min.TypeCheckError(ValueOf("1001"))))
+			expectTypeError(min, "1001")
 		})
 		It("accepts superior value", func() {
-			Expect(min.ApplyRule(ValueOf(minInt + 1))).To(Succeed())
+			markerSuccess(min, minInt+1)
 		})
 		It("accepts exact value", func() {
-			Expect(min.ApplyRule(ValueOf(minInt))).To(Succeed())
+			markerSuccess(min, minInt)
 		})
 		It("rejects inferior value", func() {
-			Expect(min.ApplyRule(ValueOf(minInt - 1))).To(MatchError(min.ValueCheckError()))
+			expectValueError(min, minInt-1)
 		})
 	})
 
@@ -81,28 +81,28 @@ var _ = Describe("Validation Rules Cases", func() {
 		emptyEnum := Enum(nil)
 
 		It("accepts a valid string value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf(arrStr[0]))).To(Succeed())
+			markerSuccess(validStrEnum, "a")
 		})
 		It("rejects an invalid string value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf("notavalue"))).To(MatchError(validStrEnum.ValueCheckError()))
+			expectValueError(validStrEnum, "notavalue")
 		})
 		It("rejects an invalid int value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf(4))).To(MatchError(validStrEnum.TypeCheckError(ValueOf(4))))
+			expectTypeError(validStrEnum, 4)
 		})
 		It("rejects a combined str value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf("ab"))).To(MatchError(validStrEnum.ValueCheckError()))
+			expectValueError(validStrEnum, "ab")
 		})
 		It("accepts a valid int value", func() {
-			Expect(validIntEnum.ApplyRule(ValueOf(arrInt[0]))).To(Succeed())
+			markerSuccess(validIntEnum, arrInt[0])
 		})
 		It("rejects an invalid int value", func() {
-			Expect(validIntEnum.ApplyRule(ValueOf(4))).To(MatchError(validIntEnum.ValueCheckError()))
+			expectValueError(validIntEnum, 4)
 		})
 		It("int enum rejects a fitting string value", func() {
-			Expect(validIntEnum.ApplyRule(ValueOf("1"))).To(MatchError(validIntEnum.ValueCheckError()))
+			expectValueError(validIntEnum, "1")
 		})
 		It("errors out if enum is empty", func() {
-			Expect(emptyEnum.ApplyRule(ValueOf("any"))).To(MatchError(emptyEnum.ValueCheckError()))
+			expectValueError(emptyEnum, "any")
 		})
 	})
 
@@ -111,24 +111,24 @@ var _ = Describe("Validation Rules Cases", func() {
 		const falseRequired Required = Required(false)
 
 		It("true errors given nil", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(nil))).To(MatchError(trueRequired.ValueCheckError()))
+			expectValueError(trueRequired, nil)
 		})
 		It("true errors given empty string", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(""))).To(MatchError(trueRequired.ValueCheckError()))
+			expectValueError(trueRequired, "")
 		})
 		It("true errors out given 0", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(0))).To(MatchError(trueRequired.ValueCheckError()))
+			expectValueError(trueRequired, 0)
 		})
 		It("true accepts regular values", func() {
-			Expect(trueRequired.ApplyRule(ValueOf("a"))).To(Succeed())
-			Expect(trueRequired.ApplyRule(ValueOf(1))).To(Succeed())
+			markerSuccess(trueRequired, "a")
+			markerSuccess(trueRequired, 1)
 		})
 		It("false doesn't error given nil", func() {
-			Expect(falseRequired.ApplyRule(ValueOf(nil))).To(Succeed())
+			markerSuccess(falseRequired, nil)
 		})
 		It("false accepts regular values", func() {
-			Expect(trueRequired.ApplyRule(ValueOf("a"))).To(Succeed())
-			Expect(trueRequired.ApplyRule(ValueOf(1))).To(Succeed())
+			markerSuccess(falseRequired, "a")
+			markerSuccess(falseRequired, 1)
 		})
 	})
 
@@ -152,30 +152,30 @@ var _ = Describe("Validation Rules Cases", func() {
 		})
 
 		It("rejects object with 3+ fields", func() {
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(MatchError(excl.ValueCheckError()))
+			expectValueError(excl, fakeObj)
 		})
 
 		It("rejects object with 2 fields", func() {
 			fakeObj.Field2 = 0
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(MatchError(excl.ValueCheckError()))
+			expectValueError(excl, fakeObj)
 		})
 
 		It("validates object with 1 field", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field2 = 0
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+			markerSuccess(excl, fakeObj)
 		})
 
 		It("accepts object with 0 fields", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field2 = 0
 			fakeObj.Field3 = 0
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+			markerSuccess(excl, fakeObj)
 		})
 
 		It("accepts object with all fields but first set", func() {
 			fakeObj.Field1 = ""
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+			markerSuccess(excl, fakeObj)
 		})
 	})
 
@@ -205,14 +205,14 @@ var _ = Describe("Validation Rules Cases", func() {
 			linked := LinkedFieldsValue(arr)
 
 			It("is valid with all non-nil fields", func() {
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				markerSuccess(linked, fakeObj)
 			})
 
 			It("is valid if given all nil fields", func() {
 				fakeObj.Field1 = ""
 				fakeObj.Field2 = 0
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				markerSuccess(linked, fakeObj)
 			})
 
 			It("is valid if given all non-nil fields (0-value pointer int is not-nil)", func() {
@@ -220,22 +220,22 @@ var _ = Describe("Validation Rules Cases", func() {
 				var pi *int = &i
 
 				fakeObj.Field3 = pi
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				markerSuccess(linked, fakeObj)
 			})
 
 			It("is invalid if given an empty string value (empty-value string is nil)", func() {
 				fakeObj.Field1 = ""
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+				expectValueError(linked, fakeObj)
 			})
 
 			It("is invalid if given one missing field (zero-int is nil)", func() {
 				fakeObj.Field2 = 0
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+				expectValueError(linked, fakeObj)
 			})
 
 			It("is invalid if given nil pointer (nil pointer is nil)", func() {
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+				expectValueError(linked, fakeObj)
 			})
 		})
 
@@ -244,14 +244,14 @@ var _ = Describe("Validation Rules Cases", func() {
 			linked := LinkedFieldsValue(arr)
 
 			It("is valid with all valid/non-nil fields", func() {
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				markerSuccess(linked, fakeObj)
 			})
 
 			It("is valid if given all nil/invalid fields", func() {
 				fakeObj.Field1 = "b"
 				fakeObj.Field2 = 1
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				markerSuccess(linked, fakeObj)
 			})
 
 			It("is valid if given all non-nil fields (0-value pointer int is not-nil)", func() {
@@ -259,27 +259,27 @@ var _ = Describe("Validation Rules Cases", func() {
 				var pi *int = &i
 
 				fakeObj.Field3 = pi
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				markerSuccess(linked, fakeObj)
 			})
 
 			It("is invalid if given empty string value (empty-value string is nil)", func() {
 				fakeObj.Field1 = ""
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+				expectValueError(linked, fakeObj)
 			})
 
 			It("is invalid if given one missing field (Field2 is 0/nil, expected value was 2)", func() {
 				fakeObj.Field2 = 0
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+				expectValueError(linked, fakeObj)
 			})
 
 			It("is invalid if given one incorrect field (Field2 is 3, expected value was 2)", func() {
 				fakeObj.Field2 = 3
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+				expectValueError(linked, fakeObj)
 			})
 
 			It("is invalid if given nil pointer (empty value for Field3)", func() {
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+				expectValueError(linked, fakeObj)
 			})
 		})
 
@@ -288,7 +288,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			linked := LinkedFieldsValue(arr)
 
 			It("accepts non-empty values for both Field1 and Field2", func() {
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				markerSuccess(linked, fakeObj)
 			})
 
 			Context("with empty string as a valid empty-required value for Field1", func() {
@@ -297,11 +297,11 @@ var _ = Describe("Validation Rules Cases", func() {
 				})
 				It("is valid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 				It("is invalid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+					expectValueError(linked, fakeObj)
 				})
 			})
 
@@ -311,11 +311,11 @@ var _ = Describe("Validation Rules Cases", func() {
 				})
 				It("is valid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 				It("is invalid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+					expectValueError(linked, fakeObj)
 				})
 			})
 		})
@@ -326,7 +326,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			linked := LinkedFieldsValue(arr)
 
 			It("accepts non-empty values for both Field2 and Field3", func() {
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+				markerSuccess(linked, fakeObj)
 			})
 
 			Context("with empty pointer as a valid empty-required value for Field3", func() {
@@ -336,12 +336,12 @@ var _ = Describe("Validation Rules Cases", func() {
 
 				It("is valid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 
 				It("is invalid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+					expectValueError(linked, fakeObj)
 				})
 			})
 
@@ -355,12 +355,12 @@ var _ = Describe("Validation Rules Cases", func() {
 
 				It("is valid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 
 				It("is invalid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+					expectValueError(linked, fakeObj)
 				})
 			})
 		})
@@ -394,22 +394,22 @@ var _ = Describe("Validation Rules Cases", func() {
 
 			Context("with valid trigger value ('Field1=aaa')", func() {
 				It("is valid if all other fields are correct", func() {
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 
 				It("is invalid if one value is nil / missing (nil-value pointer int is nil)", func() {
 					fakeObj.Field3 = nil
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+					expectValueError(linked, fakeObj)
 				})
 
 				It("is invalid if one value is nil / missing (expected value for Field2 is value 12)", func() {
 					fakeObj.Field2 = 0
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+					expectValueError(linked, fakeObj)
 				})
 
 				It("is invalid if one value is incorrect (expected value for Field2 is value 12)", func() {
 					fakeObj.Field2 = 1
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+					expectValueError(linked, fakeObj)
 				})
 
 				It("is valid if other fields are correct (incl. 0-value pointer-int -- it's not-nil)", func() {
@@ -417,7 +417,7 @@ var _ = Describe("Validation Rules Cases", func() {
 					pi := &i
 
 					fakeObj.Field3 = pi
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 			})
 
@@ -427,19 +427,19 @@ var _ = Describe("Validation Rules Cases", func() {
 				})
 
 				It("is valid if all other fields (except the trigger) are correct", func() {
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 
 				It("is valid if all other fields are incorrect", func() {
 					fakeObj.Field2 = 11
 					fakeObj.Field3 = nil
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 
 				It("is valid if all other fields are nil", func() {
 					fakeObj.Field2 = 0
 					fakeObj.Field3 = nil
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 			})
 
@@ -449,19 +449,19 @@ var _ = Describe("Validation Rules Cases", func() {
 				})
 
 				It("is valid if all other fields (except the trigger) are correct", func() {
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 
 				It("is valid if all other fields are incorrect", func() {
 					fakeObj.Field2 = 11
 					fakeObj.Field3 = nil
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 
 				It("is valid if all other fields are nil", func() {
 					fakeObj.Field2 = 0
 					fakeObj.Field3 = nil
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 			})
 		})
@@ -473,17 +473,17 @@ var _ = Describe("Validation Rules Cases", func() {
 
 			Context("with valid trigger value ('Field3=3')", func() {
 				It("is valid if all other fields are correct", func() {
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 
 				It("is invalid if one value is nil / missing(expected value is value 12)", func() {
 					fakeObj.Field2 = 0
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+					expectValueError(linked, fakeObj)
 				})
 
 				It("is invalid if one value is incorrect (expected value is value 12)", func() {
 					fakeObj.Field2 = 1
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+					expectValueError(linked, fakeObj)
 				})
 			})
 
@@ -495,19 +495,19 @@ var _ = Describe("Validation Rules Cases", func() {
 				It("is valid if all other fields (except the trigger) are correct", func() {
 					fakeObj.Field2 = 0
 					fakeObj.Field3 = nil
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 
 				It("is valid if all other fields are incorrect", func() {
 					fakeObj.Field2 = 11
 					fakeObj.Field3 = nil
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 
 				It("is valid if all other fields are nil", func() {
 					fakeObj.Field2 = 0
 					fakeObj.Field3 = nil
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+					markerSuccess(linked, fakeObj)
 				})
 			})
 		})
@@ -521,7 +521,7 @@ var _ = Describe("Validation Rules Cases", func() {
 		}
 
 		arr := []string{"Field1", "Field2", "Field3"}
-		linked := AtLeastOneOf(arr)
+		atLeast := AtLeastOneOf(arr)
 		var fakeObj dummyStruct
 
 		BeforeEach(func() {
@@ -535,7 +535,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			}
 		})
 		It("validates object with all non-nil fields", func() {
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+			markerSuccess(atLeast, fakeObj)
 		})
 
 		It("validates object with all non-nil fields (0-value pointer int is not-nil)", func() {
@@ -543,32 +543,49 @@ var _ = Describe("Validation Rules Cases", func() {
 			var pi *int = &i
 
 			fakeObj.Field3 = pi
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+			markerSuccess(atLeast, fakeObj)
 		})
 
 		It("rejects object with all nil fields", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field2 = 0
 			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
+			expectValueError(atLeast, fakeObj)
 		})
 
 		It("validates object with only 1 value (0-value int is nil, nil-value pointer int is nil)", func() {
 			fakeObj.Field2 = 0
 			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+			markerSuccess(atLeast, fakeObj)
 		})
 
 		It("validates object with only 1 value (empty-value string is nil, 0-value int is nil)", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field2 = 0
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+			markerSuccess(atLeast, fakeObj)
 		})
 
 		It("validates object with only 1 value (empty-value string is nil, nil-value pointer is nil)", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
+			markerSuccess(atLeast, fakeObj)
 		})
 	})
 })
+
+// HELPERS -- reusable logic
+
+// markerSuccess runs given value against the marker and expects no error
+func markerSuccess(marker DDValidationMarker, i any) bool {
+	return Expect(marker.ApplyRule(ValueOf(i))).To(Succeed())
+}
+
+// expectTypeError runs given value against the marker and expects a type check error
+func expectTypeError(marker DDValidationMarker, i any) {
+	Expect(marker.ApplyRule(ValueOf(i))).To(MatchError(marker.TypeCheckError(ValueOf(i))))
+}
+
+// expectTypeError runs given value against the marker and expects a value check error
+func expectValueError(marker DDValidationMarker, i any) {
+	Expect(marker.ApplyRule(ValueOf(i))).To(MatchError(marker.ValueCheckError()))
+}

--- a/ddmark/validation_unit_test.go
+++ b/ddmark/validation_unit_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Validation Rules Cases", func() {
 			Expect(max.ApplyRule(ValueOf(-1001))).To(Succeed())
 		})
 		It("rejects small string values", func() {
-			Expect(max.ApplyRule(ValueOf("0"))).To(MatchError(max.GenTypeCheckError(ValueOf("0"))))
+			Expect(max.ApplyRule(ValueOf("0"))).To(MatchError(max.TypeCheckError(ValueOf("0"))))
 		})
 		It("rejects large string values", func() {
-			Expect(max.ApplyRule(ValueOf("1001"))).To(MatchError(max.GenTypeCheckError(ValueOf("1001"))))
+			Expect(max.ApplyRule(ValueOf("1001"))).To(MatchError(max.TypeCheckError(ValueOf("1001"))))
 		})
 		It("rejects superior values", func() {
-			Expect(max.ApplyRule(ValueOf(maxInt + 1))).To(MatchError(max.GenValueCheckError(maxInt + 1)))
+			Expect(max.ApplyRule(ValueOf(maxInt + 1))).To(MatchError(max.ValueCheckError()))
 		})
 		It("accepts exact value", func() {
 			Expect(max.ApplyRule(ValueOf(maxInt))).To(Succeed())
@@ -54,13 +54,13 @@ var _ = Describe("Validation Rules Cases", func() {
 		})
 
 		It("rejects large negative values", func() {
-			Expect(min.ApplyRule(ValueOf(-1001))).To(MatchError(min.GenValueCheckError(-1001)))
+			Expect(min.ApplyRule(ValueOf(-1001))).To(MatchError(min.ValueCheckError()))
 		})
 		It("rejects small string values", func() {
-			Expect(min.ApplyRule(ValueOf("0"))).To(MatchError(min.GenTypeCheckError(ValueOf("0"))))
+			Expect(min.ApplyRule(ValueOf("0"))).To(MatchError(min.TypeCheckError(ValueOf("0"))))
 		})
 		It("rejects large string values", func() {
-			Expect(min.ApplyRule(ValueOf("1001"))).To(MatchError(min.GenTypeCheckError(ValueOf("1001"))))
+			Expect(min.ApplyRule(ValueOf("1001"))).To(MatchError(min.TypeCheckError(ValueOf("1001"))))
 		})
 		It("accepts superior value", func() {
 			Expect(min.ApplyRule(ValueOf(minInt + 1))).To(Succeed())
@@ -69,7 +69,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			Expect(min.ApplyRule(ValueOf(minInt))).To(Succeed())
 		})
 		It("rejects inferior value", func() {
-			Expect(min.ApplyRule(ValueOf(minInt - 1))).To(MatchError(min.GenValueCheckError(minInt - 1)))
+			Expect(min.ApplyRule(ValueOf(minInt - 1))).To(MatchError(min.ValueCheckError()))
 		})
 	})
 
@@ -84,25 +84,25 @@ var _ = Describe("Validation Rules Cases", func() {
 			Expect(validStrEnum.ApplyRule(ValueOf(arrStr[0]))).To(Succeed())
 		})
 		It("rejects an invalid string value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf("notavalue"))).To(MatchError(validStrEnum.GenValueCheckError(ValueOf("notavalue"))))
+			Expect(validStrEnum.ApplyRule(ValueOf("notavalue"))).To(MatchError(validStrEnum.ValueCheckError()))
 		})
 		It("rejects an invalid int value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf(4))).To(MatchError(validStrEnum.GenTypeCheckError(ValueOf(4))))
+			Expect(validStrEnum.ApplyRule(ValueOf(4))).To(MatchError(validStrEnum.TypeCheckError(ValueOf(4))))
 		})
 		It("rejects a combined str value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf("ab"))).To(MatchError(validStrEnum.GenValueCheckError(ValueOf("ab"))))
+			Expect(validStrEnum.ApplyRule(ValueOf("ab"))).To(MatchError(validStrEnum.ValueCheckError()))
 		})
 		It("accepts a valid int value", func() {
 			Expect(validIntEnum.ApplyRule(ValueOf(arrInt[0]))).To(Succeed())
 		})
 		It("rejects an invalid int value", func() {
-			Expect(validIntEnum.ApplyRule(ValueOf(4))).To(MatchError(validIntEnum.GenValueCheckError(ValueOf(4))))
+			Expect(validIntEnum.ApplyRule(ValueOf(4))).To(MatchError(validIntEnum.ValueCheckError()))
 		})
 		It("int enum rejects a fitting string value", func() {
-			Expect(validIntEnum.ApplyRule(ValueOf("1"))).To(MatchError(validIntEnum.GenValueCheckError(ValueOf("1"))))
+			Expect(validIntEnum.ApplyRule(ValueOf("1"))).To(MatchError(validIntEnum.ValueCheckError()))
 		})
 		It("errors out if enum is empty", func() {
-			Expect(emptyEnum.ApplyRule(ValueOf("any"))).To(MatchError(emptyEnum.GenValueCheckError(ValueOf("any"))))
+			Expect(emptyEnum.ApplyRule(ValueOf("any"))).To(MatchError(emptyEnum.ValueCheckError()))
 		})
 	})
 
@@ -111,13 +111,13 @@ var _ = Describe("Validation Rules Cases", func() {
 		const falseRequired Required = Required(false)
 
 		It("true errors given nil", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(nil))).To(MatchError(trueRequired.GenValueCheckError()))
+			Expect(trueRequired.ApplyRule(ValueOf(nil))).To(MatchError(trueRequired.ValueCheckError()))
 		})
 		It("true errors given empty string", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(""))).To(MatchError(trueRequired.GenValueCheckError()))
+			Expect(trueRequired.ApplyRule(ValueOf(""))).To(MatchError(trueRequired.ValueCheckError()))
 		})
 		It("true errors out given 0", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(0))).To(MatchError(trueRequired.GenValueCheckError()))
+			Expect(trueRequired.ApplyRule(ValueOf(0))).To(MatchError(trueRequired.ValueCheckError()))
 		})
 		It("true accepts regular values", func() {
 			Expect(trueRequired.ApplyRule(ValueOf("a"))).To(Succeed())
@@ -152,12 +152,12 @@ var _ = Describe("Validation Rules Cases", func() {
 		})
 
 		It("rejects object with 3+ fields", func() {
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(MatchError(excl.GenValueCheckError()))
+			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(MatchError(excl.ValueCheckError()))
 		})
 
 		It("rejects object with 2 fields", func() {
 			fakeObj.Field2 = 0
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(MatchError(excl.GenValueCheckError()))
+			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(MatchError(excl.ValueCheckError()))
 		})
 
 		It("validates object with 1 field", func() {
@@ -225,17 +225,17 @@ var _ = Describe("Validation Rules Cases", func() {
 
 			It("is invalid if given an empty string value (empty-value string is nil)", func() {
 				fakeObj.Field1 = ""
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 			})
 
 			It("is invalid if given one missing field (zero-int is nil)", func() {
 				fakeObj.Field2 = 0
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 			})
 
 			It("is invalid if given nil pointer (nil pointer is nil)", func() {
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 			})
 		})
 
@@ -264,22 +264,22 @@ var _ = Describe("Validation Rules Cases", func() {
 
 			It("is invalid if given empty string value (empty-value string is nil)", func() {
 				fakeObj.Field1 = ""
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 			})
 
 			It("is invalid if given one missing field (Field2 is 0/nil, expected value was 2)", func() {
 				fakeObj.Field2 = 0
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 			})
 
 			It("is invalid if given one incorrect field (Field2 is 3, expected value was 2)", func() {
 				fakeObj.Field2 = 3
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 			})
 
 			It("is invalid if given nil pointer (empty value for Field3)", func() {
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 			})
 		})
 
@@ -301,7 +301,7 @@ var _ = Describe("Validation Rules Cases", func() {
 				})
 				It("is invalid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 				})
 			})
 
@@ -315,7 +315,7 @@ var _ = Describe("Validation Rules Cases", func() {
 				})
 				It("is invalid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 				})
 			})
 		})
@@ -341,7 +341,7 @@ var _ = Describe("Validation Rules Cases", func() {
 
 				It("is invalid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 				})
 			})
 
@@ -360,7 +360,7 @@ var _ = Describe("Validation Rules Cases", func() {
 
 				It("is invalid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 				})
 			})
 		})
@@ -399,17 +399,17 @@ var _ = Describe("Validation Rules Cases", func() {
 
 				It("is invalid if one value is nil / missing (nil-value pointer int is nil)", func() {
 					fakeObj.Field3 = nil
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 				})
 
 				It("is invalid if one value is nil / missing (expected value for Field2 is value 12)", func() {
 					fakeObj.Field2 = 0
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 				})
 
 				It("is invalid if one value is incorrect (expected value for Field2 is value 12)", func() {
 					fakeObj.Field2 = 1
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 				})
 
 				It("is valid if other fields are correct (incl. 0-value pointer-int -- it's not-nil)", func() {
@@ -478,12 +478,12 @@ var _ = Describe("Validation Rules Cases", func() {
 
 				It("is invalid if one value is nil / missing(expected value is value 12)", func() {
 					fakeObj.Field2 = 0
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 				})
 
 				It("is invalid if one value is incorrect (expected value is value 12)", func() {
 					fakeObj.Field2 = 1
-					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 				})
 			})
 
@@ -550,7 +550,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field2 = 0
 			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.ValueCheckError()))
 		})
 
 		It("validates object with only 1 value (0-value int is nil, nil-value pointer int is nil)", func() {

--- a/ddmark/validation_unit_test.go
+++ b/ddmark/validation_unit_test.go
@@ -309,19 +309,19 @@ var _ = Describe("Validation Rules Cases", func() {
 				BeforeEach(func() {
 					fakeObj.Field1 = "notempty"
 				})
-				It("is valid if Field2 is not zero", func() {
+				It("is valid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
 					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
-				It("is invalid if Field2 is zero", func() {
+				It("is invalid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
 					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 				})
-
 			})
 		})
 
 		Context("given empty value requirements on pointer field", func() {
+			// we expect that; if Field2 value is 0 then Field3 value is 0
 			arr := []string{"Field2=", "Field3="}
 			linked := LinkedFieldsValue(arr)
 
@@ -397,17 +397,17 @@ var _ = Describe("Validation Rules Cases", func() {
 					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
 
-				It("is invalid if one field is nil / missing (nil-value pointer int is nil)", func() {
+				It("is invalid if one value is nil / missing (nil-value pointer int is nil)", func() {
 					fakeObj.Field3 = nil
 					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 				})
 
-				It("is invalid if one value is nil / missing (expected value is value 12)", func() {
+				It("is invalid if one value is nil / missing (expected value for Field2 is value 12)", func() {
 					fakeObj.Field2 = 0
 					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 				})
 
-				It("is invalid if one value is incorrect (expected value is value 12)", func() {
+				It("is invalid if one value is incorrect (expected value for Field2 is value 12)", func() {
 					fakeObj.Field2 = 1
 					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(MatchError(linked.GenValueCheckError()))
 				})
@@ -427,8 +427,6 @@ var _ = Describe("Validation Rules Cases", func() {
 				})
 
 				It("is valid if all other fields (except the trigger) are correct", func() {
-					fakeObj.Field2 = 0
-					fakeObj.Field3 = nil
 					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
 
@@ -447,12 +445,10 @@ var _ = Describe("Validation Rules Cases", func() {
 
 			Context("with nil trigger value ('Field1 = \"\"')", func() {
 				BeforeEach(func() {
-					fakeObj.Field1 = "bbb"
+					fakeObj.Field1 = ""
 				})
 
 				It("is valid if all other fields (except the trigger) are correct", func() {
-					fakeObj.Field2 = 0
-					fakeObj.Field3 = nil
 					Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
 

--- a/ddmark/validation_unit_test.go
+++ b/ddmark/validation_unit_test.go
@@ -25,22 +25,22 @@ var _ = Describe("Validation Rules Cases", func() {
 		})
 
 		It("accept large negative values", func() {
-			Expect(max.ApplyRule(ValueOf(-1001))).To(BeNil())
+			Expect(max.ApplyRule(ValueOf(-1001))).To(Succeed())
 		})
 		It("rejects small string values", func() {
-			Expect(max.ApplyRule(ValueOf("0"))).ToNot(BeNil())
+			Expect(max.ApplyRule(ValueOf("0"))).ToNot(Succeed())
 		})
 		It("rejects large string values", func() {
-			Expect(max.ApplyRule(ValueOf("1001"))).ToNot(BeNil())
+			Expect(max.ApplyRule(ValueOf("1001"))).ToNot(Succeed())
 		})
 		It("rejects superior values", func() {
-			Expect(max.ApplyRule(ValueOf(maxInt + 1))).ToNot(BeNil())
+			Expect(max.ApplyRule(ValueOf(maxInt + 1))).ToNot(Succeed())
 		})
 		It("accepts exact value", func() {
-			Expect(max.ApplyRule(ValueOf(maxInt))).To(BeNil())
+			Expect(max.ApplyRule(ValueOf(maxInt))).To(Succeed())
 		})
 		It("accepts inferior value", func() {
-			Expect(max.ApplyRule(ValueOf(maxInt - 1))).To(BeNil())
+			Expect(max.ApplyRule(ValueOf(maxInt - 1))).To(Succeed())
 		})
 	})
 
@@ -54,22 +54,22 @@ var _ = Describe("Validation Rules Cases", func() {
 		})
 
 		It("rejects large negative values", func() {
-			Expect(min.ApplyRule(ValueOf(-1001))).ToNot(BeNil())
+			Expect(min.ApplyRule(ValueOf(-1001))).ToNot(Succeed())
 		})
 		It("rejects small string values", func() {
-			Expect(min.ApplyRule(ValueOf("0"))).ToNot(BeNil())
+			Expect(min.ApplyRule(ValueOf("0"))).ToNot(Succeed())
 		})
 		It("rejects large string values", func() {
-			Expect(min.ApplyRule(ValueOf("1001"))).ToNot(BeNil())
+			Expect(min.ApplyRule(ValueOf("1001"))).ToNot(Succeed())
 		})
 		It("accepts superior value", func() {
-			Expect(min.ApplyRule(ValueOf(minInt + 1))).To(BeNil())
+			Expect(min.ApplyRule(ValueOf(minInt + 1))).To(Succeed())
 		})
 		It("accepts exact value", func() {
-			Expect(min.ApplyRule(ValueOf(minInt))).To(BeNil())
+			Expect(min.ApplyRule(ValueOf(minInt))).To(Succeed())
 		})
 		It("rejects inferior value", func() {
-			Expect(min.ApplyRule(ValueOf(minInt - 1))).ToNot(BeNil())
+			Expect(min.ApplyRule(ValueOf(minInt - 1))).ToNot(Succeed())
 		})
 	})
 
@@ -81,28 +81,28 @@ var _ = Describe("Validation Rules Cases", func() {
 		emptyEnum := Enum(nil)
 
 		It("accepts a valid string value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf(arrStr[0]))).To(BeNil())
+			Expect(validStrEnum.ApplyRule(ValueOf(arrStr[0]))).To(Succeed())
 		})
 		It("rejects an invalid string value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf("notavalue"))).ToNot(BeNil())
+			Expect(validStrEnum.ApplyRule(ValueOf("notavalue"))).ToNot(Succeed())
 		})
 		It("rejects an invalid int value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf(4))).ToNot(BeNil())
+			Expect(validStrEnum.ApplyRule(ValueOf(4))).ToNot(Succeed())
 		})
 		It("rejects a combined str value", func() {
-			Expect(validStrEnum.ApplyRule(ValueOf("ab"))).ToNot(BeNil())
+			Expect(validStrEnum.ApplyRule(ValueOf("ab"))).ToNot(Succeed())
 		})
 		It("accepts a valid int value", func() {
-			Expect(validIntEnum.ApplyRule(ValueOf(arrInt[0]))).To(BeNil())
+			Expect(validIntEnum.ApplyRule(ValueOf(arrInt[0]))).To(Succeed())
 		})
 		It("rejects an invalid int value", func() {
-			Expect(validIntEnum.ApplyRule(ValueOf(4))).ToNot(BeNil())
+			Expect(validIntEnum.ApplyRule(ValueOf(4))).ToNot(Succeed())
 		})
 		It("int enum rejects a fitting string value", func() {
-			Expect(validIntEnum.ApplyRule(ValueOf("1"))).ToNot(BeNil())
+			Expect(validIntEnum.ApplyRule(ValueOf("1"))).ToNot(Succeed())
 		})
 		It("errors out if enum is empty", func() {
-			Expect(emptyEnum.ApplyRule(ValueOf("any"))).ToNot(BeNil())
+			Expect(emptyEnum.ApplyRule(ValueOf("any"))).ToNot(Succeed())
 		})
 	})
 
@@ -111,24 +111,24 @@ var _ = Describe("Validation Rules Cases", func() {
 		const falseRequired Required = Required(false)
 
 		It("true errors given nil", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(nil))).ToNot(BeNil())
+			Expect(trueRequired.ApplyRule(ValueOf(nil))).ToNot(Succeed())
 		})
 		It("true errors given empty string", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(""))).ToNot(BeNil())
+			Expect(trueRequired.ApplyRule(ValueOf(""))).ToNot(Succeed())
 		})
 		It("true errors out given 0", func() {
-			Expect(trueRequired.ApplyRule(ValueOf(0))).ToNot(BeNil())
+			Expect(trueRequired.ApplyRule(ValueOf(0))).ToNot(Succeed())
 		})
 		It("true accepts regular values", func() {
-			Expect(trueRequired.ApplyRule(ValueOf("a"))).To(BeNil())
-			Expect(trueRequired.ApplyRule(ValueOf(1))).To(BeNil())
+			Expect(trueRequired.ApplyRule(ValueOf("a"))).To(Succeed())
+			Expect(trueRequired.ApplyRule(ValueOf(1))).To(Succeed())
 		})
 		It("false doesn't error given nil", func() {
-			Expect(falseRequired.ApplyRule(ValueOf(nil))).To(BeNil())
+			Expect(falseRequired.ApplyRule(ValueOf(nil))).To(Succeed())
 		})
 		It("false accepts regular values", func() {
-			Expect(trueRequired.ApplyRule(ValueOf("a"))).To(BeNil())
-			Expect(trueRequired.ApplyRule(ValueOf(1))).To(BeNil())
+			Expect(trueRequired.ApplyRule(ValueOf("a"))).To(Succeed())
+			Expect(trueRequired.ApplyRule(ValueOf(1))).To(Succeed())
 		})
 	})
 
@@ -152,30 +152,30 @@ var _ = Describe("Validation Rules Cases", func() {
 		})
 
 		It("rejects object with 3+ fields", func() {
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+			Expect(excl.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 		})
 
 		It("rejects object with 2 fields", func() {
 			fakeObj.Field2 = 0
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+			Expect(excl.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 		})
 
 		It("validates object with 1 field", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field2 = 0
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 		})
 
 		It("accepts object with 0 fields", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field2 = 0
 			fakeObj.Field3 = 0
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 		})
 
 		It("accepts object with all fields but first set", func() {
 			fakeObj.Field1 = ""
-			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+			Expect(excl.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 		})
 	})
 
@@ -205,14 +205,14 @@ var _ = Describe("Validation Rules Cases", func() {
 			linked := LinkedFieldsValue(arr)
 
 			It("is valid with all non-nil fields", func() {
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 			})
 
 			It("is valid if given all nil fields", func() {
 				fakeObj.Field1 = ""
 				fakeObj.Field2 = 0
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 			})
 
 			It("is valid if given all non-nil fields (0-value pointer int is not-nil)", func() {
@@ -220,22 +220,22 @@ var _ = Describe("Validation Rules Cases", func() {
 				var pi *int = &i
 
 				fakeObj.Field3 = pi
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 			})
 
 			It("is invalid if given an empty string value (empty-value string is nil)", func() {
 				fakeObj.Field1 = ""
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 			})
 
 			It("is invalid if given one missing field (zero-int is nil)", func() {
 				fakeObj.Field2 = 0
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 			})
 
 			It("is invalid if given nil pointer (nil pointer is nil)", func() {
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 			})
 		})
 
@@ -244,14 +244,14 @@ var _ = Describe("Validation Rules Cases", func() {
 			linked := LinkedFieldsValue(arr)
 
 			It("is valid with all valid/non-nil fields", func() {
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 			})
 
 			It("is valid if given all nil/invalid fields", func() {
 				fakeObj.Field1 = "b"
 				fakeObj.Field2 = 1
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 			})
 
 			It("is valid if given all non-nil fields (0-value pointer int is not-nil)", func() {
@@ -259,27 +259,27 @@ var _ = Describe("Validation Rules Cases", func() {
 				var pi *int = &i
 
 				fakeObj.Field3 = pi
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 			})
 
 			It("is invalid if given empty string value (empty-value string is nil)", func() {
 				fakeObj.Field1 = ""
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 			})
 
 			It("is invalid if given one missing field (Field2 is 0/nil, expected value was 2)", func() {
 				fakeObj.Field2 = 0
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 			})
 
 			It("is invalid if given one incorrect field (Field2 is 3, expected value was 2)", func() {
 				fakeObj.Field2 = 3
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 			})
 
 			It("is invalid if given nil pointer (empty value for Field3)", func() {
 				fakeObj.Field3 = nil
-				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+				Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 			})
 		})
 
@@ -288,7 +288,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			emptyLinked := LinkedFieldsValue(arr)
 
 			It("accepts non-empty values for both Field1 and Field2", func() {
-				Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+				Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 			})
 
 			Context("with empty string as a valid empty-required value for Field1", func() {
@@ -297,11 +297,11 @@ var _ = Describe("Validation Rules Cases", func() {
 				})
 				It("is valid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
 				It("is invalid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 				})
 			})
 			Context("with non-empty string as an invalid empty-required value for Field1", func() {
@@ -310,11 +310,11 @@ var _ = Describe("Validation Rules Cases", func() {
 				})
 				It("is valid if Field2 is not zero", func() {
 					fakeObj.Field2 = 1
-					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
 				It("is invalid if Field2 is zero", func() {
 					fakeObj.Field2 = 0
-					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+					Expect(emptyLinked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 				})
 
 			})
@@ -325,7 +325,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			emptyPointerLinked := LinkedFieldsValue(arr)
 
 			It("accepts non-empty values for both Field2 and Field3", func() {
-				Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+				Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 			})
 
 			Context("with empty pointer as a valid empty-required value for Field3", func() {
@@ -335,12 +335,12 @@ var _ = Describe("Validation Rules Cases", func() {
 
 				It("is valid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
 
 				It("is invalid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 				})
 			})
 
@@ -354,12 +354,12 @@ var _ = Describe("Validation Rules Cases", func() {
 
 				It("is valid if Field2 is not 0", func() {
 					fakeObj.Field2 = 1
-					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 				})
 
 				It("is invalid if Field2 is 0", func() {
 					fakeObj.Field2 = 0
-					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+					Expect(emptyPointerLinked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 				})
 			})
 		})
@@ -388,14 +388,14 @@ var _ = Describe("Validation Rules Cases", func() {
 			}
 		})
 		It("validates object with all correct fields", func() {
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 		})
 
 		It("validates object with all nil fields", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field2 = 0
 			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 		})
 
 		It("validates object with correct trigger, correct fields (incl. 0-value pointer-int -- it's not-nil)", func() {
@@ -403,22 +403,22 @@ var _ = Describe("Validation Rules Cases", func() {
 			var pi *int = &i
 
 			fakeObj.Field3 = pi
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 		})
 
 		It("rejects object with nil pointer value (nil-value pointer int is nil)", func() {
 			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 		})
 
 		It("rejects object with one missing value (expected value is value 12)", func() {
 			fakeObj.Field2 = 0
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 		})
 
 		It("rejects object with one incorrect value (expected value is value 12)", func() {
 			fakeObj.Field2 = 1
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 		})
 	})
 
@@ -444,7 +444,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			}
 		})
 		It("validates object with all non-nil fields", func() {
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 		})
 
 		It("validates object with all non-nil fields (0-value pointer int is not-nil)", func() {
@@ -452,32 +452,32 @@ var _ = Describe("Validation Rules Cases", func() {
 			var pi *int = &i
 
 			fakeObj.Field3 = pi
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 		})
 
 		It("rejects object with all nil fields", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field2 = 0
 			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(Succeed())
 		})
 
 		It("validates object with only 1 value (0-value int is nil, nil-value pointer int is nil)", func() {
 			fakeObj.Field2 = 0
 			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 		})
 
 		It("validates object with only 1 value (empty-value string is nil, 0-value int is nil)", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field2 = 0
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 		})
 
 		It("validates object with only 1 value (empty-value string is nil, nil-value pointer is nil)", func() {
 			fakeObj.Field1 = ""
 			fakeObj.Field3 = nil
-			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(BeNil())
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).To(Succeed())
 		})
 	})
 })

--- a/ddmark/validation_unit_test.go
+++ b/ddmark/validation_unit_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Validation Rules Cases", func() {
 			Field3 *int
 		}
 
-		arr := []string{"Field1", "Field2", "Field3"}
+		arr := []string{"Field1=a", "Field2=2", "Field3"}
 		linked := LinkedFieldsValue(arr)
 		var fakeObj dummyStruct
 
@@ -231,6 +231,11 @@ var _ = Describe("Validation Rules Cases", func() {
 
 		It("rejects object with one missing field (0-value int is nil)", func() {
 			fakeObj.Field2 = 0
+			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
+		})
+
+		It("rejects object with one missing field (Field2 is 3, expected value was 2)", func() {
+			fakeObj.Field2 = 3
 			Expect(linked.ApplyRule(ValueOf(fakeObj))).ToNot(BeNil())
 		})
 	})

--- a/ddmark/validation_unit_test.go
+++ b/ddmark/validation_unit_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Validation Rules Cases", func() {
 		})
 	})
 
-	Context("LinkedFields test", func() {
+	Context("LinkedFieldsValue test", func() {
 		type dummyStruct struct {
 			Field1 string
 			Field2 int
@@ -187,7 +187,7 @@ var _ = Describe("Validation Rules Cases", func() {
 		}
 
 		arr := []string{"Field1", "Field2", "Field3"}
-		linked := LinkedFields(arr)
+		linked := LinkedFieldsValue(arr)
 		var fakeObj dummyStruct
 
 		BeforeEach(func() {

--- a/docs/node_disruption.md
+++ b/docs/node_disruption.md
@@ -6,3 +6,12 @@ The `nodeFailure` field triggers a kernel panic on the node. Because the node wi
 * `/proc/sysrq-trigger` > `/mnt/sysrq-trigger`
 
 > :warning:️ Node behavior when using this disruption can differ depending on the cloud provider (node may or may not be replaced, restarted, cordoned, etc.).
+
+## Targeting
+
+For clarity purpose, it is mandatory to explicitely set the disruption's `level` field to either `pod` or `node`.
+
+The `nodeFailure` disruption acts on a node. However, the `level` field needs to be adapted for the selector:
+
+- if `level: node` is set, the selector will target nodes and impact those directly nodes.
+- if `level: pod` is set, the selector will targets pods and impact the nodes that hosts them.

--- a/docs/node_disruption.md
+++ b/docs/node_disruption.md
@@ -9,9 +9,9 @@ The `nodeFailure` field triggers a kernel panic on the node. Because the node wi
 
 ## Targeting
 
-For clarity purpose, it is mandatory to explicitely set the disruption's `level` field to either `pod` or `node`.
+For clarity purpose, it is mandatory to explicitly set the disruption's `level` field to either `pod` or `node`.
 
 The `nodeFailure` disruption acts on a node. However, the `level` field needs to be adapted for the selector:
 
-- if `level: node` is set, the selector will target nodes and impact those directly nodes.
-- if `level: pod` is set, the selector will targets pods and impact the nodes that hosts them.
+- if `level: node` is set, the selector will target nodes and impact those nodes directly.
+- if `level: pod` is set, the selector will targets pods and impact the nodes that host them.

--- a/examples/node_failure.yaml
+++ b/examples/node_failure.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     chaos.datadoghq.com/environment: "lima"
 spec:
+  level: node # impact the whole node instead of a single pod
   selector:
     app: demo-curl
   count: 1

--- a/examples/node_failure.yaml
+++ b/examples/node_failure.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   level: node # selector targets nodes instead of pods. Targeting a pod will impact the node hosting given pod.
   selector:
-    app: demo-curl
+    kubernetes.io/hostname: lima-default
   count: 1
   nodeFailure:
     shutdown: false # trigger a kernel panic on the node

--- a/examples/node_failure.yaml
+++ b/examples/node_failure.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     chaos.datadoghq.com/environment: "lima"
 spec:
-  level: node # impact the whole node instead of a single pod
+  level: node # selector targets nodes instead of pods. Targeting a pod will impact the node hosting given pod.
   selector:
     app: demo-curl
   count: 1

--- a/examples/node_failure_shutdown.yaml
+++ b/examples/node_failure_shutdown.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     chaos.datadoghq.com/environment: "lima"
 spec:
+  level: node # impact the whole node instead of a single pod
   selector:
     app: demo-curl
   count: 1

--- a/examples/node_failure_shutdown.yaml
+++ b/examples/node_failure_shutdown.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   level: node # selector targets nodes instead of pods. Targeting a pod will impact the node hosting given pod.
   selector:
-    app: demo-curl
+    kubernetes.io/hostname: lima-default
   count: 1
   nodeFailure:
     shutdown: true # shutdown the host (violently) instead of triggering a kernel panic so the host is kept down and not restarted

--- a/examples/node_failure_shutdown.yaml
+++ b/examples/node_failure_shutdown.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     chaos.datadoghq.com/environment: "lima"
 spec:
-  level: node # impact the whole node instead of a single pod
+  level: node # selector targets nodes instead of pods. Targeting a pod will impact the node hosting given pod.
   selector:
     app: demo-curl
   count: 1


### PR DESCRIPTION
## What does this PR do?

- [X] Adds new functionality
- [ ] Alters existing functionality
- [X] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The example around `nodeFailure` can seem confusing; it's currently easy to start a nodeFailure disruption defaulting to the pod level, with a node-oriented selector, that will most likely find no target (or worse, undesired targets).
- This PR adds a related DDMark rule allowing to solve that issue, by checking a given struct subfield value as a trigger to expect other subfield presence or specific value. Read `ddmark/README.md` for more details.

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [X] by adding new `unit` tests or `end-to-end` tests.
- [X] I manually tested the following steps:
    - play with `examples/node_failure.yaml`: remove the `nodeFailure` and `level: node` fields and validate with `chaosli` to see the difference. Do not forget to build an update chaosli (`make chaosli`) on the branch, and test with the command`./bin/chaosli/chaosli_darwin_arm64 validate --path examples/node_failure.yaml`
    - [X] locally.
    - [ ] as a canary deployment to a cluster.
