### PR TITLE
fix: updateTargetInjectionStatus handle nil maps

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -705,6 +705,14 @@ func (r *DisruptionReconciler) handleChaosPodTermination(ctx context.Context, in
 }
 
 func (r *DisruptionReconciler) updateTargetInjectionStatus(instance *chaosv1beta1.Disruption, chaosPod corev1.Pod, status chaostypes.DisruptionTargetInjectionStatus, since metav1.Time) {
+	if instance.Status.TargetInjections == nil {
+		instance.Status.TargetInjections = make(chaosv1beta1.TargetInjections)
+	}
+
+	if instance.Status.TargetInjections[chaosPod.Labels[chaostypes.TargetLabel]] == nil {
+		instance.Status.TargetInjections[chaosPod.Labels[chaostypes.TargetLabel]] = make(chaosv1beta1.TargetInjectorMap)
+	}
+
 	disruptionKindName := chaostypes.DisruptionKindName(chaosPod.Labels[chaostypes.DisruptionKindLabel])
 
 	instance.Status.TargetInjections[chaosPod.Labels[chaostypes.TargetLabel]][disruptionKindName] = chaosv1beta1.TargetInjection{


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The update of injection status returns an error on huge disruption. Handle nil map and init them. 

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
