### PR TITLE
Disruption cron docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ spec:
 
 To schedule disruption in your cluster, run `kubectl apply -f <disruption_cron_file>.yaml`. To stop, run `kubectl delete -f <disruption_cron_file>.yaml`.
 
-> :mag_right: For a comprehensive guide and more detailed use cases, delve into the [DisruptionCron guide](docs/disruption_cron.md).
+> :mag_right: Check out [DisruptionCron guide](docs/disruption_cron.md) for more detailed information on how to schedule disruptions.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -47,13 +47,39 @@ spec:
     shutdown: false # do not force the node to be kept down
 ```
 
-To disrupt your cluster, run `kubectl apply -f <disruption_file.yaml>`. You can clean up the disruption with `kubectl delete -f <disruption_file>.yaml`. For your safety, we recommend you get started with the `dry-run` mode enabled.
+To disrupt your cluster, run `kubectl apply -f <disruption_file>.yaml`. You can clean up the disruption with `kubectl delete -f <disruption_file>.yaml`. For your safety, we recommend you get started with the `dry-run` mode enabled.
 
 > :open_book: The [features guide](docs/features.md) details all the features of the Chaos Controller.
 
 > :open_book: The [examples guide](docs/examples.md) contains a list of various disruption files that you can use.
 
 > Check out [Chaosli](./cli/chaosli/README.md) if you want some help understanding/creating disruption configurations.
+
+## Chaos Scheduling
+The Chaos Controller has expanded its capabilities by introducing disruption scheduling, enhancing your ability to automate and test system resilience consistently. Instead of manual creation and deletion, use `DisruptionCron` to regularly disrupt long-lived Kubernetes resources like `Deployments` and `StatefulSets`.
+
+### Example:
+```yaml
+apiVersion: chaos.datadoghq.com/v1beta1
+kind: DisruptionCron
+metadata:
+  name: node-failure
+  namespace: chaos-demo
+spec:
+  schedule: "*/15 * * * *" # every 15 minutes
+  targetResource: 
+    kind: deployment
+    name: demo-curl
+  disruptionTemplate:
+    count: 1 
+    duration: 1h 
+    nodeFailure:
+      shutdown: false
+```
+
+To schedule disruption in your cluster, run `kubectl apply -f <disruption_cron_file>.yaml`. To stop, run `kubectl delete -f <disruption_cron_file>.yaml`.
+
+> :mag_right: For a comprehensive guide and more detailed use cases, delve into the [DisruptionCron guide](docs/disruption_cron.md).
 
 ## Contributing
 

--- a/api/v1beta1/disruption_cron_types.go
+++ b/api/v1beta1/disruption_cron_types.go
@@ -59,7 +59,7 @@ type DisruptionCronSpec struct {
 }
 
 // TargetResource specifies the long-lived resource to be targeted for disruptions.
-// Disruptions are intended to exist semi-permanently, and thus appropriate targets can only be other long-lived resources,
+// DisruptionCrons are intended to exist semi-permanently, and thus appropriate targets can only be other long-lived resources,
 // such as statefulsets or deployment.
 type TargetResourceSpec struct {
 	// +kubebuilder:validation:Enum=deployment;statefulset

--- a/docs/disruption_cron.md
+++ b/docs/disruption_cron.md
@@ -4,7 +4,7 @@
 The `DisruptionCron` is a Custom Resource Definition (CRD) that enables scheduling `Disruptions` against the Kubernetes resources at specified intervals. This tool enhances the process of chaos engineering by providing a means to continually assess a system's resilience against a wide array of potential disruptions, thereby reducing the necessity for manual intervention.
 
 ## Usage
-To schedule a disruption in a cluster, run `kubectl apply -f <disruption_cron_file.yaml>`. To halt the scheduled disruptions, use `kubectl delete -f <disruption_cron_file>.yaml`.
+To schedule a disruption in a cluster, run `kubectl apply -f <disruption_cron_file>.yaml`. To halt the scheduled disruptions, use `kubectl delete -f <disruption_cron_file>.yaml`.
 
 ## Example
 The following DisruptionCron manifest example triggers node failure disruptions every 15 minutes:
@@ -29,15 +29,17 @@ spec:
 ## Writing a DisruptionCron spec
 ### Schedule syntax
 The `.spec.schedule` field is required. The value of that field follows the [Cron](https://en.wikipedia.org/wiki/Cron) syntax:
+```
 # ┌───────────── minute (0 - 59)
 # │ ┌───────────── hour (0 - 23)
 # │ │ ┌───────────── day of the month (1 - 31)
 # │ │ │ ┌───────────── month (1 - 12)
 # │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday;
 # │ │ │ │ │                                   7 is also Sunday on some systems)
-# │ │ │ │ │
+# │ │ │ │ │                                   OR sun, mon, tue, wed, thu, fri, sat
 # │ │ │ │ │
 # * * * * *
+```
 For instance, `0 12 * * 5` states that the task must be started every Friday at noon.
 To generate CronJob schedule expressions, you can also use web tools like [crontab.guru](https://crontab.guru/).
 

--- a/docs/disruption_cron.md
+++ b/docs/disruption_cron.md
@@ -44,11 +44,16 @@ For instance, `0 12 * * 5` states that the task must be started every Friday at 
 To generate CronJob schedule expressions, you can also use web tools like [crontab.guru](https://crontab.guru/).
 
 ### Target resource
-The `spec.targetResource` field specifies which resource to run disruptions against, and is required. Since DisruptionCrons are designed to be semi-permanent, they're best used to target other long-lasting resources. As such, the `.spec.targetResource.kind` field can only be set to either `deployment` or `statefulset`. At runtime, a pod from either of these resources is randomly selected for disruption.
+The `.spec.targetResource` field specifies which resource to run disruptions against, and is required. Since DisruptionCrons are designed to be semi-permanent, they're best used to target other long-lasting resources. As such, the `.spec.targetResource.kind` field can only be set to either `deployment` or `statefulset`. At runtime, a pod from either of these resources is randomly selected for disruption.
 
 ### Disruption template
 The `.spec.disruptionTemplate` defines a template for the Disruptions that the DisruptionCron creates, and it is required.
 Its schema is identical to a `DisruptionSpec` of the `Disruption` CRD. [Detailed examples](examples.md) of various Disruption types, including their respective manifests, are readily available for reference.
+
+## Deadline for delayed job start
+The `.spec.StartingDeadlineSeconds` field is optional. This field defines a deadline (in whole seconds) for starting the Disruption. If a scheduled Disruption misses its start time for any reason and exceeds the deadline, that particular instance of the Disruption is skipped but future occurrences remain scheduled.
+If Disruptions exceed their deadline, they are considered as failed. Without a specified `startingDeadlineSeconds`, Disruptions have no deadline and can start at any delay. If `startingDeadlineSeconds` is defined, any delay exceeding this limit will cause the Disruption to be skipped. 
+For example, a value of 200 allows a Disruption to start up to 200 seconds after the actual schedule.
 
 ## Why use DisruptionCron?
 DisruptionCron facilitates chaos engineering by automating and scheduling chaos experiments. This promotes continual resilience improvement and proactive vulnerability detection, thereby mitigating risks and potential costs associated with unexpected system failures.

--- a/docs/disruption_cron.md
+++ b/docs/disruption_cron.md
@@ -50,7 +50,7 @@ The `.spec.targetResource` field specifies which resource to run disruptions aga
 The `.spec.disruptionTemplate` defines a template for the Disruptions that the DisruptionCron creates, and it is required.
 Its schema is identical to a `DisruptionSpec` of the `Disruption` CRD. [Detailed examples](examples.md) of various Disruption types, including their respective manifests, are readily available for reference.
 
-### Deadline for delayed job start
+### Deadline for delayed disruption start
 The `.spec.StartingDeadlineSeconds` field is optional. This field defines a deadline (in whole seconds) for starting the Disruption. If a scheduled Disruption misses its start time for any reason and exceeds the deadline, that particular instance of the Disruption is skipped but future occurrences remain scheduled.
 If Disruptions exceed their deadline, they are considered as failed. Without a specified `startingDeadlineSeconds`, Disruptions have no deadline and can start at any delay. If `startingDeadlineSeconds` is defined, any delay exceeding this limit will cause the Disruption to be skipped. 
 For example, a value of 200 allows a Disruption to start up to 200 seconds after the actual schedule.

--- a/docs/disruption_cron.md
+++ b/docs/disruption_cron.md
@@ -50,7 +50,7 @@ The `.spec.targetResource` field specifies which resource to run disruptions aga
 The `.spec.disruptionTemplate` defines a template for the Disruptions that the DisruptionCron creates, and it is required.
 Its schema is identical to a `DisruptionSpec` of the `Disruption` CRD. [Detailed examples](examples.md) of various Disruption types, including their respective manifests, are readily available for reference.
 
-## Deadline for delayed job start
+### Deadline for delayed job start
 The `.spec.StartingDeadlineSeconds` field is optional. This field defines a deadline (in whole seconds) for starting the Disruption. If a scheduled Disruption misses its start time for any reason and exceeds the deadline, that particular instance of the Disruption is skipped but future occurrences remain scheduled.
 If Disruptions exceed their deadline, they are considered as failed. Without a specified `startingDeadlineSeconds`, Disruptions have no deadline and can start at any delay. If `startingDeadlineSeconds` is defined, any delay exceeding this limit will cause the Disruption to be skipped. 
 For example, a value of 200 allows a Disruption to start up to 200 seconds after the actual schedule.

--- a/docs/disruption_cron.md
+++ b/docs/disruption_cron.md
@@ -1,0 +1,52 @@
+# DisruptionCron
+
+## Overview
+The `DisruptionCron` is a Custom Resource Definition (CRD) that enables scheduling `Disruptions` against the Kubernetes resources at specified intervals. This tool enhances the process of chaos engineering by providing a means to continually assess a system's resilience against a wide array of potential disruptions, thereby reducing the necessity for manual intervention.
+
+## Usage
+To schedule a disruption in a cluster, run `kubectl apply -f <disruption_cron_file.yaml>`. To halt the scheduled disruptions, use `kubectl delete -f <disruption_cron_file>.yaml`.
+
+## Example
+The following DisruptionCron manifest example triggers node failure disruptions every 15 minutes:
+```yaml
+apiVersion: chaos.datadoghq.com/v1beta1
+kind: DisruptionCron
+metadata:
+  name: node-failure
+  namespace: chaos-demo # it must be in the same namespace as targeted resources
+spec:
+  schedule: "*/15 * * * *" # cron syntax specifying that disruption occurs every 15 minutes
+  targetResource: # a resource to target
+    kind: deployment # a resource name to target
+    name: demo-curl # can be either deployment or statefulset
+  disruptionTemplate:
+    count: 1 # the number of resources to target, can be a percentage
+    duration: 1h # the amount of time before your disruption automatically terminates itself, for safety
+    nodeFailure: # trigger a kernel panic on the target node
+      shutdown: false # do not force the node to be kept down
+```
+
+## Writing a DisruptionCron spec
+### Schedule syntax
+The `.spec.schedule` field is required. The value of that field follows the [Cron](https://en.wikipedia.org/wiki/Cron) syntax:
+# ┌───────────── minute (0 - 59)
+# │ ┌───────────── hour (0 - 23)
+# │ │ ┌───────────── day of the month (1 - 31)
+# │ │ │ ┌───────────── month (1 - 12)
+# │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday;
+# │ │ │ │ │                                   7 is also Sunday on some systems)
+# │ │ │ │ │
+# │ │ │ │ │
+# * * * * *
+For instance, `0 12 * * 5` states that the task must be started every Friday at noon.
+To generate CronJob schedule expressions, you can also use web tools like [crontab.guru](https://crontab.guru/).
+
+### Target resource
+The `spec.targetResource` field specifies which resource to run disruptions against, and is required. Since DisruptionCrons are designed to be semi-permanent, they're best used to target other long-lasting resources. As such, the `.spec.targetResource.kind` field can only be set to either `deployment` or `statefulset`. At runtime, a pod from either of these resources is randomly selected for disruption.
+
+### Disruption template
+The `.spec.disruptionTemplate` defines a template for the Disruptions that the DisruptionCron creates, and it is required.
+Its schema is identical to a `DisruptionSpec` of the `Disruption` CRD. [Detailed examples](examples.md) of various Disruption types, including their respective manifests, are readily available for reference.
+
+## Why use DisruptionCron?
+DisruptionCron facilitates chaos engineering by automating and scheduling chaos experiments. This promotes continual resilience improvement and proactive vulnerability detection, thereby mitigating risks and potential costs associated with unexpected system failures.


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [x] Improves documentation or testing

This PR introduces documentation updates to cover the new DisruptionCron functionality in the Chaos Controller.
