### PR TITLE
Handle empty InjectionStatus on terminate correctly

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -365,13 +365,13 @@ func (r *DisruptionReconciler) updateInjectionStatus(instance *chaosv1beta1.Disr
 	}
 
 	status := instance.Status.InjectionStatus
-	if status == "" {
+	if status == chaostypes.DisruptionInjectionStatusInitial {
 		status = chaostypes.DisruptionInjectionStatusNotInjected
 	}
 
 	terminationStatus := disruptionTerminationStatus(*instance, chaosPods)
 	if terminationStatus != tsNotTerminated {
-		switch instance.Status.InjectionStatus {
+		switch status {
 		case
 			chaostypes.DisruptionInjectionStatusInjected,
 			chaostypes.DisruptionInjectionStatusPausedInjected,
@@ -397,7 +397,7 @@ func (r *DisruptionReconciler) updateInjectionStatus(instance *chaosv1beta1.Disr
 				status = chaostypes.DisruptionInjectionStatusPreviouslyNotInjected
 			}
 		default:
-			return fmt.Errorf("unable to transition from disruption injection status %s, unknown injection status, termination status is %d", instance.Status.InjectionStatus, terminationStatus)
+			return fmt.Errorf("unable to transition from disruption injection status %s, unknown injection status, termination status is %d", status, terminationStatus)
 		}
 	} else if len(chaosPods) > 0 {
 		// consider the disruption "partially injected" if we found at least one pod


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Whenever injectionStatus was unset, we were trying to handle it at L369 by changing `status` to NotInjected. However, we immediately enter a switch statement that checks the original `instance.Status.InjectionStatus` instead of the fixed `status`.  I've updated the switch statement to avoid that situation

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
