### PR TITLE
[398] Better Validation Logging for Improper Service Targeting Config

### DIFF
--- a/api/v1beta1/validations.go
+++ b/api/v1beta1/validations.go
@@ -29,7 +29,12 @@ func validateServices(k8sClient client.Client, services []NetworkDisruptionServi
 		// try to get the service and throw an error if it does not exist
 		if err := k8sClient.Get(context.Background(), serviceKey, &k8sService); err != nil {
 			if client.IgnoreNotFound(err) == nil {
-				return fmt.Errorf("the service specified in the network disruption (%s/%s) does not exist", service.Namespace, service.Name)
+				if service.Namespace == "" || service.Name == "" {
+					return fmt.Errorf("either service namespace or name have not been properly set for this service: %s/%s -> namespace/name", service.Namespace, service.Name)
+				} else {
+					return fmt.Errorf("the service specified in the network disruption (%s/%s) does not exist", service.Namespace, service.Name)
+				}
+
 			}
 
 			return fmt.Errorf("error retrieving the specified network disruption service: %w", err)


### PR DESCRIPTION
What a mouthful of a title....
## What does this PR do?

- [ ] Adds new functionality
- [X] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
Users will recieve an unclear error log if they improperly format the network service targeting config in a way where either the namespace or the name of the service are "". This PR catches this case and prints a more understandable reason for the error.

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [X] I manually tested the following steps:
    - `x`
    - [X] locally.
    - [ ] as a canary deployment to a cluster.
