### PR TITLE
APM: add log context to validation webhook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,7 @@ lima-install: manifests
 		--set=controller.version=$(CONTROLLER_APP_VERSION) \
 		--set=controller.metricsSink=$(LIMA_INSTALL_SINK) \
 		--set=controller.profilerSink=$(LIMA_INSTALL_SINK) \
+		--set=controller.tracerSink=$(LIMA_INSTALL_SINK) \
 		--values ./chart/values/$(HELM_VALUES) \
 		./chart | $(KUBECTL) apply -f -
 ifneq (local.yaml,$(HELM_VALUES)) # we can only wait for a controller if it exists, local.yaml does not deploy the controller

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -10,7 +10,8 @@ import (
 	"time"
 
 	"github.com/DataDog/chaos-controller/ddmark"
-	"github.com/DataDog/chaos-controller/o11y/metrics/noop"
+	metricsnoop "github.com/DataDog/chaos-controller/o11y/metrics/noop"
+	tracernoop "github.com/DataDog/chaos-controller/o11y/tracer/noop"
 	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/client-go/tools/record"
@@ -159,6 +160,7 @@ var _ = Describe("Disruption", func() {
 		Describe("general errors expectations", func() {
 			BeforeEach(func() {
 				k8sClient = makek8sClientWithDisruptionPod()
+				tracerSink = tracernoop.New(logger)
 				deleteOnly = false
 			})
 
@@ -273,7 +275,8 @@ var _ = Describe("Disruption", func() {
 				ddmarkMock.EXPECT().ValidateStructMultierror(mock.Anything, mock.Anything).Return(&multierror.Error{})
 				k8sClient = makek8sClientWithDisruptionPod()
 				recorder = record.NewFakeRecorder(1)
-				metricsSink = noop.New(logger)
+				metricsSink = metricsnoop.New(logger)
+				tracerSink = tracernoop.New(logger)
 				deleteOnly = false
 				enableSafemode = true
 			})

--- a/main.go
+++ b/main.go
@@ -235,6 +235,7 @@ func main() {
 		Manager:                       mgr,
 		Logger:                        logger,
 		MetricsSink:                   metricsSink,
+		TracerSink:                    tracerSink,
 		Recorder:                      r.Recorder,
 		NamespaceThresholdFlag:        cfg.Controller.SafeMode.NamespaceThreshold,
 		ClusterThresholdFlag:          cfg.Controller.SafeMode.ClusterThreshold,

--- a/o11y/tracer/datadog/datadog.go
+++ b/o11y/tracer/datadog/datadog.go
@@ -31,7 +31,7 @@ func New() Sink {
 }
 
 // GetLoggableTraceContext returns a Datadog-friendly trace context for logs
-// It allows to connect logs with corresponding traces and spans
+// It allows to connect logs with corresponding traces and spans.
 func (Sink) GetLoggableTraceContext(span trace.Span) []interface{} {
 	stringLogContext := []string{
 		"dd.trace_id", convertTraceID(span.SpanContext().TraceID().String()),

--- a/o11y/tracer/tracer.go
+++ b/o11y/tracer/tracer.go
@@ -19,7 +19,7 @@ import (
 type Sink interface {
 	// GetProvider returns the sink's current tracer provider for otel
 	GetProvider() trace.TracerProvider
-	// GetLoggableTraceContext returns current span context in a log-friendly way
+	// GetLoggableTraceContext returns current span context in a log-friendly way.
 	GetLoggableTraceContext(trace.Span) []interface{}
 	// GetSinkName returns the current sink name
 	GetSinkName() string

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/DataDog/chaos-controller/cloudservice"
 	"github.com/DataDog/chaos-controller/o11y/metrics"
+	"github.com/DataDog/chaos-controller/o11y/tracer"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -42,6 +43,7 @@ type SetupWebhookWithManagerConfig struct {
 	Manager                       ctrl.Manager
 	Logger                        *zap.SugaredLogger
 	MetricsSink                   metrics.Sink
+	TracerSink                    tracer.Sink
 	Recorder                      record.EventRecorder
 	NamespaceThresholdFlag        int
 	ClusterThresholdFlag          int


### PR DESCRIPTION
## What does this PR do?

This PR adds trace context to the validation logs of the chaos-controller.
The validation webhook is systematically ran after the mutating webhooks. This allows us to add tracing context to the validation webhook logs, and retrieve disruption specs with every APM span.

- [ ] Adds new functionality
- [X] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [X] I manually tested the following steps:
    - create a disruption
    - observe the span and trace ids in the logs
    - check datadog !
    - [X] locally.
    - [ ] as a canary deployment to a cluster.
