### PR TITLE
fix: remove netem distribution normal

### DIFF
--- a/network/tc.go
+++ b/network/tc.go
@@ -95,7 +95,7 @@ func (t *tc) AddNetem(ifaces []string, parent string, handle string, delay time.
 	params := ""
 
 	if delay.Milliseconds() != 0 {
-		params = fmt.Sprintf("%s delay %dms %dms distribution normal", params, delay.Milliseconds(), delayJitter.Milliseconds())
+		params = fmt.Sprintf("%s delay %dms %dms", params, delay.Milliseconds(), delayJitter.Milliseconds())
 	}
 
 	if drop != 0 {

--- a/network/tc_test.go
+++ b/network/tc_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Tc", func() {
 
 		Context("add 1s delay and 1s delayJitter to lo interface to the root parent without any handle", func() {
 			It("should execute", func() {
-				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"qdisc", "add", "dev", "lo", "root", "netem", "delay", "1000ms", "1000ms", "distribution", "normal", "loss", "5%", "duplicate", "5%", "corrupt", "1%"})
+				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"qdisc", "add", "dev", "lo", "root", "netem", "delay", "1000ms", "1000ms", "loss", "5%", "duplicate", "5%", "corrupt", "1%"})
 			})
 		})
 
@@ -90,7 +90,7 @@ var _ = Describe("Tc", func() {
 			})
 
 			It("should execute", func() {
-				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"qdisc", "add", "dev", "lo", "root", "handle", "1:", "netem", "delay", "1000ms", "1000ms", "distribution", "normal", "loss", "5%", "duplicate", "5%", "corrupt", "1%"})
+				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"qdisc", "add", "dev", "lo", "root", "handle", "1:", "netem", "delay", "1000ms", "1000ms", "loss", "5%", "duplicate", "5%", "corrupt", "1%"})
 			})
 		})
 
@@ -100,7 +100,7 @@ var _ = Describe("Tc", func() {
 			})
 
 			It("should execute", func() {
-				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"qdisc", "add", "dev", "lo", "parent", "1:4", "netem", "delay", "1000ms", "1000ms", "distribution", "normal", "loss", "5%", "duplicate", "5%", "corrupt", "1%"})
+				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"qdisc", "add", "dev", "lo", "parent", "1:4", "netem", "delay", "1000ms", "1000ms", "loss", "5%", "duplicate", "5%", "corrupt", "1%"})
 			})
 		})
 	})


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The netem tool creates soft locks that blocks the CPU of the node where the disruption is applied.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
