### PR TITLE
CHAOS-629: always push images with SHA

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,23 +56,24 @@ build:make:
     - make all docker-build-ebpf
   artifacts:
     paths:
-      - bin/injector/injector_amd64
       - bin/manager/manager_amd64
-      - bin/handler/handler_amd64
-      - bin/injector/injector_arm64
       - bin/manager/manager_arm64
+      - bin/injector/injector_amd64
+      - bin/injector/injector_arm64
+      - bin/handler/handler_amd64
       - bin/handler/handler_arm64
       - bin/injector/ebpf/*
 
 # build the target from the local Dockerfile and push it to the registry
 # replication will depend on the TARGET_LABEL set by parent job
+# we always push images with the exact commit SHA on top of any other TAG based images
 .build-image: &build-image
   <<: *docker-hub-login
   script:
     - docker buildx create --use
-    - docker buildx build --platform linux/amd64,linux/arm64 -t registry.ddbuild.io/${CONTROLLER_IMAGE_NAME}:${TAG} --label target=${TARGET_LABEL} -f bin/manager/Dockerfile ./bin/manager/ --push
-    - docker buildx build --platform linux/amd64,linux/arm64 -t registry.ddbuild.io/${INJECTOR_IMAGE_NAME}:${TAG} --label target=${TARGET_LABEL} -f bin/injector/Dockerfile ./bin/injector/ --push
-    - docker buildx build --platform linux/amd64,linux/arm64 -t registry.ddbuild.io/${HANDLER_IMAGE_NAME}:${TAG} --label target=${TARGET_LABEL} -f bin/handler/Dockerfile ./bin/handler/ --push
+    - docker buildx build --platform linux/amd64,linux/arm64 -t registry.ddbuild.io/${CONTROLLER_IMAGE_NAME}:${TAG} -t registry.ddbuild.io/${CONTROLLER_IMAGE_NAME}:${CI_COMMIT_SHA} --label target=${TARGET_LABEL} -f bin/manager/Dockerfile ./bin/manager/ --push
+    - docker buildx build --platform linux/amd64,linux/arm64 -t registry.ddbuild.io/${INJECTOR_IMAGE_NAME}:${TAG} -t registry.ddbuild.io/${INJECTOR_IMAGE_NAME}:${CI_COMMIT_SHA} --label target=${TARGET_LABEL} -f bin/injector/Dockerfile ./bin/injector/ --push
+    - docker buildx build --platform linux/amd64,linux/arm64 -t registry.ddbuild.io/${HANDLER_IMAGE_NAME}:${TAG} -t registry.ddbuild.io/${HANDLER_IMAGE_NAME}:${CI_COMMIT_SHA} --label target=${TARGET_LABEL} -f bin/handler/Dockerfile ./bin/handler/ --push
   dependencies:
     - build:make
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- This PR aims to adapt the build process to ensure:
  * container images are also pushed with the git SHA (always, no matter which trigger initiated the image build, we want ALSO an image with a full git SHA)

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
