### PR TITLE
Move duration skip check from generatePod to createChaosPods

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -563,6 +563,12 @@ func (r *DisruptionReconciler) createChaosPods(instance *chaosv1beta1.Disruption
 		return nil
 	}
 
+	if calculateRemainingDuration(*instance).Seconds() < 1 {
+		r.log.Debugw("skipping creation of chaos pods, remaining duration is too small", "remainingDuration", calculateRemainingDuration(*instance).String())
+
+		return nil
+	}
+
 	// create injection pods
 	for _, targetChaosPod := range targetChaosPods {
 		// check if an injection pod already exists for the given (instance, namespace, disruption kind) tuple
@@ -999,7 +1005,7 @@ func (r *DisruptionReconciler) getChaosPods(instance *chaosv1beta1.Disruption, l
 
 // generatePod generates a pod from a generic pod template in the same namespace
 // and on the same node as the given pod
-func (r *DisruptionReconciler) generatePod(instance *chaosv1beta1.Disruption, targetName string, targetNodeName string, args []string, kind chaostypes.DisruptionKindName) (pod corev1.Pod, shouldCreatePod bool) {
+func (r *DisruptionReconciler) generatePod(instance *chaosv1beta1.Disruption, targetName string, targetNodeName string, args []string, kind chaostypes.DisruptionKindName) (pod corev1.Pod) {
 	// volume host path type definitions
 	hostPathDirectory := corev1.HostPathDirectory
 	hostPathFile := corev1.HostPathFile
@@ -1013,10 +1019,6 @@ func (r *DisruptionReconciler) generatePod(instance *chaosv1beta1.Disruption, ta
 	activeDeadlineSeconds := int64(calculateRemainingDuration(*instance).Seconds()) + 10
 	args = append(args,
 		"--deadline", time.Now().Add(calculateRemainingDuration(*instance)).Format(time.RFC3339))
-
-	if activeDeadlineSeconds < 1 {
-		return pod, false
-	}
 
 	podSpec := corev1.PodSpec{
 		HostPID:                       true,                      // enable host pid
@@ -1214,7 +1216,7 @@ func (r *DisruptionReconciler) generatePod(instance *chaosv1beta1.Disruption, ta
 	// add finalizer to the pod so it is not deleted before we can control its exit status
 	controllerutil.AddFinalizer(&pod, chaostypes.ChaosPodFinalizer)
 
-	return pod, true
+	return pod
 }
 
 // handleMetricSinkError logs the given metric sink error if it is not nil
@@ -1323,10 +1325,8 @@ func (r *DisruptionReconciler) generateChaosPods(instance *chaosv1beta1.Disrupti
 		args := xargs.CreateCmdArgs(subspec.GenerateArgs())
 
 		// append pod to chaos pods
-		pod, shouldCreatePod := r.generatePod(instance, targetName, targetNodeName, args, kind)
-		if shouldCreatePod {
-			pods = append(pods, pod)
-		}
+		pod := r.generatePod(instance, targetName, targetNodeName, args, kind)
+		pods = append(pods, pod)
 	}
 
 	return pods, nil


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- We were having an issue where we were recording the event EmptyDisruption on disruptions near expiration. The reason for this is that we check for remaining duration in `generatePod` and then possibly skip as appropriate. When we end up returning an empty list of pods to create to createChaosPods, we think we have an invalid disruption and record this warning event. It makes more sense for generatePod to always generate the correct pod spec, and for createChaosPods to possibly skip the actual creation depending on the remaining duration

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
