### PR TITLE
CHAOS-727: Fix Watcher warnings and enqueue reconciles when target changes are noticed

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,7 +195,7 @@ func main() {
 
 	r.Controller = cont
 
-	watcherFactory := watchers.NewWatcherFactory(logger, metricsSink, r.Client, r.Recorder)
+	watcherFactory := watchers.NewWatcherFactory(logger, metricsSink, mgr.GetAPIReader(), r.Recorder)
 	r.DisruptionsWatchersManager = watchers.NewDisruptionsWatchersManager(cont, watcherFactory, r.Reader, logger)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/watchers/factory.go
+++ b/watchers/factory.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	k8scache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,11 +60,12 @@ func (f factory) NewChaosPodWatcher(name string, disruption *v1beta1.Disruption,
 
 	// Create a new watcher configuration object
 	watcherConfig := WatcherConfig{
-		Name:         name,
-		Handler:      &handler,
-		ObjectType:   &corev1.Pod{},
-		CacheOptions: cacheOptions,
-		Log:          f.log,
+		Name:           name,
+		Handler:        &handler,
+		ObjectType:     &corev1.Pod{},
+		CacheOptions:   cacheOptions,
+		Log:            f.log,
+		NamespacedName: types.NamespacedName{Name: disruption.GetName(), Namespace: disruption.GetNamespace()},
 	}
 
 	return NewWatcher(watcherConfig, cacheMock, nil)
@@ -89,11 +91,12 @@ func (f factory) NewDisruptionTargetWatcher(name string, enableObserver bool, di
 
 	// Create a new watcher configuration object
 	watcherConfig := WatcherConfig{
-		Name:         name,
-		Handler:      &handler,
-		ObjectType:   &corev1.Pod{},
-		CacheOptions: cacheOptions,
-		Log:          f.log,
+		Name:           name,
+		Handler:        &handler,
+		ObjectType:     &corev1.Pod{},
+		CacheOptions:   cacheOptions,
+		Log:            f.log,
+		NamespacedName: types.NamespacedName{Name: disruption.GetName(), Namespace: disruption.GetNamespace()},
 	}
 
 	return NewWatcher(watcherConfig, cacheMock, nil)

--- a/watchers/suite_test.go
+++ b/watchers/suite_test.go
@@ -6,11 +6,12 @@
 package watchers_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
-	"testing"
+	"go.uber.org/zap/zaptest"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -18,9 +19,7 @@ var logger *zap.SugaredLogger
 
 var _ = BeforeSuite(func() {
 	// Arrange
-	observer, _ := observer.New(zap.InfoLevel)
-	z := zap.New(observer)
-	logger = z.Sugar()
+	logger = zaptest.NewLogger(GinkgoT()).Sugar()
 })
 
 func TestAPIs(t *testing.T) {

--- a/watchers/target_pod.go
+++ b/watchers/target_pod.go
@@ -163,7 +163,7 @@ func (d DisruptionTargetHandler) OnChangeHandleNotifierSink(oldPod, newPod *core
 	}
 }
 
-func (d DisruptionTargetHandler) getEventsFromCurrentDisruption(kind string, objectMeta metav1.ObjectMeta, disruptionStateTime time.Time) ([]corev1.Event, error) {
+func (d DisruptionTargetHandler) getEventsFromCurrentDisruption(kind string, objectMeta metav1.ObjectMeta, disruptionStartTime time.Time) ([]corev1.Event, error) {
 	eventList := &corev1.EventList{}
 	fieldSelector := fields.Set{
 		"involvedObject.kind": kind,
@@ -186,7 +186,7 @@ func (d DisruptionTargetHandler) getEventsFromCurrentDisruption(kind string, obj
 	// Keep events sent during the disruption only, no need to filter events coming from the disruption itself
 	if kind != "Disruption" {
 		for i, event := range eventList.Items {
-			if event.Type == corev1.EventTypeWarning && event.Reason == string(v1beta1.EventDisrupted) || event.LastTimestamp.Time.Before(disruptionStateTime) {
+			if event.Type == corev1.EventTypeWarning && event.Reason == string(v1beta1.EventDisrupted) || event.LastTimestamp.Time.Before(disruptionStartTime) {
 				if i == 0 {
 					return []corev1.Event{}, nil
 				}

--- a/watchers/watcher.go
+++ b/watchers/watcher.go
@@ -54,7 +54,7 @@ type WatcherConfig struct {
 	Name string
 
 	// Namespace of the resource to watch.
-	Namespace types.NamespacedName
+	NamespacedName types.NamespacedName
 
 	// ObjectType of the object to watch.
 	ObjectType client.Object
@@ -115,7 +115,7 @@ func NewWatcher(config WatcherConfig, cacheMock k8scontrollercache.Cache, cacheC
 	// Used by unit test to allow mocking
 	if cacheContextMockFunc != nil {
 		cacheCtx, cacheCancelFunc := cacheContextMockFunc()
-		watcherInstance.ctxTuple = CtxTuple{cacheCancelFunc, cacheCtx, config.Namespace}
+		watcherInstance.ctxTuple = CtxTuple{cacheCancelFunc, cacheCtx, config.NamespacedName}
 	}
 
 	return &watcherInstance, nil
@@ -175,7 +175,7 @@ func (w *watcher) Start() error {
 
 	// create context and cancel function for the watcher
 	cacheCtx, cacheCancelFunc := context.WithCancel(context.Background())
-	w.ctxTuple = CtxTuple{cacheCancelFunc, cacheCtx, w.config.Namespace}
+	w.ctxTuple = CtxTuple{cacheCancelFunc, cacheCtx, w.config.NamespacedName}
 
 	// start the cache in a goroutine
 	go func() {

--- a/watchers/watcher_test.go
+++ b/watchers/watcher_test.go
@@ -8,6 +8,8 @@ package watchers_test
 import (
 	"context"
 	"fmt"
+	"sync"
+
 	"github.com/DataDog/chaos-controller/mocks"
 	"github.com/DataDog/chaos-controller/watchers"
 	. "github.com/onsi/ginkgo/v2"
@@ -19,7 +21,6 @@ import (
 	k8scache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"sync"
 )
 
 type CacheMock struct {
@@ -95,12 +96,12 @@ var _ = Describe("watcher", func() {
 
 	JustBeforeEach(func() {
 		var config = watchers.WatcherConfig{
-			Name:         watcherName,
-			Handler:      handlerMock,
-			ObjectType:   targetObjectType,
-			Namespace:    namespaceName,
-			CacheOptions: k8scache.Options{},
-			Log:          logger,
+			Name:           watcherName,
+			Handler:        handlerMock,
+			ObjectType:     targetObjectType,
+			NamespacedName: namespaceName,
+			CacheOptions:   k8scache.Options{},
+			Log:            logger,
 		}
 
 		watcher, err = watchers.NewWatcher(config, &cacheMock, cacheContextFunc)

--- a/watchers/watcher_test.go
+++ b/watchers/watcher_test.go
@@ -132,6 +132,10 @@ var _ = Describe("watcher", func() {
 				cacheMock.Wg.Add(1)
 				err = watcher.Start()
 				cacheMock.Wg.Wait()
+
+				ctxTuple, _ := watcher.GetContextTuple()
+				Expect(ctxTuple.DisruptionNamespacedName.Name).Should(Equal(namespaceName.Name))
+				Expect(ctxTuple.DisruptionNamespacedName.Namespace).Should(Equal(namespaceName.Namespace))
 			})
 		})
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Closes #744 
- The first commit fixes the log message `"couldn't get the list of events from the target. Might not be able to notify on error changes: non-exact field matches are not supported by the cache"`. The cache reader we were using for the Watchers was not allowed to search with multiple field selectors, and thus was always returning an error. I've switched to using the APIReader. This is a way more expensive client to use on the API server, but afaict, the ONLY place we're using it is to list Events, which should be low enough impact.
- Renames `disruptionStateTime` to `disruptionStartTime`, which is more correct (I think the former was an autocorrect typo)
- Sets watcherConfig.NamespacedName to the instance's NamespacedName. This was previously not being set at all, which is why the controller.Watch in `manager.go#L95` wasn't correctly enqueueing reconciles.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- Tested locally, added a small unit test assertion to confirm we are setting the ctxTuple from the config
