### PR TITLE
Inject iptables cgroup marking rules in postrouting instead of output

### DIFF
--- a/docs/dns_disruption.md
+++ b/docs/dns_disruption.md
@@ -57,8 +57,8 @@ kubectl get -ojson pod demo-curl-547bb9c686-57484 | jq '.status.containerStatuse
 
 ```
 # iptables-save | grep -- '-j CHAOS-DNS'
--A OUTPUT -p udp -m cgroup --cgroup 1048592 -m udp --dport 53 -j CHAOS-DNS
-# iptables -t nat -D OUTPUT -p udp -m cgroup --cgroup 1048592 -m udp --dport 53 -j CHAOS-DNS
+-A POSTROUTING -p udp -m cgroup --cgroup 1048592 -m udp --dport 53 -j CHAOS-DNS
+# iptables -t nat -D POSTROUTING -p udp -m cgroup --cgroup 1048592 -m udp --dport 53 -j CHAOS-DNS
 ```
 
 * Remove iptables `CHAOS-DNS` chain

--- a/docs/network_disruption.md
+++ b/docs/network_disruption.md
@@ -116,5 +116,5 @@ qdisc noqueue 0: dev eth0 root refcnt 2
 **Clean iptables rules**
 
 ```
-iptables -t mangle -D OUTPUT -m cgroup --path /kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460 -j MARK --set-mark 131074
+iptables -t mangle -D POSTROUTING -m cgroup --path /kubepods/burstable/poda37541dc-4905-4a7f-98c0-7d13f58df0eb/cb33d4ce77f7396851196043a56e625f38429720cd5d3153cb061feae6038460 -j MARK --set-mark 131074
 ```

--- a/network/iptables.go
+++ b/network/iptables.go
@@ -156,12 +156,12 @@ func (i *iptables) Intercept(protocol string, port string, cgroupPath string, cg
 
 // MarkCgroupPath marks the packets created from the given cgroup path with the given mark
 func (i *iptables) MarkCgroupPath(cgroupPath string, mark string) error {
-	return i.insert("mangle", "OUTPUT", "-m", "cgroup", "--path", cgroupPath, "-j", "MARK", "--set-mark", mark)
+	return i.insert("mangle", "POSTROUTING", "-m", "cgroup", "--path", cgroupPath, "-j", "MARK", "--set-mark", mark)
 }
 
 // MarkClassID marks the packets created with the given classid with the given mark
 func (i *iptables) MarkClassID(classID string, mark string) error {
-	return i.insert("mangle", "OUTPUT", "-m", "cgroup", "--cgroup", classID, "-j", "MARK", "--set-mark", mark)
+	return i.insert("mangle", "POSTROUTING", "-m", "cgroup", "--cgroup", classID, "-j", "MARK", "--set-mark", mark)
 }
 
 // insert creates a new iptables rule definition, stores it


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- it injects marking iptables rules in the `POSTROUTING` chain of the `mangle` table instead of the `OUTPUT` chain

When injecting against a host network pod, and depending on the CNI used (eg. Cilium), the mark could be overridden later on in the `OUTPUT` chain of the `nat` table. By moving the marking rule to the `POSTROUTING` chain of the `mangle` table, we ensure to put the mark after CNI manipulations so tc can catch it.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - injecting a network drop against a host network pod and making sure packets are effectively dropped
    - [ ] locally.
    - [x] as a canary deployment to a cluster.
