### PR TITLE
Make on-init docs slightly more explicit

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -99,6 +99,7 @@ It can be handy to disrupt packets on pod initialization, meaning before contain
 - redeploy your pod with the specific label `chaos.datadoghq.com/disrupt-on-init` to hold it in the initialization state
   - the chaos-controller will inject an init containers name `chaos-handler` as the first init container in your pod
   - this init container is lightweight and does nothing but waiting for a `SIGUSR1` signal to complete successfully
+    - thus, until a disruption targets the pod with the init container, it will do nothing but wait until it times out. The init container has no k8s api access, and does no proactive searching for existing disruption resources.
 - apply your disruption [with the init mode on](../examples/on_init.yaml)
   - the chaos pod will inject the disruption and unstuck your pod from the pending state
 


### PR DESCRIPTION
Per user request

## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Makes docs slightly more explicit about what our on-init container does

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
