### PR TITLE
CHAOS-571: Check for NXDOMAIN in dns_disruption_resolver.py

### DIFF
--- a/bin/injector/dns_disruption_resolver.py
+++ b/bin/injector/dns_disruption_resolver.py
@@ -639,8 +639,8 @@ class RuleEngine2:
             if result is not None:
                 response_data = result
 
-                # Return Nonefound if the rule says "none"
-                if response_data.lower() == 'none':
+                # Return Nonefound if the rule says "none" or "nxdomain"
+                if response_data.lower() in ('none','nxdomain') :
                     return NONEFOUND(query).make_packet()
 
                 response = CASE[query.type](query, response_data)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Long standing bug where we'd fail when checking for the digits in the IP when a user specified NXDOMAIN for an A record. It turns out the code was checking for "none", and not "NXDOMAIN". I've expanded that check.
- We don't have unit tests for this, it will have to wait until expanded e2e tests are ready. However, I've tested it manually.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
