### PR TITLE
fix(cpu-pressure): rely on controller provided container name

### DIFF
--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -232,16 +232,16 @@ func initConfig() {
 			return
 		}
 
-		for _, containerID := range disruptionArgs.TargetContainers {
+		for containerName, containerID := range disruptionArgs.TargetContainers {
 			// retrieve container info
-			ctn, err := container.New(containerID)
+			ctn, err := container.New(containerID, containerName)
 			if err != nil {
 				log.Fatalw("can't create container object", "error", err)
 
 				return
 			}
 
-			log.Infow("injector targeting container", "containerID", containerID, "container name", ctn.Name())
+			log.Infow("injector targeting container", "containerID", containerID, "containerName", containerName)
 
 			pid := ctn.PID()
 
@@ -398,7 +398,7 @@ func reinject(cmdName string) error {
 			return fmt.Errorf("container %s is not found (old containerID is %s)", conf.TargetContainer.Name(), conf.TargetContainer.ID())
 		}
 
-		if conf.TargetContainer, err = container.New(newContainerID); err != nil {
+		if conf.TargetContainer, err = container.New(newContainerID, conf.TargetContainer.Name()); err != nil {
 			return fmt.Errorf("unable to create a container from containerID %s: %w", newContainerID, err)
 		}
 

--- a/container/container.go
+++ b/container/container.go
@@ -30,13 +30,13 @@ type container struct {
 }
 
 // New creates a new container object with default config
-func New(id string) (Container, error) {
-	return NewWithConfig(id, Config{})
+func New(id, name string) (Container, error) {
+	return NewWithConfig(id, name, Config{})
 }
 
 // NewWithConfig creates a new container object with the given config
 // nil fields are defaulted
-func NewWithConfig(id string, config Config) (Container, error) {
+func NewWithConfig(id, name string, config Config) (Container, error) {
 	containerID, runtime, err := ParseContainerID(id)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse container ID %s: %w", id, err)
@@ -64,11 +64,6 @@ func NewWithConfig(id string, config Config) (Container, error) {
 	pid, err := config.Runtime.PID(containerID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting PID: %w", err)
-	}
-
-	name, err := config.Runtime.Name(containerID)
-	if err != nil {
-		return nil, fmt.Errorf("error getting container name: %w", err)
 	}
 
 	return container{

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -23,7 +23,6 @@ var _ = Describe("Container", func() {
 		// runtime
 		runtime = NewRuntimeMock(GinkgoT())
 		runtime.EXPECT().PID(mock.Anything).Return(uint32(666), nil)
-		runtime.EXPECT().Name(mock.Anything).Return("", nil)
 
 		// config
 		config = Config{
@@ -33,13 +32,14 @@ var _ = Describe("Container", func() {
 
 	JustBeforeEach(func() {
 		var err error
-		ctn, err = NewWithConfig("containerd://fake", config)
+		ctn, err = NewWithConfig("containerd://fake", "fake-name", config)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Describe("loading a container", func() {
 		It("should return a container object with parsed info", func() {
 			Expect(ctn.ID()).To(Equal("fake"))
+			Expect(ctn.Name()).To(Equal("fake-name"))
 			Expect(ctn.PID()).To(Equal(uint32(666)))
 		})
 	})

--- a/container/containerd.go
+++ b/container/containerd.go
@@ -25,21 +25,6 @@ func newContainerdRuntime() (Runtime, error) {
 	return &containerdRuntime{client: c}, nil
 }
 
-func (c containerdRuntime) Name(id string) (string, error) {
-	// load container structure
-	container, err := c.client.LoadContainer(context.Background(), id)
-	if err != nil {
-		return "", fmt.Errorf("error while loading the given container: %w", err)
-	}
-
-	info, err := container.Info(context.Background())
-	if err != nil {
-		return "", fmt.Errorf("error while info-ing the given container: %w", err)
-	}
-
-	return info.Labels["io.kubernetes.container.name"], nil
-}
-
 func (c containerdRuntime) PID(id string) (uint32, error) {
 	// load container structure
 	container, err := c.client.LoadContainer(context.Background(), id)

--- a/container/docker.go
+++ b/container/docker.go
@@ -27,15 +27,6 @@ func newDockerRuntime() (Runtime, error) {
 	return &dockerRuntime{client: c}, nil
 }
 
-func (d dockerRuntime) Name(id string) (string, error) {
-	ci, err := d.client.ContainerInspect(context.Background(), id)
-	if err != nil {
-		return "", fmt.Errorf("error while loading given container: %w", err)
-	}
-
-	return ci.ContainerJSONBase.Name, nil
-}
-
 func (d dockerRuntime) PID(id string) (uint32, error) {
 	ci, err := d.client.ContainerInspect(context.Background(), id)
 	if err != nil {

--- a/container/runtime.go
+++ b/container/runtime.go
@@ -15,7 +15,6 @@ import (
 type Runtime interface {
 	PID(id string) (uint32, error)
 	HostPath(id, path string) (string, error)
-	Name(id string) (string, error)
 }
 
 // ParseContainerID extract from given id the containerID and runtime

--- a/container/runtime_mock.go
+++ b/container/runtime_mock.go
@@ -74,58 +74,6 @@ func (_c *RuntimeMock_HostPath_Call) RunAndReturn(run func(string, string) (stri
 	return _c
 }
 
-// Name provides a mock function with given fields: id
-func (_m *RuntimeMock) Name(id string) (string, error) {
-	ret := _m.Called(id)
-
-	var r0 string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
-		return rf(id)
-	}
-	if rf, ok := ret.Get(0).(func(string) string); ok {
-		r0 = rf(id)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// RuntimeMock_Name_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Name'
-type RuntimeMock_Name_Call struct {
-	*mock.Call
-}
-
-// Name is a helper method to define mock.On call
-//   - id string
-func (_e *RuntimeMock_Expecter) Name(id interface{}) *RuntimeMock_Name_Call {
-	return &RuntimeMock_Name_Call{Call: _e.mock.On("Name", id)}
-}
-
-func (_c *RuntimeMock_Name_Call) Run(run func(id string)) *RuntimeMock_Name_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *RuntimeMock_Name_Call) Return(_a0 string, _a1 error) *RuntimeMock_Name_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *RuntimeMock_Name_Call) RunAndReturn(run func(string) (string, error)) *RuntimeMock_Name_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // PID provides a mock function with given fields: id
 func (_m *RuntimeMock) PID(id string) (uint32, error) {
 	ret := _m.Called(id)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- This PR aims to fix https://github.com/DataDog/chaos-controller/issues/731 by relying on `chaos-controller` retrieved container names instead of runtime detected ones
  - I do not see any need to rely on the container runtime that is implementation detail IMO
  - What we want is to find the new ID of the same container Name, name we know because it's defined by Kubernetes spec

## Code Quality Checklist

- [ ] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
