### PR TITLE
CHAOS-787: Validate dns disruption hostname regex in webhook

### DIFF
--- a/api/v1beta1/dns_disruption.go
+++ b/api/v1beta1/dns_disruption.go
@@ -8,6 +8,7 @@ package v1beta1
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -33,6 +34,10 @@ func (s DNSDisruptionSpec) Validate() (retErr error) {
 	for _, pair := range s {
 		if pair.Hostname == "" {
 			retErr = multierror.Append(retErr, errors.New("no hostname specified in dns disruption"))
+		}
+
+		if _, err := regexp.Compile(pair.Hostname); err != nil {
+			retErr = multierror.Append(retErr, fmt.Errorf("hostname \"%s\" not a valid regular expression: %w", pair.Hostname, err))
 		}
 
 		if pair.Record.Type != "A" && pair.Record.Type != "CNAME" {

--- a/api/v1beta1/dns_disruption_test.go
+++ b/api/v1beta1/dns_disruption_test.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DNSDisruptionSpec", func() {
+	When("'Validate' method is called", func() {
+		Describe("test regex validation cases", func() {
+			disruptionSpec := DNSDisruptionSpec{
+				{
+					Hostname: "hostname.tld",
+					Record: DNSRecord{
+						Type:  "",
+						Value: "",
+					},
+				},
+			}
+
+			err := disruptionSpec.Validate()
+			Expect(err).ToNot(HaveOccurred())
+
+			disruptionSpec[0].Hostname = "*.hostname.tld"
+
+			err = disruptionSpec.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("not a valid regular expression"))
+
+			disruptionSpec[0].Hostname = ".*.hostname.tld"
+			err = disruptionSpec.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Rather than failing in the python script, it would be best to validate the specified regular expressions ahead of time

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
