### PR TITLE
CHAOS-798: Interrupt addFilterForHosts if disruption ends early

### DIFF
--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -62,6 +62,7 @@ var (
 	handlerPID          uint32
 	configs             []injector.Config
 	signals             chan os.Signal
+	injectorCtx         context.Context
 	injectors           []injector.Injector
 	readyToInject       bool
 	clientset           *kubernetes.Clientset
@@ -115,8 +116,8 @@ func init() {
 	_ = cobra.MarkFlagRequired(rootCmd.PersistentFlags(), "level")
 	cobra.OnInitialize(initLogger)
 	cobra.OnInitialize(initMetricsSink)
-	cobra.OnInitialize(initConfig)
 	cobra.OnInitialize(initExitSignalsHandler)
+	cobra.OnInitialize(initConfig)
 }
 
 func main() {
@@ -304,6 +305,7 @@ func initConfig() {
 			K8sClient:          clientset,
 			DNS:                dnsConfig,
 			Disruption:         disruptionArgs,
+			InjectorCtx:        injectorCtx,
 		}
 		config.Log = log.With("targetLevel", disruptionArgs.Level, "target", config.TargetName()) // targetName is already taken in the initLogger
 
@@ -321,6 +323,22 @@ func initExitSignalsHandler() {
 	// as no matter how many SIGINT or SIGTERMs we receive, we want to carry out the same action: clean and die
 	signals = make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	var cancelFunc context.CancelFunc
+	injectorCtx, cancelFunc = context.WithCancel(context.Background())
+
+	// In case the inject phase manages to take more than the disruption duration + activeDeadlineSeconds
+	// we can end up receiving a sigkill during inject, leaving us stuck on removal. To prevent this, we pass a context
+	// to the injector config that can be cancelled if we receive any early exit signals. Injectors with possible length injects should
+	// take care to check if this context has been cancelled. After cancelling that context, we return the exit signal to the signals channel
+	// so that the appropriate handlers that trigger cleanup can begin
+	go func() {
+		sig := <-signals
+
+		cancelFunc()
+
+		go func() { signals <- sig }()
+	}()
 }
 
 // initPodWatch initializes the target pod watcher

--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -324,8 +324,8 @@ func initExitSignalsHandler() {
 	signals = make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
-	var cancelFunc context.CancelFunc
-	injectorCtx, cancelFunc = context.WithCancel(context.Background())
+	var injectorCancelFunc context.CancelFunc
+	injectorCtx, injectorCancelFunc = context.WithCancel(context.Background())
 
 	// In case the inject phase manages to take more than the disruption duration + activeDeadlineSeconds
 	// we can end up receiving a sigkill during inject, leaving us stuck on removal. To prevent this, we pass a context
@@ -335,7 +335,7 @@ func initExitSignalsHandler() {
 	go func() {
 		sig := <-signals
 
-		cancelFunc()
+		injectorCancelFunc()
 
 		go func() { signals <- sig }()
 	}()

--- a/injector/injector.go
+++ b/injector/injector.go
@@ -6,6 +6,7 @@
 package injector
 
 import (
+	"context"
 	"time"
 
 	chaosapi "github.com/DataDog/chaos-controller/api"
@@ -48,6 +49,7 @@ type Config struct {
 	K8sClient          kubernetes.Interface
 	DNS                network.DNSConfig
 	Disruption         chaosapi.DisruptionArgs
+	InjectorCtx        context.Context
 }
 
 // TargetName returns the name of the target that relates to this configuration

--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -1157,6 +1157,12 @@ func (i *networkDisruptionInjector) addFiltersForHosts(interfaces []string, host
 	hostFilterMap := map[v1beta1.NetworkDisruptionHostSpec]tcFilters{}
 
 	for _, host := range hosts {
+		if err := i.config.InjectorCtx.Err(); err != nil {
+			i.config.Log.Warnw("interrupting adding filters for hosts", "err", err)
+
+			return nil, nil
+		}
+
 		// resolve given hosts if needed
 		ips, err := resolveHost(i.config.DNSClient, host.Host)
 		if err != nil {

--- a/injector/network_disruption_test.go
+++ b/injector/network_disruption_test.go
@@ -6,6 +6,7 @@
 package injector_test
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -231,7 +232,8 @@ var _ = Describe("Failure", func() {
 				Disruption: api.DisruptionArgs{
 					Level: chaostypes.DisruptionLevelPod,
 				},
-				K8sClient: k8sClient,
+				K8sClient:   k8sClient,
+				InjectorCtx: context.Background(),
 			},
 			TrafficController:   tc,
 			IPTables:            iptables,


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Adds a context to the injector config that is cancelled if the injector receives a sigterm early than we currently handled
- Checks if this context has been cancelled within addfiltersForHosts

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
