### PR TITLE
CHAOS-664: Use all protocols if unspecified

### DIFF
--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -911,11 +911,6 @@ func (i *networkDisruptionInjector) addFiltersForHosts(interfaces []string, host
 				dstIP = ip
 			}
 
-			// default protocol to tcp if not specified
-			if host.Protocol == "" {
-				host.Protocol = string(network.TCP)
-			}
-
 			// cast connection state
 			connState := network.NewConnState(host.ConnState)
 			for _, protocol := range network.AllProtocols(host.Protocol) {

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -425,8 +425,10 @@ func (i *networkDisruptionInjector) applyOperations() error {
 	if len(i.spec.Hosts) == 0 && len(i.spec.Services) == 0 {
 		_, nullIP, _ := net.ParseCIDR("0.0.0.0/0")
 
-		if _, err := i.config.TrafficController.AddFilter(interfaces, "1:0", "", nil, nullIP, 0, 0, network.TCP, network.ConnStateUndefined, "1:4"); err != nil {
-			return fmt.Errorf("can't add a filter: %w", err)
+		for _, protocol := range network.AllProtocols(network.ALL) {
+			if _, err := i.config.TrafficController.AddFilter(interfaces, "1:0", "", nil, nullIP, 0, 0, protocol, network.ConnStateUndefined, "1:4"); err != nil {
+				return fmt.Errorf("can't add a filter: %w", err)
+			}
 		}
 	} else {
 		// apply filters for given hosts

--- a/network/protocol.go
+++ b/network/protocol.go
@@ -34,7 +34,6 @@ func AllProtocols[C protocolString](p C) []protocol {
 		return []protocol{
 			TCP,
 			UDP,
-			ARP,
 		}
 	}
 

--- a/network/protocol.go
+++ b/network/protocol.go
@@ -17,6 +17,7 @@ const (
 	TCP protocol = "tcp"
 	UDP protocol = "udp"
 	ARP protocol = "arp"
+	ALL protocol = "*"
 )
 
 func (p protocol) String() string {
@@ -27,17 +28,33 @@ type protocolString interface {
 	string | v1.Protocol
 }
 
+func AllProtocols[C protocolString](p C) []protocol {
+	prtcl := newProtocol(p)
+	if prtcl == ALL {
+		return []protocol{
+			TCP,
+			UDP,
+			ARP,
+		}
+	}
+
+	return []protocol{prtcl}
+}
+
 // NewProtocol returns a protocol value based on the given string, possible values are:
-// - tcp: by default if value is not recognised or is tcp
+// - all: by default if value is not recognised
+// - tcp: if provided value is tcp in any case
 // - udp: if provided value is udp in any case
 // - arp: if provided value is arp in any case
-func NewProtocol[C protocolString](protocol C) protocol {
+func newProtocol[C protocolString](protocol C) protocol {
 	switch strings.ToLower(string(protocol)) {
 	case string(UDP):
 		return UDP
 	case string(ARP):
 		return ARP
-	default:
+	case string(TCP):
 		return TCP
+	default:
+		return ALL
 	}
 }

--- a/network/protocol.go
+++ b/network/protocol.go
@@ -25,7 +25,7 @@ func (p protocol) String() string {
 }
 
 type protocolString interface {
-	string | v1.Protocol
+	string | v1.Protocol | protocol
 }
 
 func AllProtocols[C protocolString](p C) []protocol {

--- a/network/tc_test.go
+++ b/network/tc_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Tc", func() {
 		}
 		srcPort = 12345
 		dstPort = 80
-		protocol = NewProtocol("TCP")
+		protocol = newProtocol("TCP")
 		connState = ConnStateNew
 		flowid = "1:2"
 	})

--- a/network/tc_test.go
+++ b/network/tc_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Tc", func() {
 		priomap           [16]uint32
 		srcIP, dstIP      *net.IPNet
 		srcPort, dstPort  int
-		protocol          protocol
+		protoc            protocol
 		connState         connState
 		flowid            string
 	)
@@ -67,7 +67,7 @@ var _ = Describe("Tc", func() {
 		}
 		srcPort = 12345
 		dstPort = 80
-		protocol = newProtocol("TCP")
+		protoc = newProtocol(ALL)
 		connState = ConnStateNew
 		flowid = "1:2"
 	})
@@ -118,8 +118,10 @@ var _ = Describe("Tc", func() {
 
 	Describe("AddFilter", func() {
 		JustBeforeEach(func() {
-			_, err := tcRunner.AddFilter(ifaces, parent, handle, srcIP, dstIP, srcPort, dstPort, protocol, connState, flowid)
-			Expect(err).ShouldNot(HaveOccurred())
+			for _, protocol := range AllProtocols(protoc) {
+				_, err := tcRunner.AddFilter(ifaces, parent, handle, srcIP, dstIP, srcPort, dstPort, protocol, connState, flowid)
+				Expect(err).ShouldNot(HaveOccurred())
+			}
 		})
 
 		Context("add a filter on packets going to IP 10.0.0.1 and port 80 with flowid 1:4 on egress traffic", func() {
@@ -130,6 +132,7 @@ var _ = Describe("Tc", func() {
 
 			It("should execute", func() {
 				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"filter", "add", "dev", "lo", "protocol", "ip", "priority", "1001", "root", "flower", "ip_proto", "tcp", "dst_ip", "10.0.0.1/32", "dst_port", "80", "ct_state", "+trk+new", "flowid", "1:2"})
+				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"filter", "add", "dev", "lo", "protocol", "ip", "priority", "1002", "root", "flower", "ip_proto", "udp", "dst_ip", "10.0.0.1/32", "dst_port", "80", "ct_state", "+trk+new", "flowid", "1:2"})
 			})
 		})
 
@@ -141,12 +144,14 @@ var _ = Describe("Tc", func() {
 
 			It("should execute", func() {
 				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"filter", "add", "dev", "lo", "protocol", "ip", "priority", "1001", "root", "flower", "ip_proto", "tcp", "src_ip", "192.168.0.1/32", "src_port", "12345", "ct_state", "+trk+new", "flowid", "1:2"})
+				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"filter", "add", "dev", "lo", "protocol", "ip", "priority", "1002", "root", "flower", "ip_proto", "udp", "src_ip", "192.168.0.1/32", "src_port", "12345", "ct_state", "+trk+new", "flowid", "1:2"})
 			})
 		})
 
 		Context("add a filter on packets leaving IP 192.168.0.1 port 12345 and going to IP 10.0.0.1 port 80 with flowid 1:4 on egress traffic", func() {
 			It("should execute", func() {
 				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"filter", "add", "dev", "lo", "protocol", "ip", "priority", "1001", "root", "flower", "ip_proto", "tcp", "src_ip", "192.168.0.1/32", "dst_ip", "10.0.0.1/32", "src_port", "12345", "dst_port", "80", "ct_state", "+trk+new", "flowid", "1:2"})
+				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"filter", "add", "dev", "lo", "protocol", "ip", "priority", "1002", "root", "flower", "ip_proto", "udp", "src_ip", "192.168.0.1/32", "dst_ip", "10.0.0.1/32", "src_port", "12345", "dst_port", "80", "ct_state", "+trk+new", "flowid", "1:2"})
 			})
 		})
 	})


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- We used to default to blocking all protocols if the user left it unspecified, now we're always defaulting to tcp
- This behavior change should be reverted, and I've attempted to do so here.
- Do we want to include ARP in this "All", or just tcp + udp?

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
