### PR TITLE
Use targeted resource pod template spec labels instead of targeted resource labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -528,8 +528,8 @@ ifeq (,$(EXISTING_NAMESPACE))
 	helm install -n datadog-agent my-datadog-operator datadoghq/datadog-operator
 	$(KUBECTL) create secret -n datadog-agent generic datadog-secret --from-literal api-key=${STAGING_DATADOG_API_KEY} --from-literal app-key=${STAGING_DATADOG_APP_KEY}
 endif
-endif
 	$(KUBECTL) apply -f - < examples/datadog-agent.yaml
+endif
 
 open-dd:
 ifeq (true,$(INSTALL_DATADOG_AGENT))


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- It uses the targeted resource pod template labels instead of its own labels as they might not be the same
- It also fixes a small nit in the makefile for dev env

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - I created a deployment with different labels than the pod it handles
    - I created a cron disruption and ensured it was targeting the pod properly
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
