### PR TITLE
CHAOS-751: Allow for - characters in port names

### DIFF
--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -470,21 +470,19 @@ func NetworkDisruptionServiceSpecFromString(services []string) ([]NetworkDisrupt
 
 		for _, unparsedPort := range parsedService[2:] {
 			// <port-value>-<port-name>
-			parsedPort := strings.Split(unparsedPort, "-")
-			if len(parsedPort) != 2 {
+			portValue, portName, ok := strings.Cut(unparsedPort, "-")
+			if !ok {
 				return nil, fmt.Errorf("service port format is expected to follow '<port-value>-<port-name>', unexpected format detected: %s", unparsedPort)
 			}
 
-			port, err := strconv.Atoi(parsedPort[0])
+			port, err := strconv.Atoi(portValue)
 			if err != nil {
 				return nil, fmt.Errorf("port format is expected to be a valid integer, unexpected format detected in service port: %s", unparsedPort)
 			}
 
-			name := parsedPort[1]
-
 			ports = append(ports, NetworkDisruptionServicePortSpec{
 				Port: port,
-				Name: name,
+				Name: portName,
 			})
 		}
 

--- a/examples/demo.yaml
+++ b/examples/demo.yaml
@@ -161,7 +161,7 @@ metadata:
   namespace: chaos-demo
 spec:
   ports:
-    - name: regular
+    - name: regular-port
       port: 8080
       targetPort: 80
       protocol: TCP

--- a/examples/network_filter_service.yaml
+++ b/examples/network_filter_service.yaml
@@ -21,6 +21,6 @@ spec:
       - name: demo # service name
         namespace: chaos-demo # service namespace
         ports: # optional. List of affected ports. No list means all ports are affected
-          - name: regular # optional. Name of the port, used to identify the port affected. You need to specify at least one of each name or port.
+          - name: regular-port # optional. Name of the port, used to identify the port affected. You need to specify at least one of each name or port.
             port: 8080 # optional. Value of the port, used to identify the port affected.
           - port: 8081


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Prevents parsing errors such as 
> service port format is expected to follow '<port-value>-<port-name>', unexpected format detected: 6460-grpc-6460
for ports with names like `grpc-6460` that include valid `-` characters

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
