### PR TITLE
Allow for setting pulse.initialDelay independently

### DIFF
--- a/api/disruption_kind.go
+++ b/api/disruption_kind.go
@@ -80,10 +80,10 @@ func AppendArgs(args []string, xargs DisruptionArgs) []string {
 	if xargs.PulseActiveDuration > 0 && xargs.PulseDormantDuration > 0 {
 		args = append(args, "--pulse-active-duration", xargs.PulseActiveDuration.String())
 		args = append(args, "--pulse-dormant-duration", xargs.PulseDormantDuration.String())
+	}
 
-		if xargs.PulseInitialDelay > 0 {
-			args = append(args, "--pulse-initial-delay", xargs.PulseInitialDelay.String())
-		}
+	if xargs.PulseInitialDelay > 0 {
+		args = append(args, "--pulse-initial-delay", xargs.PulseInitialDelay.String())
 	}
 
 	// DNS disruption configs

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -319,12 +319,12 @@ func (s *DisruptionSpec) validateGlobalDisruptionScope() (retErr error) {
 			retErr = multierror.Append(retErr, errors.New("pulse is only compatible with network, cpu pressure, disk pressure, dns and grpc disruptions"))
 		}
 
-		if s.Pulse.ActiveDuration.Duration() < chaostypes.PulsingDisruptionMinimumDuration {
-			retErr = multierror.Append(retErr, fmt.Errorf("pulse activeDuration should be greater than %s", chaostypes.PulsingDisruptionMinimumDuration))
+		if s.Pulse.ActiveDuration.Duration() != 0 && s.Pulse.ActiveDuration.Duration() < chaostypes.PulsingDisruptionMinimumDuration {
+			retErr = multierror.Append(retErr, fmt.Errorf("pulse activeDuration of %s should be greater than %s", s.Pulse.ActiveDuration.Duration(), chaostypes.PulsingDisruptionMinimumDuration))
 		}
 
-		if s.Pulse.DormantDuration.Duration() < chaostypes.PulsingDisruptionMinimumDuration {
-			retErr = multierror.Append(retErr, fmt.Errorf("pulse dormantDuration should be greater than %s", chaostypes.PulsingDisruptionMinimumDuration))
+		if s.Pulse.DormantDuration.Duration() != 0 && s.Pulse.DormantDuration.Duration() < chaostypes.PulsingDisruptionMinimumDuration {
+			retErr = multierror.Append(retErr, fmt.Errorf("pulse dormantDuration of %s should be greater than %s", s.Pulse.DormantDuration.Duration(), chaostypes.PulsingDisruptionMinimumDuration))
 		}
 	}
 

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -315,8 +315,10 @@ func (s *DisruptionSpec) validateGlobalDisruptionScope() (retErr error) {
 
 	// Rule: pulse compatibility
 	if s.Pulse != nil {
-		if s.NodeFailure != nil || s.ContainerFailure != nil {
-			retErr = multierror.Append(retErr, errors.New("pulse is only compatible with network, cpu pressure, disk pressure, dns and grpc disruptions"))
+		if s.Pulse.ActiveDuration.Duration() > 0 || s.Pulse.DormantDuration.Duration() > 0 {
+			if s.NodeFailure != nil || s.ContainerFailure != nil {
+				retErr = multierror.Append(retErr, errors.New("pulse is only compatible with network, cpu pressure, disk pressure, dns and grpc disruptions"))
+			}
 		}
 
 		if s.Pulse.ActiveDuration.Duration() != 0 && s.Pulse.ActiveDuration.Duration() < chaostypes.PulsingDisruptionMinimumDuration {

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -217,6 +217,7 @@ type DisruptionList struct {
 }
 
 // DisruptionPulse contains the active disruption duration and the dormant disruption duration
+// +ddmark:validation:LinkedFields={ActiveDuration,DormantDuration}
 type DisruptionPulse struct {
 	ActiveDuration  DisruptionDuration `json:"activeDuration,omitempty"`
 	DormantDuration DisruptionDuration `json:"dormantDuration,omitempty"`

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -218,8 +218,8 @@ type DisruptionList struct {
 
 // DisruptionPulse contains the active disruption duration and the dormant disruption duration
 type DisruptionPulse struct {
-	ActiveDuration  DisruptionDuration `json:"activeDuration"`
-	DormantDuration DisruptionDuration `json:"dormantDuration"`
+	ActiveDuration  DisruptionDuration `json:"activeDuration,omitempty"`
+	DormantDuration DisruptionDuration `json:"dormantDuration,omitempty"`
 	InitialDelay    DisruptionDuration `json:"initialDelay,omitempty"`
 }
 

--- a/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/crds/chaos.datadoghq.com_disruptions.yaml
@@ -445,9 +445,6 @@ spec:
                     type: string
                   initialDelay:
                     type: string
-                required:
-                - activeDuration
-                - dormantDuration
                 type: object
               reporting:
                 description: Reporting provides additional reporting options in order


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- See https://github.com/DataDog/chaos-controller/pull/658/files
- Allows for specifying `pulse.initialDelay` without specifying either of `pulse.activeDuration` or `pulse.dormantDuration`. Still requires that if either active or dormant are set, that both are set (turns out ddmark does work for what we need here)

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
