### PR TITLE
feat(node_failure): increase flush interval

### DIFF
--- a/injector/node_failure.go
+++ b/injector/node_failure.go
@@ -52,7 +52,7 @@ func NewNodeFailureInjector(spec v1beta1.NodeFailureSpec, config NodeFailureInje
 	}
 
 	if config.WaitBeforeShutdown == 0 {
-		config.WaitBeforeShutdown = 10 * time.Second
+		config.WaitBeforeShutdown = 31 * time.Second
 	}
 
 	return &nodeFailureInjector{
@@ -82,7 +82,7 @@ func (i *nodeFailureInjector) Inject() error {
 	}
 
 	// Trigger kernel panic
-	i.config.Log.Infow("the injector will write to the sysrq trigger file in 10s")
+	i.config.Log.Infof("the injector will write to the sysrq trigger file in %v", i.config.WaitBeforeShutdown)
 	i.config.Log.Infow("from this point, if no fatal log occurs, the injection succeeded and the system will crash")
 	_ = i.config.Log.Sync() // If we can't flush the logger, why would logging the error help? so we just ignore
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- This PR aims to increase the log flush interval to try to guarantee at least two "beats" before performing and hard exit

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
