### PR TITLE
Fix chart to set deletionTimeout  value actually read by config.go

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,4 +5,4 @@
 apiVersion: v2
 name: chaos-controller
 description: Datadog Chaos Controller chart
-version: 2.6.0
+version: 2.6.1

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -60,7 +60,7 @@ data:
         clusterThreshold: {{ .Values.controller.safeMode.clusterThreshold }}
       disruptionCronEnabled: {{ .Values.controller.disruptionCronEnabled }}
       disruptionRolloutEnabled: {{ .Values.controller.disruptionRolloutEnabled }}
-      disruptionDeleteTimeout: {{ .Values.controller.disruptionDeleteTimeout }}
+      disruptionDeletionTimeout: {{ .Values.controller.disruptionDeletionTimeout }}
     injector:
       image: {{ template "chaos-controller.format-image" deepCopy .Values.global.chaos.defaultImage | merge .Values.global.oci | merge .Values.injector.image }}
       imagePullSecrets: {{ .Values.injector.image.pullSecrets }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -74,7 +74,7 @@ controller:
     ephemeralStorage: 1Gi
   disruptionCronEnabled: true
   disruptionRolloutEnabled: false
-  disruptionDeleteTimeout: 15m # The duration after which a disruption will be marked as "stuck on removal" if its removal process exceeds this duration.
+  disruptionDeletionTimeout: 15m # The duration after which a disruption will be marked as "stuck on removal" if its removal process exceeds this duration.
 
 injector:
   image:


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- In #798, I changed the values.yaml to match the key in configmap.yaml. It turns out, values.yaml was right and configmap.yaml was wrong 🤦 . I've aligned everything to match what's actually in config.go
https://github.com/DataDog/chaos-controller/blob/d7060a8799045216f1470513f14fb4382310327c/config/config.go#L45

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
