### PR TITLE
Dont allow users to create bandwidthLimit disruptions below 32 bytes

### DIFF
--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -346,6 +346,10 @@ func (s *NetworkDisruptionSpec) Validate() (retErr error) {
 		}
 	}
 
+	if s.BandwidthLimit > 0 && s.BandwidthLimit < 32 {
+		retErr = multierror.Append(retErr, fmt.Errorf("bandwidthLimits below 32 bytes are not supported"))
+	}
+
 	return multierror.Prefix(retErr, "Network:")
 }
 

--- a/api/v1beta1/network_disruption_test.go
+++ b/api/v1beta1/network_disruption_test.go
@@ -442,6 +442,22 @@ var _ = Describe("NetworkDisruptionSpec", func() {
 			})
 		})
 
+		Describe("test option limits", func() {
+			It("rejects bandwidthLimits below 32 bytes", func() {
+				disruptionSpec := NetworkDisruptionSpec{BandwidthLimit: 0}
+				err := disruptionSpec.Validate()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				disruptionSpec.BandwidthLimit = 32
+				err = disruptionSpec.Validate()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				disruptionSpec.BandwidthLimit = 16
+				err = disruptionSpec.Validate()
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+
 		DescribeTable("multi error cases",
 			func(invalidPaths HTTPPaths, invalidMethods HTTPMethods, expectedErrorMessages []string) {
 				// Arrange


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- According to https://man7.org/linux/man-pages/man8/tc-tbf.8.html , there is a system-dependent minimum on the `tc tbf rate` parameter. The error when setting one too low will look like:
```
error applying tc operations: could not perform operation on newly created qdisc: encountered error (exit status 1) using args ([qdisc add dev eth0 parent 2:2 handle 3: tbf rate 1 latency 50ms burst 1]): tbf: the "rate" parameter is mandatory.
Usage: ... tbf limit BYTES burst BYTES[/BYTES] rate KBPS [ mtu BYTES[/BYTES] ]
	[ peakrate KBPS ] [ latency TIME ] [ overhead BYTES ] [ linklayer TYPE ]
```
From my testing, though 64 bytes is mentioned on the man page, `lima` can handle 32 bytes, and I've found other systems we use that can go as low as 16. Let's try controlling at 32 bytes for now and see if that's a problem for users

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
