### PR TITLE
CHAOS-791: Clean should be idempotent, dont error when deleting a missing iptables chain

### DIFF
--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -354,7 +354,7 @@ func inject(kind string, sendToMetrics bool, reinjection bool) bool {
 				}
 			}
 
-			log.Errorw("disruption injection failed", "error", err)
+			log.Errorw("disruption injection failed", "error", err, "target", inj.TargetName())
 		} else {
 			if sendToMetrics {
 				if reinjection {

--- a/injector/container_failure.go
+++ b/injector/container_failure.go
@@ -41,6 +41,10 @@ func NewContainerFailureInjector(spec v1beta1.ContainerFailureSpec, config Conta
 	}
 }
 
+func (i *containerFailureInjector) TargetName() string {
+	return i.config.TargetName()
+}
+
 func (i *containerFailureInjector) GetDisruptionKind() types.DisruptionKindName {
 	return types.DisruptionKindContainerFailure
 }

--- a/injector/cpu_pressure.go
+++ b/injector/cpu_pressure.go
@@ -47,6 +47,10 @@ func NewCPUPressureInjector(config Config, count string, injectorCmdFactory Inje
 	}
 }
 
+func (i *cpuPressureInjector) TargetName() string {
+	return i.config.TargetName()
+}
+
 func (i *cpuPressureInjector) GetDisruptionKind() types.DisruptionKindName {
 	return types.DisruptionKindCPUPressure
 }

--- a/injector/cpu_stress.go
+++ b/injector/cpu_stress.go
@@ -32,6 +32,10 @@ func NewCPUStressInjector(config Config, percentage int, process process.Manager
 	}
 }
 
+func (c *cpuStressInjector) TargetName() string {
+	return c.config.TargetName()
+}
+
 func (*cpuStressInjector) GetDisruptionKind() types.DisruptionKindName {
 	return types.DisruptionKindCPUStress
 }

--- a/injector/disk_failure.go
+++ b/injector/disk_failure.go
@@ -47,6 +47,10 @@ func NewDiskFailureInjector(spec v1beta1.DiskFailureSpec, config DiskFailureInje
 	}, nil
 }
 
+func (i *DiskFailureInjector) TargetName() string {
+	return i.config.TargetName()
+}
+
 func (i *DiskFailureInjector) GetDisruptionKind() types.DisruptionKindName {
 	return types.DisruptionKindDiskFailure
 }

--- a/injector/disk_pressure.go
+++ b/injector/disk_pressure.go
@@ -79,6 +79,10 @@ func NewDiskPressureInjector(spec v1beta1.DiskPressureSpec, config DiskPressureI
 	}, nil
 }
 
+func (i *diskPressureInjector) TargetName() string {
+	return i.config.TargetName()
+}
+
 func (i *diskPressureInjector) GetDisruptionKind() types.DisruptionKindName {
 	return types.DisruptionKindDiskPressure
 }

--- a/injector/dns_disruption.go
+++ b/injector/dns_disruption.go
@@ -71,6 +71,10 @@ func NewDNSDisruptionInjector(spec v1beta1.DNSDisruptionSpec, config DNSDisrupti
 	}, err
 }
 
+func (i *DNSDisruptionInjector) TargetName() string {
+	return i.config.Config.TargetName()
+}
+
 func (i *DNSDisruptionInjector) GetDisruptionKind() chaostypes.DisruptionKindName {
 	return chaostypes.DisruptionKindDNSDisruption
 }

--- a/injector/grpc_disruption.go
+++ b/injector/grpc_disruption.go
@@ -51,6 +51,10 @@ func NewGRPCDisruptionInjector(spec v1beta1.GRPCDisruptionSpec, config GRPCDisru
 	}
 }
 
+func (i *GRPCDisruptionInjector) TargetName() string {
+	return i.config.TargetName()
+}
+
 func (i *GRPCDisruptionInjector) GetDisruptionKind() types.DisruptionKindName {
 	return types.DisruptionKindGRPCDisruption
 }

--- a/injector/injector.go
+++ b/injector/injector.go
@@ -32,6 +32,7 @@ const (
 type Injector interface {
 	GetDisruptionKind() types.DisruptionKindName
 	Inject() error
+	TargetName() string
 	UpdateConfig(config Config)
 	Clean() error
 }

--- a/injector/injector_mock.go
+++ b/injector/injector_mock.go
@@ -147,6 +147,47 @@ func (_c *InjectorMock_Inject_Call) RunAndReturn(run func() error) *InjectorMock
 	return _c
 }
 
+// TargetName provides a mock function with given fields:
+func (_m *InjectorMock) TargetName() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// InjectorMock_TargetName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TargetName'
+type InjectorMock_TargetName_Call struct {
+	*mock.Call
+}
+
+// TargetName is a helper method to define mock.On call
+func (_e *InjectorMock_Expecter) TargetName() *InjectorMock_TargetName_Call {
+	return &InjectorMock_TargetName_Call{Call: _e.mock.On("TargetName")}
+}
+
+func (_c *InjectorMock_TargetName_Call) Run(run func()) *InjectorMock_TargetName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *InjectorMock_TargetName_Call) Return(_a0 string) *InjectorMock_TargetName_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *InjectorMock_TargetName_Call) RunAndReturn(run func() string) *InjectorMock_TargetName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateConfig provides a mock function with given fields: config
 func (_m *InjectorMock) UpdateConfig(config Config) {
 	_m.Called(config)

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -154,6 +154,10 @@ func (i *networkDisruptionInjector) GetDisruptionKind() types.DisruptionKindName
 	return types.DisruptionKindNetworkDisruption
 }
 
+func (i *networkDisruptionInjector) TargetName() string {
+	return i.config.TargetName()
+}
+
 // Inject injects the given network disruption into the given container
 func (i *networkDisruptionInjector) Inject() error {
 	// enter target network namespace

--- a/injector/node_failure.go
+++ b/injector/node_failure.go
@@ -63,6 +63,10 @@ func NewNodeFailureInjector(spec v1beta1.NodeFailureSpec, config NodeFailureInje
 	}, nil
 }
 
+func (i *nodeFailureInjector) TargetName() string {
+	return i.config.TargetName()
+}
+
 func (i *nodeFailureInjector) GetDisruptionKind() types.DisruptionKindName {
 	return types.DisruptionKindNodeFailure
 }

--- a/network/iptables.go
+++ b/network/iptables.go
@@ -64,8 +64,19 @@ func (i *iptables) Clear() error {
 	for _, r := range i.injectedRules {
 		i.log.Infow("deleting injected iptables rule", "chain", r.chain, "table", r.table, "rulespec", r.rulespec)
 
+		exists, err := i.ip.ChainExists(r.table, r.chain)
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			i.log.Infow("iptables chain doesn't exist anymore, skipping cleaning", "table", r.table, "chain", r.chain)
+
+			continue
+		}
+
 		// skip if it does not exist anymore for idempotency
-		exists, err := i.ip.Exists(r.table, r.chain, r.rulespec...)
+		exists, err = i.ip.Exists(r.table, r.chain, r.rulespec...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- So far I'm unable to reproduce the original problem locally, so I'll need to test this in staging.
- Makes one serious interface change to Injector so that when we log an error about an injection failing, we include which container it failed for. It was hard for me to follow exactly what errored in the logs when targeting a five container pod given the final error doesn't specify that info.
- Make iptables.Clear more idempotent, by skipping the deletion of any iptables rule if the chain doesn't exist. we were already checking if the rule existed, but sometimes we'd get an error that the chain didn't exist. I'm not sure if the underlying behavior of the iptables dependency changed, but it's simple enough to check the chain and then check the rule

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
