### PR TITLE
Go: bump to 1.20 [CHAOS-728]

### DIFF
--- a/api/disruption_types_test.go
+++ b/api/disruption_types_test.go
@@ -23,7 +23,7 @@ var _ = Describe("DisruptionStatus.RemoveDeadTargets Test", func() {
 	var status *v1beta1.DisruptionStatus
 
 	BeforeEach(func() {
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		status = &v1beta1.DisruptionStatus{
 			TargetInjections: makeValidTargetInjections(),
 		}
@@ -144,7 +144,7 @@ var _ = Describe("DisruptionStatus.AddTargets Test", func() {
 	var eligibleTargets v1beta1.TargetInjections
 
 	BeforeEach(func() {
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		status = &v1beta1.DisruptionStatus{
 			TargetInjections: makeValidTargetInjections(),
 		}
@@ -223,7 +223,7 @@ var _ = Describe("DisruptionStatus.RemoveTargets Test", func() {
 	var status *v1beta1.DisruptionStatus
 
 	BeforeEach(func() {
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		status = &v1beta1.DisruptionStatus{
 			TargetInjections: makeValidTargetInjections(),
 		}

--- a/cli/chaosli/chaosli.DOCKERFILE
+++ b/cli/chaosli/chaosli.DOCKERFILE
@@ -1,5 +1,5 @@
 # ---------------------------------------
-FROM amd64/golang:1.18-alpine as build
+FROM amd64/golang:1.20-alpine as build
 
 ENV GOARCH=amd64 
 ENV CGO_ENABLED=0
@@ -16,7 +16,7 @@ RUN go build \
     ./cli/chaosli
 
 # ---------------------------------------
-FROM amd64/golang:1.18-alpine as bin
+FROM amd64/golang:1.20-alpine as bin
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -8,7 +8,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"strings"
@@ -529,7 +528,7 @@ func injectAndWait(cmd *cobra.Command, args []string) {
 	if injectSuccess {
 		log.Infof("disruption(s) injected, now waiting for an exit signal")
 
-		if err := ioutil.WriteFile(readinessProbeFile, []byte("1"), 0o400); err != nil {
+		if err := os.WriteFile(readinessProbeFile, []byte("1"), 0o400); err != nil {
 			log.Errorw("error writing readiness probe file", "error", err)
 		}
 	}

--- a/eventnotifier/http/http.go
+++ b/eventnotifier/http/http.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/mail"
 	"os"
@@ -72,7 +72,7 @@ func New(commonConfig types.NotifiersCommonConfig, httpConfig NotifierHTTPConfig
 			return nil, fmt.Errorf("headers file not found: %w", err)
 		}
 
-		readHeaders, err := ioutil.ReadAll(headersFile)
+		readHeaders, err := io.ReadAll(headersFile)
 		if err != nil {
 			return nil, fmt.Errorf("headers file could not be read: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/chaos-controller
 
-go 1.18
+go 1.20
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6


### PR DESCRIPTION
## What does this PR do?
- [ ] Adds new functionality
- [ ] Alters existing functionality
- [X] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Bump the official go version of the controller to 1.20, with linter checks.
- Not much to signal here; the controller has its build and CI running on go 1.20 thanks to @luphaz's previous work on CI and testing that cleared most of the work for this transition. Read through the Makefile for more info !

## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [X] I leveraged continuous integration testing
    - [X] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - [X] locally.
    - [ ] as a canary deployment to a cluster.
