### PR TITLE
Closes #748. Pad the injector pod durations so they usually complete …

### DIFF
--- a/services/chaospod.go
+++ b/services/chaospod.go
@@ -278,8 +278,11 @@ func (m *chaosPodService) GenerateChaosPodOfDisruption(disruption *chaosv1beta1.
 	// to give time for cleaning
 	activeDeadlineSeconds := int64(disruption.RemainingDuration().Seconds()) + 10
 
+	// It can cause abnormalities in the status of a Disruption if injector pods consider themselves complete in the ~second before the chaos-controller believes the disruption is complete.
+	// To avoid making our termination state machine logic more complicated, we will pad the injector pod duration by two seconds.
+	// See https://github.com/DataDog/chaos-controller/issues/748
 	args = append(args,
-		"--deadline", time.Now().Add(disruption.RemainingDuration()).Format(time.RFC3339))
+		"--deadline", time.Now().Add(time.Second*2).Add(disruption.RemainingDuration()).Format(time.RFC3339))
 
 	chaosPod = corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/services/chaospod.go
+++ b/services/chaospod.go
@@ -314,7 +314,7 @@ func (m *chaosPodService) GenerateChaosPodOfDisruption(disruption *chaosv1beta1.
 	// To avoid making our termination state machine logic more complicated, we will pad the injector pod duration by two seconds.
 	// See https://github.com/DataDog/chaos-controller/issues/748
 	args = append(args,
-		"--deadline", time.Now().Add(time.Second*2).Add(disruption.RemainingDuration()).Format(time.RFC3339))
+		"--deadline", time.Now().Add(chaostypes.InjectorPadDuration).Add(disruption.RemainingDuration()).Format(time.RFC3339))
 
 	chaosPod = corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/services/chaospod_test.go
+++ b/services/chaospod_test.go
@@ -728,7 +728,7 @@ var _ = Describe("Chaos Pod Service", func() {
 			args.NotInjectedBefore = notInjectedBefore
 
 			expectedArgs = args.CreateCmdArgs(subSpec.GenerateArgs())
-			expectedArgs = append(expectedArgs, "--deadline", time.Now().Add(time.Second*2).Add(disruption.RemainingDuration()).Format(time.RFC3339))
+			expectedArgs = append(expectedArgs, "--deadline", time.Now().Add(chaostypes.InjectorPadDuration).Add(disruption.RemainingDuration()).Format(time.RFC3339))
 
 			// Action
 			chaosPods, err = chaosPodService.GenerateChaosPodsOfDisruption(&disruption, DefaultTargetName, DefaultTargetNodeName, targetContainers, DefaultTargetPodIp)

--- a/services/chaospod_test.go
+++ b/services/chaospod_test.go
@@ -727,7 +727,7 @@ var _ = Describe("Chaos Pod Service", func() {
 			args.NotInjectedBefore = notInjectedBefore
 
 			expectedArgs = args.CreateCmdArgs(subSpec.GenerateArgs())
-			expectedArgs = append(expectedArgs, "--deadline", time.Now().Add(disruption.RemainingDuration()).Format(time.RFC3339))
+			expectedArgs = append(expectedArgs, "--deadline", time.Now().Add(time.Second*2).Add(disruption.RemainingDuration()).Format(time.RFC3339))
 
 			// Action
 			chaosPods, err = chaosPodService.GenerateChaosPodsOfDisruption(&disruption, DefaultTargetName, DefaultTargetNodeName, targetContainers, DefaultTargetPodIp)

--- a/types/types.go
+++ b/types/types.go
@@ -125,6 +125,9 @@ const (
 	ChaosPodFinalizer   = finalizerPrefix + "/chaos-pod"
 
 	PulsingDisruptionMinimumDuration = 500 * time.Millisecond
+	// InjectorPadDuration is the length of time we extend the injector's duration on top of the disruption's duration,
+	// in order to ensure the manager stops the disruption prior to the injectors dying
+	InjectorPadDuration = 2 * time.Second
 
 	// InjectorCgroupClassID is linked to the TC tree in the injector network disruption.
 	// Also used in the DNS Disruption to allow combined Network + DNS Disruption


### PR DESCRIPTION
…later than the chaos-controller

## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Pad the duration of the injector pods by two seconds to "usually" eliminate the case where the injectors stop <1 second prior to the chaos-controller expecting them to, resulting in status abnormalities such as #748. 
- After testing in our staging env, this seems to have no adverse effects. It should help mitigate #748

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
