### PR TITLE
CHAOS-797: use correct flags when checking safemode config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -306,28 +306,28 @@ func New(logger *zap.SugaredLogger, osArgs []string) (config, error) {
 
 	mainFS.StringVar(&cfg.Controller.SafeMode.Environment, "safemode-environment", "", "Specify the 'location' this controller is run in. All disruptions must have an annotation of chaos.datadoghq.com/environment configured with this location to be allowed to create")
 
-	if err := viper.BindPFlag("conroller.safemode.environment", mainFS.Lookup("safemode-environment")); err != nil {
+	if err := viper.BindPFlag("controller.safeMode.environment", mainFS.Lookup("safemode-environment")); err != nil {
 		return cfg, err
 	}
 
 	mainFS.BoolVar(&cfg.Controller.SafeMode.Enable, "safemode-enable", true,
 		"Enable or disable the safemode functionality of the chaos-controller")
 
-	if err := viper.BindPFlag("controller.safemode.enable", mainFS.Lookup("safemode-enable")); err != nil {
+	if err := viper.BindPFlag("controller.safeMode.enable", mainFS.Lookup("safemode-enable")); err != nil {
 		return cfg, err
 	}
 
 	mainFS.IntVar(&cfg.Controller.SafeMode.NamespaceThreshold, "safemode-namespace-threshold", 80,
 		"Threshold which safemode checks against to see if the number of targets is over safety measures within a namespace.")
 
-	if err := viper.BindPFlag("controller.safemode.namespaceThreshold", mainFS.Lookup("safemode-namespace-threshold")); err != nil {
+	if err := viper.BindPFlag("controller.safeMode.namespaceThreshold", mainFS.Lookup("safemode-namespace-threshold")); err != nil {
 		return cfg, err
 	}
 
 	mainFS.IntVar(&cfg.Controller.SafeMode.ClusterThreshold, "safemode-cluster-threshold", 66,
 		"Threshold which safemode checks against to see if the number of targets is over safety measures within a cluster")
 
-	if err := viper.BindPFlag("controller.safemode.clusterThreshold", mainFS.Lookup("safemode-cluster-threshold")); err != nil {
+	if err := viper.BindPFlag("controller.safeMode.clusterThreshold", mainFS.Lookup("safemode-cluster-threshold")); err != nil {
 		return cfg, err
 	}
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- So I've learned the keys we pass to viper are entirely cosmetic (for how we use them, at least)? It's the `mainFS.Lookup` that figures out where in the configmap to look, based on the json tags we put for the config structs. You can put literally anything in these keys (I tried it), and we will still read all the config values correctly. Nonetheless, these should be fixed for consistency

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
