### PR TITLE
Closes #748: Disruption should have a terminated status when remainin…

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -66,7 +66,7 @@ func disruptionTerminationStatus(instance chaosv1beta1.Disruption, chaosPods []c
 
 	// a definitive state (expired duration or deletion) imply a definitively deleted injection
 	// and should be returned prior to a temporarily terminated state
-	if calculateRemainingDuration(instance) < 0 || !instance.DeletionTimestamp.IsZero() {
+	if calculateRemainingDuration(instance) <= 0 || !instance.DeletionTimestamp.IsZero() {
 		return tsDefinitivelyTerminated
 	}
 


### PR DESCRIPTION
…g duration is 0

## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Full description of the user problem and my attempt at a diagnosis can be found in #748 https://github.com/DataDog/chaos-controller/issues/748#issuecomment-1665992572
- You can see that at https://github.com/DataDog/chaos-controller/blob/89f1a67a2c132ec4fcf74e04f94838a0e368cdd8/controllers/disruption_controller.go#L291 that the Reconcile loop begins terminating a disruption when remainingDuration <= 0. Yet we were only evaluating terminationStatus in `disruptionTerminationStatus` when remainingDuration < 0. This represents a one second window in which we might assign a disruption an inaccurate injectionStatus. By adjusting the function `disruptionTerminationStatus` to match the check in `Reconcile`, we can close that gap.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
