### PR TITLE
Fix: ignore preceding gitlab incomplete job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,7 +182,7 @@ slack-notifier-build.on-failure:
     - main
     - tags
 
-slack-notifier-release-staging: &slack-notifier-release-staging
+.slack-notifier-release-staging: &slack-notifier-release-staging
   image: registry.ddbuild.io/slack-notifier:sdm
   tags: [ "runner:main" ]
   stage: notify


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [X] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Forgot to precede the to-be-extended job with `.`
- Consequently, it consistently ran without the necessary environment variables and consistently errored out
- Still used as an extended job using `<<`

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [X] I manually tested the following steps:
    - running this branch and observing the Gitlab CI
