### PR TITLE
fix: wrong usage of variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ minikube-load-all: $(addprefix minikube-load-,$(TARGETS))
 
 # Build chaosli
 chaosli:
-	GOOS=darwin GOARCH=${GOARCH} CGO_ENABLED=0 go build -ldflags="-X github.com/DataDog/chaos-controller/cli/chaosli/cmd.Version=$(VERSION)" -o bin/chaosli/chaosli_darwin_${GOARCH} ./cli/chaosli/
+	GOOS=darwin GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags="-X github.com/DataDog/chaos-controller/cli/chaosli/cmd.Version=$(VERSION)" -o bin/chaosli/chaosli_darwin_$(GOARCH) ./cli/chaosli/
 
 # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
 _ginkgo_test:


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The step `chaosli` from the `Makefile` which compiles the `chaosli` does not use the `GOARCH` variable. Replace `{}` by `()`.

> **Before**
``` bash
> make chaosli
> ls -l bin/chaosli
total 79348
-rw-r--r-- 1 aymeric.daurelle 24517526 Sep 11 14:52 chaosli.tar.gz
-rwxr-xr-x 1 aymeric.daurelle 56427314 Sep 11 14:52 chaosli_darwin <<< Error is here
-rw-r--r-- 1 aymeric.daurelle       65 Sep 11 14:52 chaosli_darwin_arm64.sha256sum
```

> **After**
``` shell
> make chaosli
> ls -l bin/chaosli
total 79348
-rw-r--r-- 1 aymeric.daurelle 24517526 Sep 11 14:52 chaosli.tar.gz
-rwxr-xr-x 1 aymeric.daurelle 56427314 Sep 11 14:52 chaosli_darwin_arm64
-rw-r--r-- 1 aymeric.daurelle       65 Sep 11 14:52 chaosli_darwin_arm64.sha256sum
```
## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
