### PR TITLE
Refactor Shared Logic from DisruptionCron for DisruptionRollout

### DIFF
--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -87,21 +87,10 @@ func GetSelectors(ctx context.Context, cl client.Client, targetResource *chaosv1
 	return labels, nil
 }
 
-// GenerateDisruptionName produces a disruption name based on the specific CR controller, that's invoking it.
-// It returns a formatted string name.
-func GenerateDisruptionName(owner metav1.Object) string {
-	switch typedOwner := owner.(type) {
-	case *chaosv1beta1.DisruptionCron:
-		return fmt.Sprintf("disruption-cron-%s", typedOwner.GetName())
-	}
-
-	return ""
-}
-
 // CreateBaseDisruption generates a basic Disruption object using the provided owner and disruptionSpec.
 // The returned Disruption object has its basic details set, but it's not saved or stored anywhere yet.
 func CreateBaseDisruption(owner metav1.Object, disruptionSpec *chaosv1beta1.DisruptionSpec) *chaosv1beta1.Disruption {
-	name := GenerateDisruptionName(owner)
+	name := fmt.Sprintf("disruption-cron-%s", owner.GetName())
 
 	return &chaosv1beta1.Disruption{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -140,8 +140,10 @@ func OverwriteDisruptionSelectors(ctx context.Context, cl client.Client, disrupt
 // CreateDisruptionFromTemplate constructs a Disruption object based on the provided owner, disruptionSpec, and targetResource.
 // The function sets annotations, overwrites selectors, and associates the Disruption with its owner.
 // It returns the constructed Disruption or an error if any step fails.
-func CreateDisruptionFromTemplate(ctx context.Context, cl client.Client, scheme *runtime.Scheme, owner metav1.Object, targetResource *chaosv1beta1.TargetResourceSpec, disruptionSpec *chaosv1beta1.DisruptionSpec, scheduledTime time.Time) (*chaosv1beta1.Disruption, error) {
+func CreateDisruptionFromTemplate(ctx context.Context, cl client.Client, scheme *runtime.Scheme, owner metav1.Object, targetResource *chaosv1beta1.TargetResourceSpec, disruptionSpec *chaosv1beta1.DisruptionSpec, scheduledTime time.Time, ownerLabel string) (*chaosv1beta1.Disruption, error) {
 	disruption := CreateBaseDisruption(owner, disruptionSpec)
+
+	disruption.Labels[ownerLabel] = owner.GetName()
 
 	SetDisruptionAnnotations(disruption, owner, scheduledTime)
 

--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -6,6 +6,7 @@ import (
 	chaosv1beta1 "github.com/DataDog/chaos-controller/api/v1beta1"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,4 +44,18 @@ func getTargetResource(ctx context.Context, cl client.Client, targetResource *ch
 	}, targetObj)
 
 	return targetObj, err
+}
+
+// checkTargetResourceExists determines if the target resource exists.
+// Returns a boolean indicating presence and an error if one occurs.
+func checkTargetResourceExists(ctx context.Context, cl client.Client, targetResource *chaosv1beta1.TargetResourceSpec, namespace string) (bool, error) {
+	_, err := getTargetResource(ctx, cl, targetResource, namespace)
+
+	if errors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }

--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -6,7 +6,6 @@ import (
 	chaosv1beta1 "github.com/DataDog/chaos-controller/api/v1beta1"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,4 +23,24 @@ func getChildDisruptions(ctx context.Context, cl client.Client, log *zap.Sugared
 	}
 
 	return disruptions, nil
+}
+
+// getTargetResource retrieves the specified target resource (Deployment or StatefulSet).
+// It returns the target resource object and any error encountered during retrieval.
+func getTargetResource(ctx context.Context, cl client.Client, targetResource *chaosv1beta1.TargetResourceSpec, namespace string) (client.Object, error) {
+	var targetObj client.Object
+
+	switch targetResource.Kind {
+	case "deployment":
+		targetObj = &appsv1.Deployment{}
+	case "statefulset":
+		targetObj = &appsv1.StatefulSet{}
+	}
+
+	err := cl.Get(ctx, types.NamespacedName{
+		Name:      targetResource.Name,
+		Namespace: namespace,
+	}, targetObj)
+
+	return targetObj, err
 }

--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -2,14 +2,25 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	chaosv1beta1 "github.com/DataDog/chaos-controller/api/v1beta1"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ScheduledAtAnnotation          = chaosv1beta1.GroupName + "/scheduled-at"
+	DisruptionCronNameLabel        = chaosv1beta1.GroupName + "/disruption-cron-name"
+	TargetResourceMissingThreshold = time.Hour * 24
 )
 
 // getChildDisruptions retrieves disruptions associated with a resource by its label.
@@ -74,4 +85,80 @@ func getSelectors(ctx context.Context, cl client.Client, targetResource *chaosv1
 	}
 
 	return labels, nil
+}
+
+// generateDisruptionName produces a disruption name based on the specific CR controller, that's invoking it.
+// It returns a formatted string name.
+func generateDisruptionName(owner metav1.Object) string {
+	switch typedOwner := owner.(type) {
+	case *chaosv1beta1.DisruptionCron:
+		return fmt.Sprintf("disruption-cron-%s", typedOwner.GetName())
+	}
+
+	return ""
+}
+
+// createBaseDisruption generates a basic Disruption object using the provided owner and disruptionSpec.
+// The returned Disruption object has its basic details set, but it's not saved or stored anywhere yet.
+func createBaseDisruption(owner metav1.Object, disruptionSpec *chaosv1beta1.DisruptionSpec) *chaosv1beta1.Disruption {
+	name := generateDisruptionName(owner)
+
+	return &chaosv1beta1.Disruption{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   owner.GetNamespace(),
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Spec: *disruptionSpec.DeepCopy(),
+	}
+}
+
+// setDisruptionAnnotations updates the annotations of a given Disruption object with those of its owner.
+// Additionally, it sets a scheduled time annotation using the provided scheduledTime.
+func setDisruptionAnnotations(disruption *chaosv1beta1.Disruption, owner metav1.Object, scheduledTime time.Time) {
+	for k, v := range owner.GetAnnotations() {
+		disruption.Annotations[k] = v
+	}
+
+	disruption.Annotations[ScheduledAtAnnotation] = scheduledTime.Format(time.RFC3339)
+}
+
+// overwriteDisruptionSelectors updates the selectors of a given Disruption object based on the provided targetResource.
+// Returns an error if fetching selectors from the target resource fails.
+func overwriteDisruptionSelectors(ctx context.Context, cl client.Client, disruption *chaosv1beta1.Disruption, targetResource *chaosv1beta1.TargetResourceSpec, namespace string) error {
+	// Get selectors from target resource
+	selectors, err := getSelectors(ctx, cl, targetResource, namespace)
+	if err != nil {
+		return err
+	}
+
+	if disruption.Spec.Selector == nil {
+		disruption.Spec.Selector = make(map[string]string)
+	}
+
+	for k, v := range selectors {
+		disruption.Spec.Selector[k] = v
+	}
+
+	return nil
+}
+
+// createDisruptionFromTemplate constructs a Disruption object based on the provided owner, disruptionSpec, and targetResource.
+// The function sets annotations, overwrites selectors, and associates the Disruption with its owner.
+// It returns the constructed Disruption or an error if any step fails.
+func createDisruptionFromTemplate(ctx context.Context, cl client.Client, scheme *runtime.Scheme, owner metav1.Object, targetResource *chaosv1beta1.TargetResource, disruptionSpec *chaosv1beta1.DisruptionSpec, scheduledTime time.Time) (*chaosv1beta1.Disruption, error) {
+	disruption := createBaseDisruption(owner, disruptionSpec)
+
+	setDisruptionAnnotations(disruption, owner, scheduledTime)
+
+	if err := overwriteDisruptionSelectors(ctx, cl, disruption, targetResource, owner.GetNamespace()); err != nil {
+		return nil, err
+	}
+
+	if err := ctrl.SetControllerReference(owner, disruption, scheme); err != nil {
+		return nil, err
+	}
+
+	return disruption, nil
 }

--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -1,3 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
 package controllers
 
 import (

--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -59,3 +59,19 @@ func checkTargetResourceExists(ctx context.Context, cl client.Client, targetReso
 
 	return true, nil
 }
+
+// getSelectors retrieves the labels of the specified target resource (Deployment or StatefulSet).
+// Returns a set of labels to be used as Disruption selectors and an error if retrieval fails.
+func getSelectors(ctx context.Context, cl client.Client, targetResource *chaosv1beta1.TargetResourceSpec, namespace string) (labels.Set, error) {
+	targetObj, err := getTargetResource(ctx, cl, targetResource, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := targetObj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	return labels, nil
+}

--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -91,9 +91,9 @@ func GetSelectors(ctx context.Context, cl client.Client, targetResource *chaosv1
 	return labels, nil
 }
 
-// CreateBaseDisruption generates a basic Disruption object using the provided owner and disruptionSpec.
+// createBaseDisruption generates a basic Disruption object using the provided owner and disruptionSpec.
 // The returned Disruption object has its basic details set, but it's not saved or stored anywhere yet.
-func CreateBaseDisruption(owner metav1.Object, disruptionSpec *chaosv1beta1.DisruptionSpec) *chaosv1beta1.Disruption {
+func createBaseDisruption(owner metav1.Object, disruptionSpec *chaosv1beta1.DisruptionSpec) *chaosv1beta1.Disruption {
 	name := fmt.Sprintf("disruption-cron-%s", owner.GetName())
 
 	return &chaosv1beta1.Disruption{
@@ -107,9 +107,9 @@ func CreateBaseDisruption(owner metav1.Object, disruptionSpec *chaosv1beta1.Disr
 	}
 }
 
-// SetDisruptionAnnotations updates the annotations of a given Disruption object with those of its owner.
+// setDisruptionAnnotations updates the annotations of a given Disruption object with those of its owner.
 // Additionally, it sets a scheduled time annotation using the provided scheduledTime.
-func SetDisruptionAnnotations(disruption *chaosv1beta1.Disruption, owner metav1.Object, scheduledTime time.Time) {
+func setDisruptionAnnotations(disruption *chaosv1beta1.Disruption, owner metav1.Object, scheduledTime time.Time) {
 	for k, v := range owner.GetAnnotations() {
 		disruption.Annotations[k] = v
 	}
@@ -117,9 +117,9 @@ func SetDisruptionAnnotations(disruption *chaosv1beta1.Disruption, owner metav1.
 	disruption.Annotations[ScheduledAtAnnotation] = scheduledTime.Format(time.RFC3339)
 }
 
-// OverwriteDisruptionSelectors updates the selectors of a given Disruption object based on the provided targetResource.
+// overwriteDisruptionSelectors updates the selectors of a given Disruption object based on the provided targetResource.
 // Returns an error if fetching selectors from the target resource fails.
-func OverwriteDisruptionSelectors(ctx context.Context, cl client.Client, disruption *chaosv1beta1.Disruption, targetResource *chaosv1beta1.TargetResourceSpec, namespace string) error {
+func overwriteDisruptionSelectors(ctx context.Context, cl client.Client, disruption *chaosv1beta1.Disruption, targetResource *chaosv1beta1.TargetResourceSpec, namespace string) error {
 	// Get selectors from target resource
 	selectors, err := GetSelectors(ctx, cl, targetResource, namespace)
 	if err != nil {
@@ -141,13 +141,13 @@ func OverwriteDisruptionSelectors(ctx context.Context, cl client.Client, disrupt
 // The function sets annotations, overwrites selectors, and associates the Disruption with its owner.
 // It returns the constructed Disruption or an error if any step fails.
 func CreateDisruptionFromTemplate(ctx context.Context, cl client.Client, scheme *runtime.Scheme, owner metav1.Object, targetResource *chaosv1beta1.TargetResourceSpec, disruptionSpec *chaosv1beta1.DisruptionSpec, scheduledTime time.Time, ownerLabel string) (*chaosv1beta1.Disruption, error) {
-	disruption := CreateBaseDisruption(owner, disruptionSpec)
+	disruption := createBaseDisruption(owner, disruptionSpec)
 
 	disruption.Labels[ownerLabel] = owner.GetName()
 
-	SetDisruptionAnnotations(disruption, owner, scheduledTime)
+	setDisruptionAnnotations(disruption, owner, scheduledTime)
 
-	if err := OverwriteDisruptionSelectors(ctx, cl, disruption, targetResource, owner.GetNamespace()); err != nil {
+	if err := overwriteDisruptionSelectors(ctx, cl, disruption, targetResource, owner.GetNamespace()); err != nil {
 		return nil, err
 	}
 

--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -1,0 +1,27 @@
+package controllers
+
+import (
+	"context"
+
+	chaosv1beta1 "github.com/DataDog/chaos-controller/api/v1beta1"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// getChildDisruptions retrieves disruptions associated with a resource by its label.
+// Most of the time, this will return an empty list as disruptions are typically short-lived objects.
+func getChildDisruptions(ctx context.Context, cl client.Client, log *zap.SugaredLogger, namespace, labelKey, labelVal string) (*chaosv1beta1.DisruptionList, error) {
+	disruptions := &chaosv1beta1.DisruptionList{}
+	labelSelector := labels.SelectorFromSet(labels.Set{labelKey: labelVal})
+
+	if err := cl.List(ctx, disruptions, client.InNamespace(namespace), &client.ListOptions{LabelSelector: labelSelector}); err != nil {
+		log.Errorw("unable to list Disruptions", "err", err)
+		return disruptions, err
+	}
+
+	return disruptions, nil
+}

--- a/controllers/disruption_cron_controller.go
+++ b/controllers/disruption_cron_controller.go
@@ -115,7 +115,7 @@ func (r *DisruptionCronReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	r.log.Infow("processing current run", "currentRun", missedRun.Format(time.UnixDate))
 
 	// Create disruption for current run
-	disruption, err := CreateDisruptionFromTemplate(ctx, r.Client, r.Scheme, instance, &instance.Spec.TargetResource, &instance.Spec.DisruptionTemplate, missedRun)
+	disruption, err := CreateDisruptionFromTemplate(ctx, r.Client, r.Scheme, instance, &instance.Spec.TargetResource, &instance.Spec.DisruptionTemplate, missedRun, DisruptionCronNameLabel)
 	if err != nil {
 		r.log.Warnw("unable to construct disruption from template", "err", err)
 		// Don't requeue until update to the spec is received

--- a/controllers/disruption_cron_controller.go
+++ b/controllers/disruption_cron_controller.go
@@ -66,7 +66,7 @@ func (r *DisruptionCronReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	disruptions, err := r.getChildDisruptions(ctx, instance)
+	disruptions, err := getChildDisruptions(ctx, r.Client, r.log, instance.Namespace, DisruptionCronNameLabel, instance.Name)
 	if err != nil {
 		return ctrl.Result{}, nil
 	}
@@ -154,20 +154,6 @@ func (r *DisruptionCronReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	return scheduledResult, nil
-}
-
-// getChildDisruptions fetches all disruptions associated with the given DisruptionCron instance.
-// Most of the time, this will return an empty list as disruptions are typically short-lived objects.
-func (r *DisruptionCronReconciler) getChildDisruptions(ctx context.Context, instance *chaosv1beta1.DisruptionCron) (*chaosv1beta1.DisruptionList, error) {
-	disruptions := &chaosv1beta1.DisruptionList{}
-	labelSelector := labels.SelectorFromSet(labels.Set{DisruptionCronNameLabel: instance.Name})
-
-	if err := r.Client.List(ctx, disruptions, client.InNamespace(instance.Namespace), &client.ListOptions{LabelSelector: labelSelector}); err != nil {
-		r.log.Errorw("unable to list Disruptions", "err", err)
-		return disruptions, err
-	}
-
-	return disruptions, nil
 }
 
 // updateLastScheduleTime updates the LastScheduleTime in the status of a DisruptionCron instance

--- a/controllers/disruption_cron_controller.go
+++ b/controllers/disruption_cron_controller.go
@@ -56,7 +56,7 @@ func (r *DisruptionCronReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	disruptions, err := getChildDisruptions(ctx, r.Client, r.log, instance.Namespace, DisruptionCronNameLabel, instance.Name)
+	disruptions, err := GetChildDisruptions(ctx, r.Client, r.log, instance.Namespace, DisruptionCronNameLabel, instance.Name)
 	if err != nil {
 		return ctrl.Result{}, nil
 	}
@@ -115,7 +115,7 @@ func (r *DisruptionCronReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	r.log.Infow("processing current run", "currentRun", missedRun.Format(time.UnixDate))
 
 	// Create disruption for current run
-	disruption, err := createDisruptionFromTemplate(ctx, r.Client, r.Scheme, instance, instance.Spec.TargetResource, &instance.Spec.DisruptionTemplate, missedRun)
+	disruption, err := CreateDisruptionFromTemplate(ctx, r.Client, r.Scheme, instance, &instance.Spec.TargetResource, &instance.Spec.DisruptionTemplate, missedRun)
 	if err != nil {
 		r.log.Warnw("unable to construct disruption from template", "err", err)
 		// Don't requeue until update to the spec is received
@@ -203,7 +203,7 @@ func (r *DisruptionCronReconciler) getScheduledTimeForDisruption(disruption *cha
 // - error: Represents any error that occurred during the execution of the function.
 func (r *DisruptionCronReconciler) updateTargetResourcePreviouslyMissing(ctx context.Context, instance *chaosv1beta1.DisruptionCron) (bool, bool, error) {
 	disruptionCronDeleted := false
-	targetResourceExists, err := checkTargetResourceExists(ctx, r.Client, &instance.Spec.TargetResource, instance.Namespace)
+	targetResourceExists, err := CheckTargetResourceExists(ctx, r.Client, &instance.Spec.TargetResource, instance.Namespace)
 
 	if err != nil {
 		return targetResourceExists, disruptionCronDeleted, err


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing
- [x] Refactors code

This PR refactors the shared logic from the `DisruptionCron` codebase to be reusable with the new `DisruptionRollout` custom resource definition (CRD). The shared logic has been abstracted and modified to integrate with the `DisruptionRollout`.

For more context, please refer to the linked [PR](https://github.com/DataDog/chaos-controller/tree/diyarab/disruption_rollout) for `DisruptionRollout`.

## Code Quality Checklist

- [x] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
