### PR TITLE
CHAOSPLT-122: refacto + fix: prevent disruption to be marked as stuck on removal after failing to find tmpfs path

### DIFF
--- a/cli/injector/disk_failure.go
+++ b/cli/injector/disk_failure.go
@@ -6,9 +6,6 @@
 package main
 
 import (
-	"errors"
-	"os"
-
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/injector"
 	"github.com/spf13/cobra"
@@ -35,11 +32,7 @@ var diskFailureCmd = &cobra.Command{
 		for _, config := range configs {
 			inj, err := injector.NewDiskFailureInjector(spec, injector.DiskFailureInjectorConfig{Config: config})
 			if err != nil {
-				if errors.Is(errors.Unwrap(err), os.ErrNotExist) {
-					log.Fatalw("error initializing the disk failure injector because given path does not exist", "error", err)
-				} else {
-					log.Fatalw("error initializing the disk failure injector", "error", err)
-				}
+				log.Fatalw("error initializing the disk failure injector", "error", err)
 			}
 
 			if inj == nil {

--- a/cli/injector/disk_pressure.go
+++ b/cli/injector/disk_pressure.go
@@ -8,6 +8,7 @@ package main
 import (
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/injector"
@@ -46,8 +47,10 @@ var diskPressureCmd = &cobra.Command{
 		for _, config := range configs {
 			inj, err := injector.NewDiskPressureInjector(spec, injector.DiskPressureInjectorConfig{Config: config})
 			if err != nil {
-				if errors.Is(errors.Unwrap(err), os.ErrNotExist) {
+				if errors.Is(errors.Unwrap(err), os.ErrNotExist) || strings.Contains(err.Error(), "No such file or directory") {
 					log.Errorw("error initializing the disk pressure injector because the given path does not exist", "error", err)
+				} else if errors.Is(errors.Unwrap(err), os.ErrPermission) {
+					log.Errorw("error initializing the disk pressure injector because the given path is not accessible", "error", err)
 				} else {
 					log.Fatalw("error initializing the disk pressure injector", "error", err)
 				}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- `fix: handle tmpfs directory for disk pressure`: Before this fix the disruption was marked as stuck on removal during the deletion process of a disruption if the target directory is a tmpfs mount. It is not possible to get the host path of a tmpfs directory because it's loaded in memory (/proc/meminfo)
- `refacto: remove useless code for disk failure`

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
