### PR TITLE
fix: set repo and tag to generated manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Generate install manifest
         run: >
           helm template ./chart/
-          --set defaultImage.repo=datadog --set defaultImage.tag=${GITHUB_REF_NAME}
+          --set global.oci.registry=datadog --set global.chaos.defaultImage.tag=${GITHUB_REF_NAME}
           > ./chart/install.yaml
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- This PR aims to fix the bug introduced while refactoring the chart, fixes https://github.com/DataDog/chaos-controller/issues/728

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.


```bash
helm template ./chart/ --set global.oci.registry=datadog --set global.chaos.defaultImage.tag=7.19.0 
```