### PR TITLE
 Upgrade ubuntu to version 23.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ chart/install.yaml
 dogfood/bin
 out
 dist
+docker-metadata.json
 
 # Test binary, build with `go test -c`
 *.test

--- a/bin/ebpf-builder/Dockerfile
+++ b/bin/ebpf-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10
+FROM ubuntu:23.10
 
 # Download development environment.
 RUN apt-get update && \

--- a/bin/injector/Dockerfile
+++ b/bin/injector/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10 as binaries
+FROM ubuntu:23.10 as binaries
 
 RUN apt-get update && \
     # iproute2 => tc
@@ -14,13 +14,11 @@ FROM gcr.io/distroless/python3-debian11:latest
 # binaries used by the chaos-injector, ran as commmands
 COPY --from=binaries /usr/bin/df /usr/bin/ls /usr/bin/test /usr/bin/
 COPY --from=binaries /usr/sbin/iptables /usr/sbin/
-COPY --from=binaries /sbin/tc /sbin/tc
+COPY --from=binaries /usr/sbin/tc /sbin/tc
 
 # libraries used by above mentioned binaries (mostly GLIBC related)
 COPY --from=binaries /lib/ld-linux-aarch64.so.[1]  /lib/
 COPY --from=binaries /lib64/ld-linux-x86-64.so.[2] /lib64/
-COPY --from=binaries /lib/tc /lib/tc/
-COPY --from=binaries /usr/lib/tc /usr/lib/tc/
 COPY --from=binaries /lib/aarch64-linux-gn[u] /lib/aarch64-linux-gnu/
 COPY --from=binaries /lib/x86_64-linux-gn[u] /lib/x86_64-linux-gnu/
 COPY --from=binaries /usr/lib/aarch64-linux-gn[u] /usr/lib/aarch64-linux-gnu/

--- a/dogfood/client/Dockerfile
+++ b/dogfood/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10 as client
+FROM ubuntu:23.10 as client
 
 COPY built_go_client /usr/local/bin/dogfood_client
 

--- a/dogfood/server/Dockerfile
+++ b/dogfood/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10 as client
+FROM ubuntu:23.10 as client
 
 COPY built_go_server /usr/local/bin/dogfood_server
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Ignore the `docker-metadata.json` generated by the image signing.
- Upgrade ubuntu docker image to `23.10` version to fix this [error](https://gitlab.ddbuild.io/DataDog/chaos-controller/-/jobs/328166650#L363) from the `22.10`:
``` bash
Err:7 http://archive.ubuntu.com/ubuntu kinetic-updates Release
  404  Not Found [IP: 185.125.190.39 80]
```

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
