### PR TITLE
fix: handle typo in resolv.conf filename

### DIFF
--- a/network/dns.go
+++ b/network/dns.go
@@ -40,14 +40,14 @@ func (c dnsClient) Resolve(host string) ([]net.IP, error) {
 	// and other dns configurations
 	podDNSConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
 	if err != nil {
-		return nil, fmt.Errorf("can't read resolve.conf file: %w", err)
+		return nil, fmt.Errorf("can't read resolv.conf file: %w", err)
 	}
 
 	// also read the node resolv conf file to get search domain
 	// and other dns configurations
 	nodeDNSConfig, err := dns.ClientConfigFromFile("/mnt/host/etc/resolv.conf")
 	if err != nil {
-		return nil, fmt.Errorf("can't read resolve.conf file: %w", err)
+		return nil, fmt.Errorf("can't read resolv.conf file: %w", err)
 	}
 
 	// compute resolvers list


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The PR contains a fix for typo found in the `network/dns.go` file. Instead of `resolve.conf` it should be `resolv.conf`.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
