### PR TITLE
Running Chaos Pods should not be evaluated as StuckOnRemoval

### DIFF
--- a/cloudservice/cloud_provider_ip_range_manager_mock.go
+++ b/cloudservice/cloud_provider_ip_range_manager_mock.go
@@ -24,17 +24,17 @@ func (_m *CloudProviderIPRangeManagerMock) EXPECT() *CloudProviderIPRangeManager
 	return &CloudProviderIPRangeManagerMock_Expecter{mock: &_m.Mock}
 }
 
-// ConvertToGenericIPRanges provides a mock function with given fields: _a0
-func (_m *CloudProviderIPRangeManagerMock) ConvertToGenericIPRanges(_a0 []byte) (*types.CloudProviderIPRangeInfo, error) {
-	ret := _m.Called(_a0)
+// ConvertToGenericIPRanges provides a mock function with given fields: ipRangeData
+func (_m *CloudProviderIPRangeManagerMock) ConvertToGenericIPRanges(ipRangeData []byte) (*types.CloudProviderIPRangeInfo, error) {
+	ret := _m.Called(ipRangeData)
 
 	var r0 *types.CloudProviderIPRangeInfo
 	var r1 error
 	if rf, ok := ret.Get(0).(func([]byte) (*types.CloudProviderIPRangeInfo, error)); ok {
-		return rf(_a0)
+		return rf(ipRangeData)
 	}
 	if rf, ok := ret.Get(0).(func([]byte) *types.CloudProviderIPRangeInfo); ok {
-		r0 = rf(_a0)
+		r0 = rf(ipRangeData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.CloudProviderIPRangeInfo)
@@ -42,7 +42,7 @@ func (_m *CloudProviderIPRangeManagerMock) ConvertToGenericIPRanges(_a0 []byte) 
 	}
 
 	if rf, ok := ret.Get(1).(func([]byte) error); ok {
-		r1 = rf(_a0)
+		r1 = rf(ipRangeData)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -56,12 +56,12 @@ type CloudProviderIPRangeManagerMock_ConvertToGenericIPRanges_Call struct {
 }
 
 // ConvertToGenericIPRanges is a helper method to define mock.On call
-//   - _a0 []byte
-func (_e *CloudProviderIPRangeManagerMock_Expecter) ConvertToGenericIPRanges(_a0 interface{}) *CloudProviderIPRangeManagerMock_ConvertToGenericIPRanges_Call {
-	return &CloudProviderIPRangeManagerMock_ConvertToGenericIPRanges_Call{Call: _e.mock.On("ConvertToGenericIPRanges", _a0)}
+//   - ipRangeData []byte
+func (_e *CloudProviderIPRangeManagerMock_Expecter) ConvertToGenericIPRanges(ipRangeData interface{}) *CloudProviderIPRangeManagerMock_ConvertToGenericIPRanges_Call {
+	return &CloudProviderIPRangeManagerMock_ConvertToGenericIPRanges_Call{Call: _e.mock.On("ConvertToGenericIPRanges", ipRangeData)}
 }
 
-func (_c *CloudProviderIPRangeManagerMock_ConvertToGenericIPRanges_Call) Run(run func(_a0 []byte)) *CloudProviderIPRangeManagerMock_ConvertToGenericIPRanges_Call {
+func (_c *CloudProviderIPRangeManagerMock_ConvertToGenericIPRanges_Call) Run(run func(ipRangeData []byte)) *CloudProviderIPRangeManagerMock_ConvertToGenericIPRanges_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].([]byte))
 	})
@@ -78,23 +78,23 @@ func (_c *CloudProviderIPRangeManagerMock_ConvertToGenericIPRanges_Call) RunAndR
 	return _c
 }
 
-// IsNewVersion provides a mock function with given fields: _a0, _a1
-func (_m *CloudProviderIPRangeManagerMock) IsNewVersion(_a0 []byte, _a1 string) (bool, error) {
-	ret := _m.Called(_a0, _a1)
+// IsNewVersion provides a mock function with given fields: ipRangeData, version
+func (_m *CloudProviderIPRangeManagerMock) IsNewVersion(ipRangeData []byte, version string) (bool, error) {
+	ret := _m.Called(ipRangeData, version)
 
 	var r0 bool
 	var r1 error
 	if rf, ok := ret.Get(0).(func([]byte, string) (bool, error)); ok {
-		return rf(_a0, _a1)
+		return rf(ipRangeData, version)
 	}
 	if rf, ok := ret.Get(0).(func([]byte, string) bool); ok {
-		r0 = rf(_a0, _a1)
+		r0 = rf(ipRangeData, version)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	if rf, ok := ret.Get(1).(func([]byte, string) error); ok {
-		r1 = rf(_a0, _a1)
+		r1 = rf(ipRangeData, version)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -108,13 +108,13 @@ type CloudProviderIPRangeManagerMock_IsNewVersion_Call struct {
 }
 
 // IsNewVersion is a helper method to define mock.On call
-//   - _a0 []byte
-//   - _a1 string
-func (_e *CloudProviderIPRangeManagerMock_Expecter) IsNewVersion(_a0 interface{}, _a1 interface{}) *CloudProviderIPRangeManagerMock_IsNewVersion_Call {
-	return &CloudProviderIPRangeManagerMock_IsNewVersion_Call{Call: _e.mock.On("IsNewVersion", _a0, _a1)}
+//   - ipRangeData []byte
+//   - version string
+func (_e *CloudProviderIPRangeManagerMock_Expecter) IsNewVersion(ipRangeData interface{}, version interface{}) *CloudProviderIPRangeManagerMock_IsNewVersion_Call {
+	return &CloudProviderIPRangeManagerMock_IsNewVersion_Call{Call: _e.mock.On("IsNewVersion", ipRangeData, version)}
 }
 
-func (_c *CloudProviderIPRangeManagerMock_IsNewVersion_Call) Run(run func(_a0 []byte, _a1 string)) *CloudProviderIPRangeManagerMock_IsNewVersion_Call {
+func (_c *CloudProviderIPRangeManagerMock_IsNewVersion_Call) Run(run func(ipRangeData []byte, version string)) *CloudProviderIPRangeManagerMock_IsNewVersion_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].([]byte), args[1].(string))
 	})

--- a/services/chaospod.go
+++ b/services/chaospod.go
@@ -182,6 +182,8 @@ func (m *chaosPodService) HandleChaosPodTermination(ctx context.Context, disrupt
 // DeletePod attempts to delete the specified pod from the Kubernetes cluster.
 // Returns true if deletion was successful, otherwise returns false.
 func (m *chaosPodService) DeletePod(ctx context.Context, pod corev1.Pod) bool {
+	m.config.Log.Infow("terminating chaos pod to trigger cleanup", "chaosPod", pod.Name)
+
 	if err := m.deletePod(ctx, pod); err != nil {
 		m.config.Log.Errorw("Error terminating chaos pod", "error", err, "chaosPod", pod.Name)
 

--- a/services/chaospod.go
+++ b/services/chaospod.go
@@ -150,6 +150,7 @@ func (m *chaosPodService) HandleChaosPodTermination(ctx context.Context, disrupt
 
 		// Remove the finalizer for the chaos pod since cleanup won't be fully reliable.
 		err = m.removeFinalizerForChaosPod(ctx, chaosPod)
+
 		return false, err
 	}
 
@@ -203,9 +204,9 @@ func (m *chaosPodService) HandleChaosPodTermination(ctx context.Context, disrupt
 		// Remove the finalizer for the chaos pod since cleanup was successful.
 		err = m.removeFinalizerForChaosPod(ctx, chaosPod)
 		return false, err
-	} else {
-		return true, nil
 	}
+
+	return true, nil
 }
 
 // DeletePod attempts to delete the specified pod from the Kubernetes cluster.

--- a/services/chaospod_test.go
+++ b/services/chaospod_test.go
@@ -438,7 +438,7 @@ var _ = Describe("Chaos Pod Service", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					// Action
-					isRemoved, err := chaosPodService.HandleChaosPodTermination(context.Background(), disruption, &chaosPod)
+					isStuckOnRemoval, err := chaosPodService.HandleChaosPodTermination(context.Background(), disruption, &chaosPod)
 
 					// Assert
 					By("not return an error")
@@ -446,7 +446,7 @@ var _ = Describe("Chaos Pod Service", func() {
 
 					By("remove the finalizer")
 					Expect(chaosPod.GetFinalizers()).Should(Equal([]string{}))
-					Expect(isRemoved).To(BeTrue())
+					Expect(isStuckOnRemoval).To(BeFalse())
 				},
 					Entry("not found target", metav1.Status{
 						Message: "Not found",

--- a/services/chaospod_test.go
+++ b/services/chaospod_test.go
@@ -245,8 +245,8 @@ var _ = Describe("Chaos Pod Service", func() {
 	Describe("HandleChaosPodTermination", func() {
 
 		var (
-			isFinalizerRemoved bool
-			cpBuilder          *builderstest.ChaosPodBuilder
+			isStuckOnRemoval bool
+			cpBuilder        *builderstest.ChaosPodBuilder
 		)
 
 		BeforeEach(func() {
@@ -260,7 +260,7 @@ var _ = Describe("Chaos Pod Service", func() {
 			chaosPod = cpBuilder.Build()
 
 			// Action
-			isFinalizerRemoved, err = chaosPodService.HandleChaosPodTermination(context.Background(), disruption, &chaosPod)
+			isStuckOnRemoval, err = chaosPodService.HandleChaosPodTermination(context.Background(), disruption, &chaosPod)
 		})
 
 		DescribeTable("success cases", func(chaosPodBuilder *builderstest.ChaosPodBuilder) {
@@ -477,7 +477,7 @@ var _ = Describe("Chaos Pod Service", func() {
 
 						By("not remove the finalizer")
 						Expect(chaosPod.GetFinalizers()).Should(Equal([]string{chaostypes.ChaosPodFinalizer}))
-						Expect(isFinalizerRemoved).To(BeFalse())
+						Expect(isStuckOnRemoval).To(BeFalse())
 					})
 
 				})
@@ -501,7 +501,7 @@ var _ = Describe("Chaos Pod Service", func() {
 						Expect(err).Should(HaveOccurred())
 
 						By("not remove the finalizer")
-						Expect(isFinalizerRemoved).To(BeFalse())
+						Expect(isStuckOnRemoval).To(BeFalse())
 					})
 				})
 
@@ -524,7 +524,7 @@ var _ = Describe("Chaos Pod Service", func() {
 					It("should propagate the error", func() {
 						// Assert
 						Expect(err).Should(HaveOccurred())
-						Expect(isFinalizerRemoved).To(BeFalse())
+						Expect(isStuckOnRemoval).To(BeFalse())
 					})
 				})
 
@@ -546,7 +546,7 @@ var _ = Describe("Chaos Pod Service", func() {
 					It("should propagate the error", func() {
 						// Assert
 						Expect(err).Should(HaveOccurred())
-						Expect(isFinalizerRemoved).To(BeFalse())
+						Expect(isStuckOnRemoval).To(BeFalse())
 					})
 				})
 			})
@@ -566,7 +566,7 @@ var _ = Describe("Chaos Pod Service", func() {
 
 				By("not remove the finalizer")
 				k8sClientMock.AssertNotCalled(GinkgoT(), "Update", mock.Anything, mock.Anything)
-				Expect(isFinalizerRemoved).To(BeFalse())
+				Expect(isStuckOnRemoval).To(BeFalse())
 			})
 		})
 
@@ -586,7 +586,7 @@ var _ = Describe("Chaos Pod Service", func() {
 				k8sClientMock.AssertNotCalled(GinkgoT(), "Update", mock.Anything, mock.Anything)
 
 				By("return true because the finalizer is already removed")
-				Expect(isFinalizerRemoved).To(BeTrue())
+				Expect(isStuckOnRemoval).To(BeFalse())
 			})
 		})
 	})

--- a/services/chaospod_test.go
+++ b/services/chaospod_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Chaos Pod Service", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Action
-			isRemoved, err := chaosPodService.HandleChaosPodTermination(context.Background(), disruption, &chaosPod)
+			isStuckOnRemoval, err := chaosPodService.HandleChaosPodTermination(context.Background(), disruption, &chaosPod)
 
 			// Assert
 			By("not return an error")
@@ -287,7 +287,7 @@ var _ = Describe("Chaos Pod Service", func() {
 
 			By("remove the finalizer")
 			Expect(chaosPod.GetFinalizers()).Should(Equal([]string{}))
-			Expect(isRemoved).To(BeTrue())
+			Expect(isStuckOnRemoval).To(BeFalse())
 		},
 			Entry(
 				"with a success pod",

--- a/services/chaospod_test.go
+++ b/services/chaospod_test.go
@@ -495,12 +495,10 @@ var _ = Describe("Chaos Pod Service", func() {
 						k8sClientMock.EXPECT().Update(mock.Anything, mock.Anything).Return(fmt.Errorf("an error happened"))
 					})
 
-					It("should not remove the finalizer", func() {
+					It("should propagate the error", func() {
 						// Assert
 						By("return an error")
 						Expect(err).Should(HaveOccurred())
-
-						By("not remove the finalizer")
 						Expect(isStuckOnRemoval).To(BeFalse())
 					})
 				})
@@ -559,12 +557,12 @@ var _ = Describe("Chaos Pod Service", func() {
 				cpBuilder.WithChaosPodLabels(DefaultDisruptionName, DefaultNamespace, "", "").WithChaosFinalizer()
 			})
 
-			It("should not remove the finalizer", func() {
+			It("should not be StuckOnRemoval", func() {
 				// Assert
 				By("not return an error")
 				Expect(err).ShouldNot(HaveOccurred())
 
-				By("not remove the finalizer")
+				By("not be Stuck")
 				k8sClientMock.AssertNotCalled(GinkgoT(), "Update", mock.Anything, mock.Anything)
 				Expect(isStuckOnRemoval).To(BeFalse())
 			})
@@ -585,7 +583,7 @@ var _ = Describe("Chaos Pod Service", func() {
 				By("not try to remove finalizer because it is already deleted")
 				k8sClientMock.AssertNotCalled(GinkgoT(), "Update", mock.Anything, mock.Anything)
 
-				By("return true because the finalizer is already removed")
+				By("return false because the finalizer is already removed")
 				Expect(isStuckOnRemoval).To(BeFalse())
 			})
 		})


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- After #764, any disruption that was deleted manually, would consider itself as StuckOnRemoval. We'd issue a delete to the chaos pod, then run handleChaosPodTermination, and immediately evaluate it as Stuck. At first, I couldn't identify the change in #764 that caused this, as we did the same back-to-back procedure there. _however_, I did ultimately identify a small change.
https://github.com/DataDog/chaos-controller/blob/c618197d023c5f88441c9bb0fe58d6def7e49c71/controllers/disruption_controller.go#L829C10-L834
The default case of this switch statement was no longer considered after the refactor. Any chaos pods that weren't yet in a terminated state, were being considered as Stuck, as we assumed their finalizers couldn't be removed. I've in-lined the function `isFinalizerNotRemovableForChaosPod`, as its `bool` return value was making it hard to handle the fact that we needed three different exit cases: (1) pod is terminated and we can remove the finalizer, (2) pod is terminated  and we cannot remove the finalizer, i.e., StuckOnRemoval, and (3) pod is still cleaning and we should come back to it next time we reconcile.

The relevant test cases have been updated, especially when we expect stuckOnRemoval to be true:
https://github.com/DataDog/chaos-controller/pull/781/files#diff-7e0579210295a9153cd7c4bde60932eca36fffac5d47fc6b8ad1646600b17ae9R406-R415
## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [x] as a canary deployment to a cluster.
