### PR TITLE
Reduce frequency of expired watcher log, and make message less concerning

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,13 +201,13 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
-		ticker := time.NewTicker(time.Minute)
+		ticker := time.NewTicker(time.Minute * 5)
 		defer ticker.Stop()
 
 		for {
 			select {
 			case <-ticker.C:
-				logger.Debugw("Initiate the removal of all expired watchers.")
+				logger.Debugw("Check if we need to remove of any expired watchers...")
 				r.DisruptionsWatchersManager.RemoveAllExpiredWatchers()
 
 			case <-ctx.Done():

--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ func main() {
 		for {
 			select {
 			case <-ticker.C:
-				logger.Debugw("Check if we need to remove of any expired watchers...")
+				logger.Debugw("Check if we need to remove any expired watchers...")
 				r.DisruptionsWatchersManager.RemoveAllExpiredWatchers()
 
 			case <-ctx.Done():


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The log used to imply there were expired watchers, but that typically isn't true. Every minute is also more often than we need

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
