### PR TITLE
fix: avoid sending useless node failure events

### DIFF
--- a/watchers/target_pod_handler.go
+++ b/watchers/target_pod_handler.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
+	"github.com/DataDog/chaos-controller/types"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -451,7 +452,7 @@ func (d DisruptionTargetHandler) buildNodeEventsToSend(oldNode corev1.Node, newN
 		case corev1.NodeRunning:
 			eventsToSend[v1beta1.EventTargetNodeRecoveredState] = true
 		case corev1.NodePending, corev1.NodeTerminated:
-			if oldNode.Status.Phase == corev1.NodeRunning {
+			if oldNode.Status.Phase == corev1.NodeRunning && d.disruption.Spec.Level != types.DisruptionLevelNode {
 				eventsToSend[v1beta1.EventTargetNodeWarningState] = true
 			}
 		}


### PR DESCRIPTION
When a node disruption is created, no need to send node failure warning events caused by the node disruption.

## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- `x`

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
