### PR TITLE
Remove environment annotation from examples

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -64,7 +64,7 @@ controller:
     host: "" # host to use to serve requests
     port: 9443 # port to use to serve requests
   safeMode:
-    environment: lima
+    environment: ""
     enable: false
     namespaceThreshold: 80
     clusterThreshold: 66

--- a/examples/advanced_selector.yaml
+++ b/examples/advanced_selector.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: advanced-selector
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   advancedSelector: # advanced selectors can select targets on something else than an exact key/value match

--- a/examples/annotation_filter.yaml
+++ b/examples/annotation_filter.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-drop
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/complete.yaml
+++ b/examples/complete.yaml
@@ -7,9 +7,7 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: disruption-sample
-  namespace: chaos-demo # disruption resource must be in the same namespace as targeted pods
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
+  namespace: chaos-demo # disruption resource must be in the same namespace as targeted pods\
 spec:
   dryRun: false # optional, enable dry-run mode (chaos pods will be created but won't inject anything)
   reporting: # optional, add custom notification for this disruption

--- a/examples/complete.yaml
+++ b/examples/complete.yaml
@@ -7,7 +7,9 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: disruption-sample
-  namespace: chaos-demo # disruption resource must be in the same namespace as targeted pods\
+  namespace: chaos-demo # disruption resource must be in the same namespace as targeted pods
+  annotations:
+    chaos.datadoghq.com/environment: "lima"
 spec:
   dryRun: false # optional, enable dry-run mode (chaos pods will be created but won't inject anything)
   reporting: # optional, add custom notification for this disruption

--- a/examples/container_failure_all_forced.yaml
+++ b/examples/container_failure_all_forced.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: container-failure-all-forced
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   selector:
     app: demo-curl

--- a/examples/container_failure_all_graceful.yaml
+++ b/examples/container_failure_all_graceful.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: container-failure-all-graceful
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   selector:
     app: demo-curl

--- a/examples/container_failure_forced.yaml
+++ b/examples/container_failure_forced.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: container-failure-forced
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   selector:
     app: demo-curl

--- a/examples/container_failure_graceful.yaml
+++ b/examples/container_failure_graceful.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: container-failure-graceful
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   selector:
     app: demo-curl

--- a/examples/containers_targeting.yaml
+++ b/examples/containers_targeting.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: containers-targeting
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/count_percentage.yaml
+++ b/examples/count_percentage.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: count-percentage
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/cpu_level_node.yaml
+++ b/examples/cpu_level_node.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: level-node
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: node # impact the whole node instead of a single pod
   selector:

--- a/examples/cpu_pressure.yaml
+++ b/examples/cpu_pressure.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: cpu-pressure
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   duration: 5m
   selector:

--- a/examples/cpu_pressure_count.yaml
+++ b/examples/cpu_pressure_count.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: cpu-pressure
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/disk_failure.yaml
+++ b/examples/disk_failure.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: disk-failure
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/disk_pressure_read.yaml
+++ b/examples/disk_pressure_read.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: disk-pressure-read
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/disk_pressure_read_unsafemode.yaml
+++ b/examples/disk_pressure_read_unsafemode.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: disk-pressure-read
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/disk_pressure_write.yaml
+++ b/examples/disk_pressure_write.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: disk-pressure-write
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/disruption_crons/disruption_cron_network_drop.yaml
+++ b/examples/disruption_crons/disruption_cron_network_drop.yaml
@@ -8,8 +8,6 @@ kind: DisruptionCron
 metadata:
   name: network-drop
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   schedule: "*/15 * * * *"
   targetResource:

--- a/examples/disruption_rollouts/disruption_rollout_network_drop.yaml
+++ b/examples/disruption_rollouts/disruption_rollout_network_drop.yaml
@@ -8,8 +8,6 @@ kind: DisruptionRollout
 metadata:
   name: network-drop
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   targetResource:
     kind: deployment

--- a/examples/dns.yaml
+++ b/examples/dns.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: dns
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/dry_run.yaml
+++ b/examples/dry_run.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: dry-run
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   dryRun: true # enable dry-run mode (chaos pods will be created but won't inject anything)
   level: pod

--- a/examples/grpc.yaml
+++ b/examples/grpc.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: grpc
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/grpc_error.yaml
+++ b/examples/grpc_error.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: grpc-error
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/grpc_override.yaml
+++ b/examples/grpc_override.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: grpc-override
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/network_allowed_hosts.yaml
+++ b/examples/network_allowed_hosts.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-drop
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/network_bandwidth_limitation.yaml
+++ b/examples/network_bandwidth_limitation.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-bandwidth-limitation
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/network_cloud.yaml
+++ b/examples/network_cloud.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-cloud
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/network_cloud_s3.yaml
+++ b/examples/network_cloud_s3.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-cloud
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/network_corrupt.yaml
+++ b/examples/network_corrupt.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-corrupt
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/network_delay.yaml
+++ b/examples/network_delay.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-delay
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/network_delay_node.yaml
+++ b/examples/network_delay_node.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-delay-node
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: node
   selector:

--- a/examples/network_drop.yaml
+++ b/examples/network_drop.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-drop
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/network_duplication.yaml
+++ b/examples/network_duplication.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-duplication
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   selector:
     app: demo-curl

--- a/examples/network_filter_connstate.yaml
+++ b/examples/network_filter_connstate.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-filter-connstate
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/network_filter_http.yaml
+++ b/examples/network_filter_http.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-drop
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/network_filter_service.yaml
+++ b/examples/network_filter_service.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-filter-service
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/network_ingress.yaml
+++ b/examples/network_ingress.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-ingress
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/node_failure.yaml
+++ b/examples/node_failure.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: node-failure
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: node # selector targets nodes instead of pods. Targeting a pod will impact the node hosting given pod.
   selector:

--- a/examples/node_failure_shutdown.yaml
+++ b/examples/node_failure_shutdown.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: node-failure-shutdown
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: node # selector targets nodes instead of pods. Targeting a pod will impact the node hosting given pod.
   selector:

--- a/examples/on_init.yaml
+++ b/examples/on_init.yaml
@@ -7,8 +7,6 @@ apiVersion: chaos.datadoghq.com/v1beta1
 kind: Disruption
 metadata:
   name: on-init
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   onInit: true # apply the disruption on pod initialization (it requires the pod to target to be redeployed with the chaos.datadoghq.com/disrupt-on-init label to be held in the pending state)
   level: pod

--- a/examples/pulse.yaml
+++ b/examples/pulse.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: pulse
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/reporting_network_drop.yaml
+++ b/examples/reporting_network_drop.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: reporting-network-drop
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   reporting: # optional, add custom notification for this disruption
     slackChannel: team-slack-channel # required, custom slack channel to send notifications to (can be a name or slack channel ID)

--- a/examples/static_targeting.yaml
+++ b/examples/static_targeting.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: network-duplication-static-targeting
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   selector:
     app: demo-curl

--- a/examples/timed_disruption.yaml
+++ b/examples/timed_disruption.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: timed-network-drop
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:

--- a/examples/triggers.yaml
+++ b/examples/triggers.yaml
@@ -8,8 +8,6 @@ kind: Disruption
 metadata:
   name: delayed-network-drop
   namespace: chaos-demo
-  annotations:
-    chaos.datadoghq.com/environment: "lima"
 spec:
   level: pod
   selector:


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Removes all of the safemode environment annotations from the examples
- Removes the requirement to use the safemode annotations in lima
- We've had many, many users who, quite naturally, build their disruptions by looking at examples, rather than reading any of the docs. They end up not knowing what this env annotation is for, and set it incorrectly. In environments where it is actually mandatory, the webhook rejection message explains how to use it, so we don't need to explicitly include it in the examples like this. It's only been doing more UX harm than good

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
