### PR TITLE
CI: automatic build for branches ending with `.*-staging`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,13 +192,13 @@ slack-notifier-build.on-failure:
     - /usr/local/bin/notify.sh
 
 slack-notifier-release-staging.on-success:
-  <<: .slack-notifier-release-staging
+  <<: *.slack-notifier-release-staging
   when: on_success
   variables:
     MESSAGE: ':check: | Staging Image Build Complete | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ][ $CI_COMMIT_SHA ]'
 
 slack-notifier-release-staging.on-failure:
-  extends: .slack-notifier-release-staging
+  <<: *.slack-notifier-release-staging
   when: on_failure
   variables:
     MESSAGE: ':siren: | Staging Image Build Failed | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ][ $CI_COMMIT_SHA ] :siren:'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,9 +90,13 @@ build:make:
 
 release-staging-ref:
   <<: *release-staging
-  when: manual
-  except:
-    - tags
+  rules:
+    - if: $CI_COMMIT_TAG
+      when: never
+    - if: $CI_COMMIT_BRANCH =~ /^.*-staging$/
+      when: on_success
+    - when: manual
+      allow_failure: true
   variables:
     TARGET_LABEL: "staging"
     TAG: "${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}"
@@ -177,3 +181,24 @@ slack-notifier-build.on-failure:
   only:
     - main
     - tags
+
+.slack-notifier-release-staging:
+  image: registry.ddbuild.io/slack-notifier:sdm
+  tags: [ "runner:main" ]
+  stage: notify
+  only:
+    - /^.*-staging$/
+  script:
+    - /usr/local/bin/notify.sh
+
+slack-notifier-release-staging.on-success:
+  extends: .slack-notifier-release-staging
+  when: on_success
+  variables:
+    MESSAGE: ':check: | Staging Image Build Complete | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ][ $CI_COMMIT_SHA ]'
+
+slack-notifier-release-staging.on-failure:
+  extends: .slack-notifier-release-staging
+  when: on_failure
+  variables:
+    MESSAGE: ':siren: | Staging Image Build Failed | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ][ $CI_COMMIT_SHA ] :siren:'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,7 +182,7 @@ slack-notifier-build.on-failure:
     - main
     - tags
 
-.slack-notifier-release-staging:
+.slack-notifier-release-staging: &.slack-notifier-release-staging
   image: registry.ddbuild.io/slack-notifier:sdm
   tags: [ "runner:main" ]
   stage: notify
@@ -192,7 +192,7 @@ slack-notifier-build.on-failure:
     - /usr/local/bin/notify.sh
 
 slack-notifier-release-staging.on-success:
-  extends: .slack-notifier-release-staging
+  <<: .slack-notifier-release-staging
   when: on_success
   variables:
     MESSAGE: ':check: | Staging Image Build Complete | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ][ $CI_COMMIT_SHA ]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,7 +182,7 @@ slack-notifier-build.on-failure:
     - main
     - tags
 
-.slack-notifier-release-staging: &.slack-notifier-release-staging
+slack-notifier-release-staging: &slack-notifier-release-staging
   image: registry.ddbuild.io/slack-notifier:sdm
   tags: [ "runner:main" ]
   stage: notify
@@ -192,13 +192,13 @@ slack-notifier-build.on-failure:
     - /usr/local/bin/notify.sh
 
 slack-notifier-release-staging.on-success:
-  <<: *.slack-notifier-release-staging
+  <<: *slack-notifier-release-staging
   when: on_success
   variables:
     MESSAGE: ':check: | Staging Image Build Complete | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ][ $CI_COMMIT_SHA ]'
 
 slack-notifier-release-staging.on-failure:
-  <<: *.slack-notifier-release-staging
+  <<: *slack-notifier-release-staging
   when: on_failure
   variables:
     MESSAGE: ':siren: | Staging Image Build Failed | [ $CI_PROJECT_NAME ][ $CI_COMMIT_REF_NAME ][ $CI_COMMIT_SHA ] :siren:'


### PR DESCRIPTION
## What does this PR do?
- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [X] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
Testing with staging images and clusters is painful for now, having to wait for the build to end, then clicking to get a publish image, etc. that can take up to 15 minutes+. This aims to make it easier with a push-and-forget mechanism.
With this gitlab change:
- for branches that end with `-staging`
- if the build works,, creates a new testing image
- notifies the user through slack at the end of the build

To-discuss:
- commit name regex instead of branch (more flexible, but more work ?)
- notify on all staging build success/failure instead of just the auto-builds (`.*-staging` branches)
- gitlab UI button preferences and possibilities (for gitlab ui experts)

Samples:
Successful `.*-staging` pipeline (green jobs are Build ⇒ Staging Image Build ⇒ Notify Success):
<img width="887" alt="image" src="https://github.com/DataDog/chaos-controller/assets/17198797/353b5124-4910-4be9-b989-4bdd27d641be">
Successful regular pipeline (green job is Build):
![image](https://github.com/DataDog/chaos-controller/assets/17198797/12b72276-ec07-4403-b75f-1f9ee3dbde6d)

Successful Build Notification:
<img width="1037" alt="image" src="https://github.com/DataDog/chaos-controller/assets/17198797/3e486ec0-988b-41b1-a46f-8995f2e296c2">
Failed Build Notification:
<img width="1049" alt="image" src="https://github.com/DataDog/chaos-controller/assets/17198797/304a2317-7161-4c81-bb4b-609984de88fe">

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [X] I manually tested the following steps:
    - just pushing this branch and [nathan/otel-apm-staging](https://gitlab.ddbuild.io/DataDog/chaos-controller/-/commits/nathan/otel-apm-staging). Check gitlab !

