### PR TITLE
fix: panic + error handling

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -449,23 +449,23 @@ func (s DisruptionSpec) KindNames() []chaostypes.DisruptionKindName {
 func ReadUnmarshal(path string) (*Disruption, error) {
 	fullPath, err := filepath.Abs(path)
 	if err != nil {
-		return nil, fmt.Errorf("error finding absolute path: %v", err)
+		return nil, fmt.Errorf("error finding absolute path: %w", err)
 	}
 
 	yaml, err := os.Open(filepath.Clean(fullPath))
 	if err != nil {
-		return nil, fmt.Errorf("could not open yaml file at %s: %v", fullPath, err)
+		return nil, fmt.Errorf("could not open yaml file at %s: %w", fullPath, err)
 	}
 
 	yamlBytes, err := io.ReadAll(yaml)
 	if err != nil {
-		return nil, fmt.Errorf("could not read yaml file: %v ", err)
+		return nil, fmt.Errorf("could not read yaml file: %w", err)
 	}
 
 	parsedSpec := Disruption{}
 
 	if err = goyaml.UnmarshalStrict(yamlBytes, &parsedSpec); err != nil {
-		return nil, fmt.Errorf("could not unmarshal yaml file to Disruption: %v", err)
+		return nil, fmt.Errorf("could not unmarshal yaml file to Disruption: %w", err)
 	}
 
 	return &parsedSpec, nil

--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -367,7 +367,7 @@ func NetworkDisruptionHostSpecFromString(hosts []string) ([]NetworkDisruptionHos
 		if len(parsedHost) > 1 && parsedHost[1] != "" {
 			port, err = strconv.Atoi(parsedHost[1])
 			if err != nil {
-				return nil, fmt.Errorf("unexpected port parameter in %s: %v", host, err)
+				return nil, fmt.Errorf("unexpected port parameter in %s: %w", host, err)
 			}
 		}
 

--- a/api/v1beta1/validations.go
+++ b/api/v1beta1/validations.go
@@ -90,7 +90,7 @@ func GetIntOrPercentValueSafely(intOrStr *intstr.IntOrString) (int, bool, error)
 
 		v, err := strconv.Atoi(s)
 		if err != nil {
-			return 0, false, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
+			return 0, false, fmt.Errorf("invalid value %q: %w", intOrStr.StrVal, err)
 		}
 
 		return v, isPercent, nil

--- a/cli/chaosli/cmd/context.go
+++ b/cli/chaosli/cmd/context.go
@@ -182,7 +182,7 @@ func getPods(disruption v1beta1.Disruption) (v1.PodList, error) {
 
 	pods, err := clientset.CoreV1().Pods(disruption.ObjectMeta.Namespace).List(context.TODO(), options)
 	if err != nil {
-		return v1.PodList{}, fmt.Errorf("errored when attempted to get list of pods: %v", err)
+		return v1.PodList{}, fmt.Errorf("errored when attempted to get list of pods: %w", err)
 	}
 
 	return *pods, nil
@@ -195,7 +195,7 @@ func getNodes(disruption v1beta1.Disruption) (v1.NodeList, error) {
 
 	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), options)
 	if err != nil {
-		return v1.NodeList{}, fmt.Errorf("errored when attempted to get list of nodes: %v", err)
+		return v1.NodeList{}, fmt.Errorf("errored when attempted to get list of nodes: %w", err)
 	}
 
 	return *nodes, nil
@@ -384,12 +384,12 @@ func setKubeconfig() error {
 
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
-		return fmt.Errorf("failed to Build the kubeconfiguration: %v", err)
+		return fmt.Errorf("failed to Build the kubeconfiguration: %w", err)
 	}
 
 	clientset, err = kubernetes.NewForConfig(config)
 	if err != nil {
-		return fmt.Errorf("failed to create clientset: %v", err)
+		return fmt.Errorf("failed to create clientset: %w", err)
 	}
 
 	return nil

--- a/cli/chaosli/cmd/validate.go
+++ b/cli/chaosli/cmd/validate.go
@@ -34,7 +34,7 @@ func init() {
 func ValidateDisruption(path string) error {
 	_, err := DisruptionFromFile(path)
 	if err != nil {
-		return fmt.Errorf("error reading from disruption at %v: %v", path, err)
+		return fmt.Errorf("error reading from disruption at %v: %w", path, err)
 	}
 
 	fmt.Println("file is valid !")

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -372,7 +372,7 @@ func inject(kind string, sendToMetrics bool, reinjection bool) bool {
 	}
 
 	if errOnInject {
-		log.Errorf("an injector could not inject the disruption successfully, please look at the logs above for more details")
+		log.Error("an injector could not inject the disruption successfully, please look at the logs above for more details")
 	}
 
 	return !errOnInject
@@ -581,7 +581,7 @@ func injectAndWait(cmd *cobra.Command, args []string) {
 				case <-time.After(sleepDuration):
 					action, err = pulse(&isInjected, &sleepDuration, action, cmd.Name())
 					if err != nil {
-						log.Errorf(err.Error())
+						log.Errorw("an error occurred when calling pulse", "error", err)
 
 						// break of PulsingLoop only
 						break pulsingLoop

--- a/cloudservice/manager.go
+++ b/cloudservice/manager.go
@@ -103,7 +103,7 @@ func (s *CloudServicesProvidersManager) StartPeriodicPull() {
 				}
 			case <-time.After(s.periodicPullInterval):
 				if err := s.PullIPRanges(); err != nil {
-					s.log.Errorf(err.Error())
+					s.log.Errorw("an error occurred when pulling IP ranges", "error", err)
 				}
 			}
 		}

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -33,7 +33,7 @@ func getScaledValueFromIntOrPercent(intOrPercent *intstr.IntOrString, total int,
 
 	value, isPercent, err := chaosv1beta1.GetIntOrPercentValueSafely(intOrPercent)
 	if err != nil {
-		return 0, fmt.Errorf("invalid value for IntOrString: %v", err)
+		return 0, fmt.Errorf("invalid value for IntOrString: %w", err)
 	}
 
 	if isPercent {

--- a/ddmark/ddmark.go
+++ b/ddmark/ddmark.go
@@ -118,7 +118,7 @@ func (c client) ValidateStructMultierror(marshalledStruct interface{}, filePath 
 	pkgs, err = k8sloader.LoadRoots(localStructPkgs...)
 
 	if err != nil {
-		return multierror.Append(retErr, fmt.Errorf("error loading markers from crd validation: \n\t%v", err))
+		return multierror.Append(retErr, fmt.Errorf("error loading markers from crd validation: \n\t%w", err))
 	}
 
 	typesMap := getAllPackageTypes(pkgs, col)

--- a/ddmark/validation.go
+++ b/ddmark/validation.go
@@ -15,8 +15,10 @@ import (
 )
 
 // AllDefinitions contains all marker definitions for this package.
-var AllDefinitions []*k8smarkers.Definition
-var rulePrefix = "ddmark:validation:"
+var (
+	AllDefinitions []*k8smarkers.Definition
+	rulePrefix     = "ddmark:validation:"
+)
 
 func init() {
 	addDefinition(Maximum(0), k8smarkers.DescribesField)
@@ -190,7 +192,7 @@ func (r Required) TypeCheckError(fieldValue reflect.Value) error {
 func (l LinkedFieldsValue) ApplyRule(fieldvalue reflect.Value) error {
 	fieldvalue = reflect.Indirect(fieldvalue)
 
-	var matchCount = 0
+	matchCount := 0
 
 	structMap, ok := structValueToMap(fieldvalue)
 	if !ok {
@@ -227,9 +229,9 @@ func (l LinkedFieldsValue) TypeCheckError(fieldValue reflect.Value) error {
 func (l LinkedFieldsValueWithTrigger) ApplyRule(fieldvalue reflect.Value) error {
 	fieldvalue = reflect.Indirect(fieldvalue)
 
-	var matchCount = 0
+	matchCount := 0
 	// room for logic to possibly expand the marker to accept multiple/combined trigger values (instead of 1)
-	var c = 1
+	c := 1
 
 	if len(l) < 2 {
 		return fmt.Errorf("%s: marker was wrongly defined in struct: less than 2 fields", ruleName(l))
@@ -323,8 +325,8 @@ func Register(reg *k8smarkers.Registry) error {
 // addDefinition creates and adds a definition to the package's AllDefinition object, containing all markers definitions
 func addDefinition(obj DDValidationMarker, targetType k8smarkers.TargetType) {
 	name := rulePrefix + reflect.TypeOf(obj).Name()
-	def, err := k8smarkers.MakeDefinition(name, targetType, obj)
 
+	def, err := k8smarkers.MakeDefinition(name, targetType, obj)
 	if err != nil {
 		panic(err)
 	}

--- a/injector/grpc_disruption.go
+++ b/injector/grpc_disruption.go
@@ -8,6 +8,7 @@ package injector
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -65,8 +66,7 @@ func (i *GRPCDisruptionInjector) Inject() error {
 
 	conn, err := i.connectToServer()
 	if err != nil {
-		i.config.Log.Errorf(err.Error())
-		return err
+		return fmt.Errorf("an error occurred when connecting to server (inject): %w", err)
 	}
 
 	// as long as we managed to dial the server, then we have to assume we're injected
@@ -103,8 +103,7 @@ func (i *GRPCDisruptionInjector) Clean() error {
 
 	conn, err := i.connectToServer()
 	if err != nil {
-		i.config.Log.Errorf(err.Error())
-		return err
+		return fmt.Errorf("an error occurred when connecting to server (clean): %w", err)
 	}
 
 	i.config.Log.Infow("removing grpc disruption", "spec", i.spec)

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -766,36 +766,44 @@ func (i *networkDisruptionInjector) handleKubernetesPodsChanges(event watch.Even
 
 // watchServiceChanges for every changes happening in the kubernetes service destination or in the pods related to the kubernetes service destination, we update the tc service filters
 func (i *networkDisruptionInjector) watchServiceChanges(ctx context.Context, watcher serviceWatcher, interfaces []string, flowid string) {
+	log := i.config.Log.With("serviceNamespace", watcher.watchedServiceSpec.Namespace, "serviceName", watcher.watchedServiceSpec.Name)
+
 	for {
 		// We create the watcher channels when it's closed
 		if watcher.kubernetesServiceWatcher == nil {
+			log := log.With("watcher", "kubernetesServiceWatcher")
+
 			serviceWatcher, err := i.config.K8sClient.CoreV1().Services(watcher.watchedServiceSpec.Namespace).Watch(context.Background(), metav1.ListOptions{
 				ResourceVersion:     watcher.servicesResourceVersion,
 				AllowWatchBookmarks: true,
 			})
 			if err != nil {
-				i.config.Log.Errorf("error watching the changes for the given kubernetes service (%s/%s): %w", watcher.watchedServiceSpec.Namespace, watcher.watchedServiceSpec.Name, err)
+				log.Errorw("error watching the changes for the given kubernetes service", "error", err)
 
 				return
 			}
 
-			i.config.Log.Infow("starting kubernetes service watch", "serviceName", watcher.watchedServiceSpec.Name, "serviceNamespace", watcher.watchedServiceSpec.Namespace)
+			log.Infow("starting kubernetes service watch")
+
 			watcher.kubernetesServiceWatcher = serviceWatcher.ResultChan()
 		}
 
 		if watcher.kubernetesPodEndpointsWatcher == nil {
+			log := log.With("watcher", "kubernetesPodEndpointsWatcher")
+
 			podsWatcher, err := i.config.K8sClient.CoreV1().Pods(watcher.watchedServiceSpec.Namespace).Watch(context.Background(), metav1.ListOptions{
 				LabelSelector:       watcher.labelServiceSelector,
 				ResourceVersion:     watcher.podsResourceVersion,
 				AllowWatchBookmarks: true,
 			})
 			if err != nil {
-				i.config.Log.Errorf("error watching the list of pods for the given kubernetes service (%s/%s): %w", watcher.watchedServiceSpec.Namespace, watcher.watchedServiceSpec.Name, err)
+				log.Errorw("error watching the list of pods for the given kubernetes service", "error", err)
 
 				return
 			}
 
-			i.config.Log.Infow("starting kubernetes pods watch", "serviceName", watcher.watchedServiceSpec.Name, "serviceNamespace", watcher.watchedServiceSpec.Namespace)
+			log.Infow("starting kubernetes pods watch")
+
 			watcher.kubernetesPodEndpointsWatcher = podsWatcher.ResultChan()
 		}
 
@@ -806,13 +814,14 @@ func (i *networkDisruptionInjector) watchServiceChanges(ctx context.Context, wat
 			if !ok { // channel is closed
 				watcher.kubernetesServiceWatcher = nil
 			} else {
-				i.config.Log.Debugw(fmt.Sprintf("changes in service %s/%s", watcher.watchedServiceSpec.Name, watcher.watchedServiceSpec.Namespace), "eventType", event.Type)
+				log := log.With("watcher", "kubernetesServiceWatcher")
+				log.Debugw("changes in service", "eventType", event.Type)
 
 				if err := i.handleKubernetesServiceChanges(event, &watcher, interfaces, flowid); err != nil {
-					i.config.Log.Errorf("couldn't apply changes to tc filters: %w... Rebuilding watcher", err)
+					log.Errorw("couldn't apply changes to tc filters: Rebuilding watcher", "error", err)
 
 					if _, err = i.removeServiceFiltersInList(interfaces, watcher.tcFiltersFromNamespaceServices, watcher.tcFiltersFromNamespaceServices); err != nil {
-						i.config.Log.Errorf("couldn't clean list of tc filters: %w", err)
+						log.Errorw("couldn't clean list of tc filters", "error", err)
 					}
 
 					watcher.kubernetesServiceWatcher = nil // restart the watcher in case of error
@@ -823,13 +832,14 @@ func (i *networkDisruptionInjector) watchServiceChanges(ctx context.Context, wat
 			if !ok { // channel is closed
 				watcher.kubernetesPodEndpointsWatcher = nil
 			} else {
-				i.config.Log.Debugw(fmt.Sprintf("changes in pods of service %s/%s", watcher.watchedServiceSpec.Name, watcher.watchedServiceSpec.Namespace), "eventType", event.Type)
+				log := log.With("watcher", "kubernetesPodEndpointsWatcher")
+				log.Debugw(fmt.Sprintf("changes in pods of service %s/%s", watcher.watchedServiceSpec.Name, watcher.watchedServiceSpec.Namespace), "eventType", event.Type)
 
 				if err := i.handleKubernetesPodsChanges(event, &watcher, interfaces, flowid); err != nil {
-					i.config.Log.Errorf("couldn't apply changes to tc filters: %w... Rebuilding watcher", err)
+					log.Errorw("couldn't apply changes to tc filters: Rebuilding watcher", "error", err)
 
 					if _, err = i.removeServiceFiltersInList(interfaces, watcher.tcFiltersFromPodEndpoints, watcher.tcFiltersFromPodEndpoints); err != nil {
-						i.config.Log.Errorf("couldn't clean list of tc filters: %w", err)
+						log.Errorw("couldn't clean list of tc filters", "error", err)
 					}
 
 					watcher.kubernetesPodEndpointsWatcher = nil // restart the watcher in case of error

--- a/injector/node_failure.go
+++ b/injector/node_failure.go
@@ -96,7 +96,7 @@ func (i *nodeFailureInjector) Inject() error {
 		}
 
 		if err != nil {
-			i.config.Log.Errorf("error while writing to the sysrq trigger file (%s): %v", i.sysrqTriggerPath, err)
+			i.config.Log.Errorw("error while writing to the sysrq trigger file: %v", "sysrqTriggerPath", i.sysrqTriggerPath, "error", err)
 		}
 	}()
 

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func main() {
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	if err = metricsSink.MetricRestart(); err != nil {
-		logger.Errorw("error sending MetricRestart", "sink", metricsSink.GetSinkName(), "err", err)
+		logger.Errorw("error sending MetricRestart", "sink", metricsSink.GetSinkName(), "error", err)
 	}
 
 	// target selector
@@ -160,7 +160,7 @@ func main() {
 	// initialize the cloud provider manager which will handle ip ranges files updates
 	cloudProviderManager, err := cloudservice.New(logger, cfg.Controller.CloudProviders)
 	if err != nil {
-		handleFatalError(fmt.Errorf("error initializing CloudProviderManager: %s", err.Error()))
+		handleFatalError(fmt.Errorf("error initializing CloudProviderManager: %w", err))
 	}
 
 	cloudProviderManager.StartPeriodicPull()

--- a/watchers/watcher.go
+++ b/watchers/watcher.go
@@ -180,7 +180,7 @@ func (w *watcher) Start() error {
 	// start the cache in a goroutine
 	go func() {
 		if err := w.cache.Start(cacheCtx); err != nil {
-			w.config.Log.Errorf("could not start the watcher. Error: %w", err)
+			w.config.Log.Errorw("could not start the watcher", "error", err)
 		}
 	}()
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- This PR aims to improve error handling by:
  - adding a recover into Reconcile to guarantee we keep the logging and metrics reporting accurate even in case of panic
  - align error management to use `%w` in error building to keep stack trace
  - align error logging to use `error` as field and avoir formatting whenever possible

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
