### PR TITLE
CHAOSPLT-179: fix - use custom logger for libbpf

### DIFF
--- a/ebpf/disk-failure/main.go
+++ b/ebpf/disk-failure/main.go
@@ -39,6 +39,21 @@ func main() {
 	logger, err = log.NewZapLogger()
 	must(err)
 
+	bpf.SetLoggerCbs(bpf.Callbacks{
+		Log: func(level int, msg string) {
+			switch level {
+			case bpf.LibbpfDebugLevel:
+				logger.Debug(msg)
+			case bpf.LibbpfInfoLevel:
+				logger.Info(msg)
+			case bpf.LibbpfWarnLevel:
+				logger.Warn(msg)
+			default:
+				logger.Error(msg)
+			}
+		},
+	})
+
 	// Create the bpf module
 	bpfModule, err := bpf.NewModuleFromFile("/usr/local/bin/bpf-disk-failure.bpf.o")
 	must(err)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The `libbpf` library used by `libbpgo` print text to the `stderr/stdout`. To log properly the **output** of `libbpf` we set our own **logger** to force `libbpf` to use it.

> Before

``` json
libbpf: loading /usr/local/bin/bpf-disk-failure.bpf.o
libbpf: elf: section(3) kprobe/sys_openat, size 1312, link 0, flags 6, type=1
libbpf: sec 'kprobe/sys_openat': found program 'injection_disk_failure' at insn offset 0 (0 bytes), code size 164 insns (1312 bytes)
libbpf: elf: section(4) .relkprobe/sys_openat, size 176, link 29, flags 40, type=9
libbpf: elf: section(5) license, size 13, link 0, flags 3, type=1
libbpf: license of /usr/local/bin/bpf-disk-failure.bpf.o is Dual BSD/GPL
libbpf: elf: section(6) .rodata, size 77, link 0, flags 2, type=1
```

> After

``` json
{"level":"debug","ts":1699978953556.7654,"caller":"disk-failure/main.go:48","message":"libbpf: loading /usr/local/bin/bpf-disk-failure.bpf.o\n"}
{"level":"debug","ts":1699978953556.908,"caller":"disk-failure/main.go:48","message":"libbpf: elf: section(3) kprobe/sys_openat, size 1312, link 0, flags 6, type=1\n"}
{"level":"debug","ts":1699978953556.9219,"caller":"disk-failure/main.go:48","message":"libbpf: sec 'kprobe/sys_openat': found program 'injection_disk_failure' at insn offset 0 (0 bytes), code size 164 insns (1312 bytes)\n"}
{"level":"debug","ts":1699978953556.9436,"caller":"disk-failure/main.go:48","message":"libbpf: elf: section(4) .relkprobe/sys_openat, size 176, link 29, flags 40, type=9\n"}
{"level":"debug","ts":1699978953556.9526,"caller":"disk-failure/main.go:48","message":"libbpf: elf: section(5) license, size 13, link 0, flags 3, type=1\n"}
{"level":"debug","ts":1699978953556.9573,"caller":"disk-failure/main.go:48","message":"libbpf: license of /usr/local/bin/bpf-disk-failure.bpf.o is Dual BSD/GPL\n"}
{"level":"debug","ts":1699978953556.9688,"caller":"disk-failure/main.go:48","message":"libbpf: elf: section(6) .rodata, size 77, link 0, flags 2, type=1\n"}
```


## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
