### PR TITLE
upgrade: mockery v2.38.0

### DIFF
--- a/.local.mockery.yaml
+++ b/.local.mockery.yaml
@@ -1,5 +1,4 @@
 all: True
-case: underscore
 dir: "{{.InterfaceDir}}"
 inpackage: True
 disable-version-string: True

--- a/.vendor.mockery.yaml
+++ b/.vendor.mockery.yaml
@@ -1,5 +1,4 @@
 all: False
-case: underscore
 disable-version-string: True
 filename: "{{.InterfaceNameSnake}}.go"
 mockname: "{{.InterfaceName}}Mock"

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ GOLANGCI_LINT_INSTALLED_VERSION = $(shell (golangci-lint --version || echo "") |
 CONTROLLER_GEN_VERSION = v0.12.0
 CONTROLLER_GEN_INSTALLED_VERSION = $(shell (controller-gen --version || echo "") | awk '{ print $$2 }')
 
-MOCKERY_VERSION = 2.28.2
+MOCKERY_VERSION = 2.38.0
 MOCKERY_INSTALLED_VERSION = $(shell mockery --version --quiet --config="" 2>/dev/null || echo "")
 
 # Additional args to provide to test runner (ginkgo)

--- a/api/disruption_kind_mock.go
+++ b/api/disruption_kind_mock.go
@@ -25,6 +25,10 @@ func (_m *DisruptionKindMock) EXPECT() *DisruptionKindMock_Expecter {
 func (_m *DisruptionKindMock) GenerateArgs() []string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GenerateArgs")
+	}
+
 	var r0 []string
 	if rf, ok := ret.Get(0).(func() []string); ok {
 		r0 = rf()
@@ -68,6 +72,10 @@ func (_c *DisruptionKindMock_GenerateArgs_Call) RunAndReturn(run func() []string
 func (_m *DisruptionKindMock) Validate() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Validate")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -105,13 +113,12 @@ func (_c *DisruptionKindMock_Validate_Call) RunAndReturn(run func() error) *Disr
 	return _c
 }
 
-type mockConstructorTestingTNewDisruptionKindMock interface {
+// NewDisruptionKindMock creates a new instance of DisruptionKindMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewDisruptionKindMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewDisruptionKindMock creates a new instance of DisruptionKindMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewDisruptionKindMock(t mockConstructorTestingTNewDisruptionKindMock) *DisruptionKindMock {
+}) *DisruptionKindMock {
 	mock := &DisruptionKindMock{}
 	mock.Mock.Test(t)
 

--- a/cgroup/all_c_group_manager_mock.go
+++ b/cgroup/all_c_group_manager_mock.go
@@ -25,6 +25,10 @@ func (_m *allCGroupManagerMock) EXPECT() *allCGroupManagerMock_Expecter {
 func (_m *allCGroupManagerMock) EnterPid(cgroupPaths map[string]string, pid int) error {
 	ret := _m.Called(cgroupPaths, pid)
 
+	if len(ret) == 0 {
+		panic("no return value specified for EnterPid")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(map[string]string, int) error); ok {
 		r0 = rf(cgroupPaths, pid)
@@ -67,6 +71,10 @@ func (_c *allCGroupManagerMock_EnterPid_Call) RunAndReturn(run func(map[string]s
 // GetPaths provides a mock function with given fields:
 func (_m *allCGroupManagerMock) GetPaths() map[string]string {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPaths")
+	}
 
 	var r0 map[string]string
 	if rf, ok := ret.Get(0).(func() map[string]string); ok {
@@ -111,6 +119,10 @@ func (_c *allCGroupManagerMock_GetPaths_Call) RunAndReturn(run func() map[string
 func (_m *allCGroupManagerMock) Path(_a0 string) string {
 	ret := _m.Called(_a0)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Path")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func(string) string); ok {
 		r0 = rf(_a0)
@@ -153,6 +165,10 @@ func (_c *allCGroupManagerMock_Path_Call) RunAndReturn(run func(string) string) 
 func (_m *allCGroupManagerMock) PathExists(path string) bool {
 	ret := _m.Called(path)
 
+	if len(ret) == 0 {
+		panic("no return value specified for PathExists")
+	}
+
 	var r0 bool
 	if rf, ok := ret.Get(0).(func(string) bool); ok {
 		r0 = rf(path)
@@ -194,6 +210,10 @@ func (_c *allCGroupManagerMock_PathExists_Call) RunAndReturn(run func(string) bo
 // ReadFile provides a mock function with given fields: dir, file
 func (_m *allCGroupManagerMock) ReadFile(dir string, file string) (string, error) {
 	ret := _m.Called(dir, file)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReadFile")
+	}
 
 	var r0 string
 	var r1 error
@@ -248,6 +268,10 @@ func (_c *allCGroupManagerMock_ReadFile_Call) RunAndReturn(run func(string, stri
 func (_m *allCGroupManagerMock) WriteFile(dir string, file string, data string) error {
 	ret := _m.Called(dir, file, data)
 
+	if len(ret) == 0 {
+		panic("no return value specified for WriteFile")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
 		r0 = rf(dir, file, data)
@@ -288,13 +312,12 @@ func (_c *allCGroupManagerMock_WriteFile_Call) RunAndReturn(run func(string, str
 	return _c
 }
 
-type mockConstructorTestingTnewAllCGroupManagerMock interface {
+// newAllCGroupManagerMock creates a new instance of allCGroupManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func newAllCGroupManagerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// newAllCGroupManagerMock creates a new instance of allCGroupManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func newAllCGroupManagerMock(t mockConstructorTestingTnewAllCGroupManagerMock) *allCGroupManagerMock {
+}) *allCGroupManagerMock {
 	mock := &allCGroupManagerMock{}
 	mock.Mock.Test(t)
 

--- a/cgroup/inst_c_group_manager_mock.go
+++ b/cgroup/inst_c_group_manager_mock.go
@@ -25,6 +25,10 @@ func (_m *instCGroupManagerMock) EXPECT() *instCGroupManagerMock_Expecter {
 func (_m *instCGroupManagerMock) GetPaths() map[string]string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetPaths")
+	}
+
 	var r0 map[string]string
 	if rf, ok := ret.Get(0).(func() map[string]string); ok {
 		r0 = rf()
@@ -68,6 +72,10 @@ func (_c *instCGroupManagerMock_GetPaths_Call) RunAndReturn(run func() map[strin
 func (_m *instCGroupManagerMock) Path(_a0 string) string {
 	ret := _m.Called(_a0)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Path")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func(string) string); ok {
 		r0 = rf(_a0)
@@ -106,13 +114,12 @@ func (_c *instCGroupManagerMock_Path_Call) RunAndReturn(run func(string) string)
 	return _c
 }
 
-type mockConstructorTestingTnewInstCGroupManagerMock interface {
+// newInstCGroupManagerMock creates a new instance of instCGroupManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func newInstCGroupManagerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// newInstCGroupManagerMock creates a new instance of instCGroupManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func newInstCGroupManagerMock(t mockConstructorTestingTnewInstCGroupManagerMock) *instCGroupManagerMock {
+}) *instCGroupManagerMock {
 	mock := &instCGroupManagerMock{}
 	mock.Mock.Test(t)
 

--- a/cgroup/manager_mock.go
+++ b/cgroup/manager_mock.go
@@ -28,6 +28,10 @@ func (_m *ManagerMock) EXPECT() *ManagerMock_Expecter {
 func (_m *ManagerMock) IsCgroupV2() bool {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for IsCgroupV2")
+	}
+
 	var r0 bool
 	if rf, ok := ret.Get(0).(func() bool); ok {
 		r0 = rf()
@@ -68,6 +72,10 @@ func (_c *ManagerMock_IsCgroupV2_Call) RunAndReturn(run func() bool) *ManagerMoc
 // Join provides a mock function with given fields: pid
 func (_m *ManagerMock) Join(pid int) error {
 	ret := _m.Called(pid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Join")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(int) error); ok {
@@ -110,6 +118,10 @@ func (_c *ManagerMock_Join_Call) RunAndReturn(run func(int) error) *ManagerMock_
 // Read provides a mock function with given fields: controller, file
 func (_m *ManagerMock) Read(controller string, file string) (string, error) {
 	ret := _m.Called(controller, file)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Read")
+	}
 
 	var r0 string
 	var r1 error
@@ -164,6 +176,10 @@ func (_c *ManagerMock_Read_Call) RunAndReturn(run func(string, string) (string, 
 func (_m *ManagerMock) ReadCPUSet() (cpuset.CPUSet, error) {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for ReadCPUSet")
+	}
+
 	var r0 cpuset.CPUSet
 	var r1 error
 	if rf, ok := ret.Get(0).(func() (cpuset.CPUSet, error)); ok {
@@ -215,6 +231,10 @@ func (_c *ManagerMock_ReadCPUSet_Call) RunAndReturn(run func() (cpuset.CPUSet, e
 func (_m *ManagerMock) RelativePath(controller string) string {
 	ret := _m.Called(controller)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RelativePath")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func(string) string); ok {
 		r0 = rf(controller)
@@ -257,6 +277,10 @@ func (_c *ManagerMock_RelativePath_Call) RunAndReturn(run func(string) string) *
 func (_m *ManagerMock) Write(controller string, file string, data string) error {
 	ret := _m.Called(controller, file, data)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Write")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
 		r0 = rf(controller, file, data)
@@ -297,13 +321,12 @@ func (_c *ManagerMock_Write_Call) RunAndReturn(run func(string, string, string) 
 	return _c
 }
 
-type mockConstructorTestingTNewManagerMock interface {
+// NewManagerMock creates a new instance of ManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewManagerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewManagerMock creates a new instance of ManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewManagerMock(t mockConstructorTestingTNewManagerMock) *ManagerMock {
+}) *ManagerMock {
 	mock := &ManagerMock{}
 	mock.Mock.Test(t)
 

--- a/cgroup/pkg_c_group_manager_mock.go
+++ b/cgroup/pkg_c_group_manager_mock.go
@@ -25,6 +25,10 @@ func (_m *pkgCGroupManagerMock) EXPECT() *pkgCGroupManagerMock_Expecter {
 func (_m *pkgCGroupManagerMock) EnterPid(cgroupPaths map[string]string, pid int) error {
 	ret := _m.Called(cgroupPaths, pid)
 
+	if len(ret) == 0 {
+		panic("no return value specified for EnterPid")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(map[string]string, int) error); ok {
 		r0 = rf(cgroupPaths, pid)
@@ -68,6 +72,10 @@ func (_c *pkgCGroupManagerMock_EnterPid_Call) RunAndReturn(run func(map[string]s
 func (_m *pkgCGroupManagerMock) PathExists(path string) bool {
 	ret := _m.Called(path)
 
+	if len(ret) == 0 {
+		panic("no return value specified for PathExists")
+	}
+
 	var r0 bool
 	if rf, ok := ret.Get(0).(func(string) bool); ok {
 		r0 = rf(path)
@@ -109,6 +117,10 @@ func (_c *pkgCGroupManagerMock_PathExists_Call) RunAndReturn(run func(string) bo
 // ReadFile provides a mock function with given fields: dir, file
 func (_m *pkgCGroupManagerMock) ReadFile(dir string, file string) (string, error) {
 	ret := _m.Called(dir, file)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReadFile")
+	}
 
 	var r0 string
 	var r1 error
@@ -163,6 +175,10 @@ func (_c *pkgCGroupManagerMock_ReadFile_Call) RunAndReturn(run func(string, stri
 func (_m *pkgCGroupManagerMock) WriteFile(dir string, file string, data string) error {
 	ret := _m.Called(dir, file, data)
 
+	if len(ret) == 0 {
+		panic("no return value specified for WriteFile")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
 		r0 = rf(dir, file, data)
@@ -203,13 +219,12 @@ func (_c *pkgCGroupManagerMock_WriteFile_Call) RunAndReturn(run func(string, str
 	return _c
 }
 
-type mockConstructorTestingTnewPkgCGroupManagerMock interface {
+// newPkgCGroupManagerMock creates a new instance of pkgCGroupManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func newPkgCGroupManagerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// newPkgCGroupManagerMock creates a new instance of pkgCGroupManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func newPkgCGroupManagerMock(t mockConstructorTestingTnewPkgCGroupManagerMock) *pkgCGroupManagerMock {
+}) *pkgCGroupManagerMock {
 	mock := &pkgCGroupManagerMock{}
 	mock.Mock.Test(t)
 

--- a/clientset/v1beta1/disruption_interface_mock.go
+++ b/clientset/v1beta1/disruption_interface_mock.go
@@ -35,6 +35,10 @@ func (_m *DisruptionInterfaceMock) EXPECT() *DisruptionInterfaceMock_Expecter {
 func (_m *DisruptionInterfaceMock) Create(ctx context.Context, disruption *apiv1beta1.Disruption) (*apiv1beta1.Disruption, error) {
 	ret := _m.Called(ctx, disruption)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Create")
+	}
+
 	var r0 *apiv1beta1.Disruption
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *apiv1beta1.Disruption) (*apiv1beta1.Disruption, error)); ok {
@@ -90,6 +94,10 @@ func (_c *DisruptionInterfaceMock_Create_Call) RunAndReturn(run func(context.Con
 func (_m *DisruptionInterfaceMock) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	ret := _m.Called(ctx, name, opts)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, v1.DeleteOptions) error); ok {
 		r0 = rf(ctx, name, opts)
@@ -133,6 +141,10 @@ func (_c *DisruptionInterfaceMock_Delete_Call) RunAndReturn(run func(context.Con
 // Get provides a mock function with given fields: ctx, name, opts
 func (_m *DisruptionInterfaceMock) Get(ctx context.Context, name string, opts v1.GetOptions) (*apiv1beta1.Disruption, error) {
 	ret := _m.Called(ctx, name, opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
 
 	var r0 *apiv1beta1.Disruption
 	var r1 error
@@ -190,6 +202,10 @@ func (_c *DisruptionInterfaceMock_Get_Call) RunAndReturn(run func(context.Contex
 func (_m *DisruptionInterfaceMock) List(ctx context.Context, opts v1.ListOptions) (*apiv1beta1.DisruptionList, error) {
 	ret := _m.Called(ctx, opts)
 
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
+
 	var r0 *apiv1beta1.DisruptionList
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, v1.ListOptions) (*apiv1beta1.DisruptionList, error)); ok {
@@ -245,6 +261,10 @@ func (_c *DisruptionInterfaceMock_List_Call) RunAndReturn(run func(context.Conte
 func (_m *DisruptionInterfaceMock) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	ret := _m.Called(ctx, opts)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Watch")
+	}
+
 	var r0 watch.Interface
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, v1.ListOptions) (watch.Interface, error)); ok {
@@ -296,13 +316,12 @@ func (_c *DisruptionInterfaceMock_Watch_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-type mockConstructorTestingTNewDisruptionInterfaceMock interface {
+// NewDisruptionInterfaceMock creates a new instance of DisruptionInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewDisruptionInterfaceMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewDisruptionInterfaceMock creates a new instance of DisruptionInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewDisruptionInterfaceMock(t mockConstructorTestingTNewDisruptionInterfaceMock) *DisruptionInterfaceMock {
+}) *DisruptionInterfaceMock {
 	mock := &DisruptionInterfaceMock{}
 	mock.Mock.Test(t)
 

--- a/clientset/v1beta1/disruption_v_1_beta_1_interface_mock.go
+++ b/clientset/v1beta1/disruption_v_1_beta_1_interface_mock.go
@@ -25,6 +25,10 @@ func (_m *DisruptionV1Beta1InterfaceMock) EXPECT() *DisruptionV1Beta1InterfaceMo
 func (_m *DisruptionV1Beta1InterfaceMock) Disruptions(namespace string) DisruptionInterface {
 	ret := _m.Called(namespace)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Disruptions")
+	}
+
 	var r0 DisruptionInterface
 	if rf, ok := ret.Get(0).(func(string) DisruptionInterface); ok {
 		r0 = rf(namespace)
@@ -65,13 +69,12 @@ func (_c *DisruptionV1Beta1InterfaceMock_Disruptions_Call) RunAndReturn(run func
 	return _c
 }
 
-type mockConstructorTestingTNewDisruptionV1Beta1InterfaceMock interface {
+// NewDisruptionV1Beta1InterfaceMock creates a new instance of DisruptionV1Beta1InterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewDisruptionV1Beta1InterfaceMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewDisruptionV1Beta1InterfaceMock creates a new instance of DisruptionV1Beta1InterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewDisruptionV1Beta1InterfaceMock(t mockConstructorTestingTNewDisruptionV1Beta1InterfaceMock) *DisruptionV1Beta1InterfaceMock {
+}) *DisruptionV1Beta1InterfaceMock {
 	mock := &DisruptionV1Beta1InterfaceMock{}
 	mock.Mock.Test(t)
 

--- a/cloudservice/cloud_provider_ip_range_manager_mock.go
+++ b/cloudservice/cloud_provider_ip_range_manager_mock.go
@@ -28,6 +28,10 @@ func (_m *CloudProviderIPRangeManagerMock) EXPECT() *CloudProviderIPRangeManager
 func (_m *CloudProviderIPRangeManagerMock) ConvertToGenericIPRanges(ipRangeData []byte) (*types.CloudProviderIPRangeInfo, error) {
 	ret := _m.Called(ipRangeData)
 
+	if len(ret) == 0 {
+		panic("no return value specified for ConvertToGenericIPRanges")
+	}
+
 	var r0 *types.CloudProviderIPRangeInfo
 	var r1 error
 	if rf, ok := ret.Get(0).(func([]byte) (*types.CloudProviderIPRangeInfo, error)); ok {
@@ -82,6 +86,10 @@ func (_c *CloudProviderIPRangeManagerMock_ConvertToGenericIPRanges_Call) RunAndR
 func (_m *CloudProviderIPRangeManagerMock) IsNewVersion(ipRangeData []byte, version string) (bool, error) {
 	ret := _m.Called(ipRangeData, version)
 
+	if len(ret) == 0 {
+		panic("no return value specified for IsNewVersion")
+	}
+
 	var r0 bool
 	var r1 error
 	if rf, ok := ret.Get(0).(func([]byte, string) (bool, error)); ok {
@@ -131,13 +139,12 @@ func (_c *CloudProviderIPRangeManagerMock_IsNewVersion_Call) RunAndReturn(run fu
 	return _c
 }
 
-type mockConstructorTestingTNewCloudProviderIPRangeManagerMock interface {
+// NewCloudProviderIPRangeManagerMock creates a new instance of CloudProviderIPRangeManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewCloudProviderIPRangeManagerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewCloudProviderIPRangeManagerMock creates a new instance of CloudProviderIPRangeManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewCloudProviderIPRangeManagerMock(t mockConstructorTestingTNewCloudProviderIPRangeManagerMock) *CloudProviderIPRangeManagerMock {
+}) *CloudProviderIPRangeManagerMock {
 	mock := &CloudProviderIPRangeManagerMock{}
 	mock.Mock.Test(t)
 

--- a/cloudservice/cloud_services_providers_manager_mock.go
+++ b/cloudservice/cloud_services_providers_manager_mock.go
@@ -28,6 +28,10 @@ func (_m *CloudServicesProvidersManagerMock) EXPECT() *CloudServicesProvidersMan
 func (_m *CloudServicesProvidersManagerMock) GetProviderByName(name types.CloudProviderName) *CloudServicesProvider {
 	ret := _m.Called(name)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetProviderByName")
+	}
+
 	var r0 *CloudServicesProvider
 	if rf, ok := ret.Get(0).(func(types.CloudProviderName) *CloudServicesProvider); ok {
 		r0 = rf(name)
@@ -72,6 +76,10 @@ func (_c *CloudServicesProvidersManagerMock_GetProviderByName_Call) RunAndReturn
 func (_m *CloudServicesProvidersManagerMock) GetServiceList(cloudProviderName types.CloudProviderName) []string {
 	ret := _m.Called(cloudProviderName)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetServiceList")
+	}
+
 	var r0 []string
 	if rf, ok := ret.Get(0).(func(types.CloudProviderName) []string); ok {
 		r0 = rf(cloudProviderName)
@@ -115,6 +123,10 @@ func (_c *CloudServicesProvidersManagerMock_GetServiceList_Call) RunAndReturn(ru
 // GetServicesIPRanges provides a mock function with given fields: cloudProviderName, serviceNames
 func (_m *CloudServicesProvidersManagerMock) GetServicesIPRanges(cloudProviderName types.CloudProviderName, serviceNames []string) (map[string][]string, error) {
 	ret := _m.Called(cloudProviderName, serviceNames)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetServicesIPRanges")
+	}
 
 	var r0 map[string][]string
 	var r1 error
@@ -170,6 +182,10 @@ func (_c *CloudServicesProvidersManagerMock_GetServicesIPRanges_Call) RunAndRetu
 // PullIPRanges provides a mock function with given fields:
 func (_m *CloudServicesProvidersManagerMock) PullIPRanges() error {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for PullIPRanges")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
@@ -272,13 +288,12 @@ func (_c *CloudServicesProvidersManagerMock_StopPeriodicPull_Call) RunAndReturn(
 	return _c
 }
 
-type mockConstructorTestingTNewCloudServicesProvidersManagerMock interface {
+// NewCloudServicesProvidersManagerMock creates a new instance of CloudServicesProvidersManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewCloudServicesProvidersManagerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewCloudServicesProvidersManagerMock creates a new instance of CloudServicesProvidersManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewCloudServicesProvidersManagerMock(t mockConstructorTestingTNewCloudServicesProvidersManagerMock) *CloudServicesProvidersManagerMock {
+}) *CloudServicesProvidersManagerMock {
 	mock := &CloudServicesProvidersManagerMock{}
 	mock.Mock.Test(t)
 

--- a/command/background_cmd_mock.go
+++ b/command/background_cmd_mock.go
@@ -25,6 +25,10 @@ func (_m *BackgroundCmdMock) EXPECT() *BackgroundCmdMock_Expecter {
 func (_m *BackgroundCmdMock) DryRun() bool {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for DryRun")
+	}
+
 	var r0 bool
 	if rf, ok := ret.Get(0).(func() bool); ok {
 		r0 = rf()
@@ -98,6 +102,10 @@ func (_c *BackgroundCmdMock_KeepAlive_Call) RunAndReturn(run func()) *Background
 func (_m *BackgroundCmdMock) Start() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Start")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -139,6 +147,10 @@ func (_c *BackgroundCmdMock_Start_Call) RunAndReturn(run func() error) *Backgrou
 func (_m *BackgroundCmdMock) Stop() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Stop")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -176,13 +188,12 @@ func (_c *BackgroundCmdMock_Stop_Call) RunAndReturn(run func() error) *Backgroun
 	return _c
 }
 
-type mockConstructorTestingTNewBackgroundCmdMock interface {
+// NewBackgroundCmdMock creates a new instance of BackgroundCmdMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewBackgroundCmdMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewBackgroundCmdMock creates a new instance of BackgroundCmdMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewBackgroundCmdMock(t mockConstructorTestingTNewBackgroundCmdMock) *BackgroundCmdMock {
+}) *BackgroundCmdMock {
 	mock := &BackgroundCmdMock{}
 	mock.Mock.Test(t)
 

--- a/command/cmd_mock.go
+++ b/command/cmd_mock.go
@@ -25,6 +25,10 @@ func (_m *CmdMock) EXPECT() *CmdMock_Expecter {
 func (_m *CmdMock) DryRun() bool {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for DryRun")
+	}
+
 	var r0 bool
 	if rf, ok := ret.Get(0).(func() bool); ok {
 		r0 = rf()
@@ -65,6 +69,10 @@ func (_c *CmdMock_DryRun_Call) RunAndReturn(run func() bool) *CmdMock_DryRun_Cal
 // ExitCode provides a mock function with given fields:
 func (_m *CmdMock) ExitCode() int {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExitCode")
+	}
 
 	var r0 int
 	if rf, ok := ret.Get(0).(func() int); ok {
@@ -107,6 +115,10 @@ func (_c *CmdMock_ExitCode_Call) RunAndReturn(run func() int) *CmdMock_ExitCode_
 func (_m *CmdMock) PID() int {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for PID")
+	}
+
 	var r0 int
 	if rf, ok := ret.Get(0).(func() int); ok {
 		r0 = rf()
@@ -147,6 +159,10 @@ func (_c *CmdMock_PID_Call) RunAndReturn(run func() int) *CmdMock_PID_Call {
 // Start provides a mock function with given fields:
 func (_m *CmdMock) Start() error {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Start")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
@@ -189,6 +205,10 @@ func (_c *CmdMock_Start_Call) RunAndReturn(run func() error) *CmdMock_Start_Call
 func (_m *CmdMock) String() string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for String")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
@@ -230,6 +250,10 @@ func (_c *CmdMock_String_Call) RunAndReturn(run func() string) *CmdMock_String_C
 func (_m *CmdMock) Wait() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Wait")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -267,13 +291,12 @@ func (_c *CmdMock_Wait_Call) RunAndReturn(run func() error) *CmdMock_Wait_Call {
 	return _c
 }
 
-type mockConstructorTestingTNewCmdMock interface {
+// NewCmdMock creates a new instance of CmdMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewCmdMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewCmdMock creates a new instance of CmdMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewCmdMock(t mockConstructorTestingTNewCmdMock) *CmdMock {
+}) *CmdMock {
 	mock := &CmdMock{}
 	mock.Mock.Test(t)
 

--- a/command/factory_mock.go
+++ b/command/factory_mock.go
@@ -29,6 +29,10 @@ func (_m *FactoryMock) EXPECT() *FactoryMock_Expecter {
 func (_m *FactoryMock) NewCmd(ctx context.Context, name string, args []string) Cmd {
 	ret := _m.Called(ctx, name, args)
 
+	if len(ret) == 0 {
+		panic("no return value specified for NewCmd")
+	}
+
 	var r0 Cmd
 	if rf, ok := ret.Get(0).(func(context.Context, string, []string) Cmd); ok {
 		r0 = rf(ctx, name, args)
@@ -71,13 +75,12 @@ func (_c *FactoryMock_NewCmd_Call) RunAndReturn(run func(context.Context, string
 	return _c
 }
 
-type mockConstructorTestingTNewFactoryMock interface {
+// NewFactoryMock creates a new instance of FactoryMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewFactoryMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewFactoryMock creates a new instance of FactoryMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewFactoryMock(t mockConstructorTestingTNewFactoryMock) *FactoryMock {
+}) *FactoryMock {
 	mock := &FactoryMock{}
 	mock.Mock.Test(t)
 

--- a/container/container_mock.go
+++ b/container/container_mock.go
@@ -25,6 +25,10 @@ func (_m *ContainerMock) EXPECT() *ContainerMock_Expecter {
 func (_m *ContainerMock) ID() string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for ID")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
@@ -65,6 +69,10 @@ func (_c *ContainerMock_ID_Call) RunAndReturn(run func() string) *ContainerMock_
 // Name provides a mock function with given fields:
 func (_m *ContainerMock) Name() string {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Name")
+	}
 
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
@@ -107,6 +115,10 @@ func (_c *ContainerMock_Name_Call) RunAndReturn(run func() string) *ContainerMoc
 func (_m *ContainerMock) PID() uint32 {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for PID")
+	}
+
 	var r0 uint32
 	if rf, ok := ret.Get(0).(func() uint32); ok {
 		r0 = rf()
@@ -148,6 +160,10 @@ func (_c *ContainerMock_PID_Call) RunAndReturn(run func() uint32) *ContainerMock
 func (_m *ContainerMock) Runtime() Runtime {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Runtime")
+	}
+
 	var r0 Runtime
 	if rf, ok := ret.Get(0).(func() Runtime); ok {
 		r0 = rf()
@@ -187,13 +203,12 @@ func (_c *ContainerMock_Runtime_Call) RunAndReturn(run func() Runtime) *Containe
 	return _c
 }
 
-type mockConstructorTestingTNewContainerMock interface {
+// NewContainerMock creates a new instance of ContainerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewContainerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewContainerMock creates a new instance of ContainerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewContainerMock(t mockConstructorTestingTNewContainerMock) *ContainerMock {
+}) *ContainerMock {
 	mock := &ContainerMock{}
 	mock.Mock.Test(t)
 

--- a/container/runtime_mock.go
+++ b/container/runtime_mock.go
@@ -25,6 +25,10 @@ func (_m *RuntimeMock) EXPECT() *RuntimeMock_Expecter {
 func (_m *RuntimeMock) HostPath(id string, path string) (string, error) {
 	ret := _m.Called(id, path)
 
+	if len(ret) == 0 {
+		panic("no return value specified for HostPath")
+	}
+
 	var r0 string
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string, string) (string, error)); ok {
@@ -78,6 +82,10 @@ func (_c *RuntimeMock_HostPath_Call) RunAndReturn(run func(string, string) (stri
 func (_m *RuntimeMock) PID(id string) (uint32, error) {
 	ret := _m.Called(id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for PID")
+	}
+
 	var r0 uint32
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) (uint32, error)); ok {
@@ -126,13 +134,12 @@ func (_c *RuntimeMock_PID_Call) RunAndReturn(run func(string) (uint32, error)) *
 	return _c
 }
 
-type mockConstructorTestingTNewRuntimeMock interface {
+// NewRuntimeMock creates a new instance of RuntimeMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewRuntimeMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewRuntimeMock creates a new instance of RuntimeMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewRuntimeMock(t mockConstructorTestingTNewRuntimeMock) *RuntimeMock {
+}) *RuntimeMock {
 	mock := &RuntimeMock{}
 	mock.Mock.Test(t)
 

--- a/ddmark/client_mock.go
+++ b/ddmark/client_mock.go
@@ -28,6 +28,10 @@ func (_m *ClientMock) EXPECT() *ClientMock_Expecter {
 func (_m *ClientMock) CleanupLibraries() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for CleanupLibraries")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -68,6 +72,10 @@ func (_c *ClientMock_CleanupLibraries_Call) RunAndReturn(run func() error) *Clie
 // ValidateStruct provides a mock function with given fields: marshalledStruct, filePath
 func (_m *ClientMock) ValidateStruct(marshalledStruct interface{}, filePath string) []error {
 	ret := _m.Called(marshalledStruct, filePath)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateStruct")
+	}
 
 	var r0 []error
 	if rf, ok := ret.Get(0).(func(interface{}, string) []error); ok {
@@ -114,6 +122,10 @@ func (_c *ClientMock_ValidateStruct_Call) RunAndReturn(run func(interface{}, str
 func (_m *ClientMock) ValidateStructMultierror(marshalledStruct interface{}, filePath string) *multierror.Error {
 	ret := _m.Called(marshalledStruct, filePath)
 
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateStructMultierror")
+	}
+
 	var r0 *multierror.Error
 	if rf, ok := ret.Get(0).(func(interface{}, string) *multierror.Error); ok {
 		r0 = rf(marshalledStruct, filePath)
@@ -155,13 +167,12 @@ func (_c *ClientMock_ValidateStructMultierror_Call) RunAndReturn(run func(interf
 	return _c
 }
 
-type mockConstructorTestingTNewClientMock interface {
+// NewClientMock creates a new instance of ClientMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewClientMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewClientMock creates a new instance of ClientMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewClientMock(t mockConstructorTestingTNewClientMock) *ClientMock {
+}) *ClientMock {
 	mock := &ClientMock{}
 	mock.Mock.Test(t)
 

--- a/ddmark/dd_validation_marker_mock.go
+++ b/ddmark/dd_validation_marker_mock.go
@@ -29,6 +29,10 @@ func (_m *DDValidationMarkerMock) EXPECT() *DDValidationMarkerMock_Expecter {
 func (_m *DDValidationMarkerMock) ApplyRule(_a0 reflect.Value) error {
 	ret := _m.Called(_a0)
 
+	if len(ret) == 0 {
+		panic("no return value specified for ApplyRule")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(reflect.Value) error); ok {
 		r0 = rf(_a0)
@@ -70,6 +74,10 @@ func (_c *DDValidationMarkerMock_ApplyRule_Call) RunAndReturn(run func(reflect.V
 // TypeCheckError provides a mock function with given fields: _a0
 func (_m *DDValidationMarkerMock) TypeCheckError(_a0 reflect.Value) error {
 	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TypeCheckError")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(reflect.Value) error); ok {
@@ -113,6 +121,10 @@ func (_c *DDValidationMarkerMock_TypeCheckError_Call) RunAndReturn(run func(refl
 func (_m *DDValidationMarkerMock) ValueCheckError() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for ValueCheckError")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -150,13 +162,12 @@ func (_c *DDValidationMarkerMock_ValueCheckError_Call) RunAndReturn(run func() e
 	return _c
 }
 
-type mockConstructorTestingTNewDDValidationMarkerMock interface {
+// NewDDValidationMarkerMock creates a new instance of DDValidationMarkerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewDDValidationMarkerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewDDValidationMarkerMock creates a new instance of DDValidationMarkerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewDDValidationMarkerMock(t mockConstructorTestingTNewDDValidationMarkerMock) *DDValidationMarkerMock {
+}) *DDValidationMarkerMock {
 	mock := &DDValidationMarkerMock{}
 	mock.Mock.Test(t)
 

--- a/disk/informer_mock.go
+++ b/disk/informer_mock.go
@@ -25,6 +25,10 @@ func (_m *InformerMock) EXPECT() *InformerMock_Expecter {
 func (_m *InformerMock) Major() int {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Major")
+	}
+
 	var r0 int
 	if rf, ok := ret.Get(0).(func() int); ok {
 		r0 = rf()
@@ -66,6 +70,10 @@ func (_c *InformerMock_Major_Call) RunAndReturn(run func() int) *InformerMock_Ma
 func (_m *InformerMock) Source() string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Source")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
@@ -103,13 +111,12 @@ func (_c *InformerMock_Source_Call) RunAndReturn(run func() string) *InformerMoc
 	return _c
 }
 
-type mockConstructorTestingTNewInformerMock interface {
+// NewInformerMock creates a new instance of InformerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewInformerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewInformerMock creates a new instance of InformerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewInformerMock(t mockConstructorTestingTNewInformerMock) *InformerMock {
+}) *InformerMock {
 	mock := &InformerMock{}
 	mock.Mock.Test(t)
 

--- a/dogfood/chaosdogfood/chaos_dogfood_client_mock.go
+++ b/dogfood/chaosdogfood/chaos_dogfood_client_mock.go
@@ -39,6 +39,10 @@ func (_m *ChaosDogfoodClientMock) GetCatalog(ctx context.Context, in *emptypb.Em
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetCatalog")
+	}
+
 	var r0 *CatalogReply
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*CatalogReply, error)); ok {
@@ -109,6 +113,10 @@ func (_m *ChaosDogfoodClientMock) Order(ctx context.Context, in *FoodRequest, op
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Order")
+	}
+
 	var r0 *FoodReply
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *FoodRequest, ...grpc.CallOption) (*FoodReply, error)); ok {
@@ -168,13 +176,12 @@ func (_c *ChaosDogfoodClientMock_Order_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
-type mockConstructorTestingTNewChaosDogfoodClientMock interface {
+// NewChaosDogfoodClientMock creates a new instance of ChaosDogfoodClientMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewChaosDogfoodClientMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewChaosDogfoodClientMock creates a new instance of ChaosDogfoodClientMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewChaosDogfoodClientMock(t mockConstructorTestingTNewChaosDogfoodClientMock) *ChaosDogfoodClientMock {
+}) *ChaosDogfoodClientMock {
 	mock := &ChaosDogfoodClientMock{}
 	mock.Mock.Test(t)
 

--- a/dogfood/chaosdogfood/chaos_dogfood_server_mock.go
+++ b/dogfood/chaosdogfood/chaos_dogfood_server_mock.go
@@ -30,6 +30,10 @@ func (_m *ChaosDogfoodServerMock) EXPECT() *ChaosDogfoodServerMock_Expecter {
 func (_m *ChaosDogfoodServerMock) GetCatalog(_a0 context.Context, _a1 *emptypb.Empty) (*CatalogReply, error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetCatalog")
+	}
+
 	var r0 *CatalogReply
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *emptypb.Empty) (*CatalogReply, error)); ok {
@@ -84,6 +88,10 @@ func (_c *ChaosDogfoodServerMock_GetCatalog_Call) RunAndReturn(run func(context.
 // Order provides a mock function with given fields: _a0, _a1
 func (_m *ChaosDogfoodServerMock) Order(_a0 context.Context, _a1 *FoodRequest) (*FoodReply, error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Order")
+	}
 
 	var r0 *FoodReply
 	var r1 error
@@ -168,13 +176,12 @@ func (_c *ChaosDogfoodServerMock_mustEmbedUnimplementedChaosDogfoodServer_Call) 
 	return _c
 }
 
-type mockConstructorTestingTNewChaosDogfoodServerMock interface {
+// NewChaosDogfoodServerMock creates a new instance of ChaosDogfoodServerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewChaosDogfoodServerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewChaosDogfoodServerMock creates a new instance of ChaosDogfoodServerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewChaosDogfoodServerMock(t mockConstructorTestingTNewChaosDogfoodServerMock) *ChaosDogfoodServerMock {
+}) *ChaosDogfoodServerMock {
 	mock := &ChaosDogfoodServerMock{}
 	mock.Mock.Test(t)
 

--- a/dogfood/chaosdogfood/unsafe_chaos_dogfood_server_mock.go
+++ b/dogfood/chaosdogfood/unsafe_chaos_dogfood_server_mock.go
@@ -53,13 +53,12 @@ func (_c *UnsafeChaosDogfoodServerMock_mustEmbedUnimplementedChaosDogfoodServer_
 	return _c
 }
 
-type mockConstructorTestingTNewUnsafeChaosDogfoodServerMock interface {
+// NewUnsafeChaosDogfoodServerMock creates a new instance of UnsafeChaosDogfoodServerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewUnsafeChaosDogfoodServerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewUnsafeChaosDogfoodServerMock creates a new instance of UnsafeChaosDogfoodServerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewUnsafeChaosDogfoodServerMock(t mockConstructorTestingTNewUnsafeChaosDogfoodServerMock) *UnsafeChaosDogfoodServerMock {
+}) *UnsafeChaosDogfoodServerMock {
 	mock := &UnsafeChaosDogfoodServerMock{}
 	mock.Mock.Test(t)
 

--- a/ebpf/config_informer_mock.go
+++ b/ebpf/config_informer_mock.go
@@ -25,6 +25,10 @@ func (_m *ConfigInformerMock) EXPECT() *ConfigInformerMock_Expecter {
 func (_m *ConfigInformerMock) GetKernelFeatures() (Features, error) {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetKernelFeatures")
+	}
+
 	var r0 Features
 	var r1 error
 	if rf, ok := ret.Get(0).(func() (Features, error)); ok {
@@ -76,6 +80,10 @@ func (_c *ConfigInformerMock_GetKernelFeatures_Call) RunAndReturn(run func() (Fe
 func (_m *ConfigInformerMock) GetMapTypes() MapTypes {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetMapTypes")
+	}
+
 	var r0 MapTypes
 	if rf, ok := ret.Get(0).(func() MapTypes); ok {
 		r0 = rf()
@@ -116,6 +124,10 @@ func (_c *ConfigInformerMock_GetMapTypes_Call) RunAndReturn(run func() MapTypes)
 // GetRequiredSystemConfig provides a mock function with given fields:
 func (_m *ConfigInformerMock) GetRequiredSystemConfig() KernelParams {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRequiredSystemConfig")
+	}
 
 	var r0 KernelParams
 	if rf, ok := ret.Get(0).(func() KernelParams); ok {
@@ -160,6 +172,10 @@ func (_c *ConfigInformerMock_GetRequiredSystemConfig_Call) RunAndReturn(run func
 func (_m *ConfigInformerMock) IsKernelConfigAvailable() bool {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for IsKernelConfigAvailable")
+	}
+
 	var r0 bool
 	if rf, ok := ret.Get(0).(func() bool); ok {
 		r0 = rf()
@@ -201,6 +217,10 @@ func (_c *ConfigInformerMock_IsKernelConfigAvailable_Call) RunAndReturn(run func
 func (_m *ConfigInformerMock) ValidateRequiredSystemConfig() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateRequiredSystemConfig")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -238,13 +258,12 @@ func (_c *ConfigInformerMock_ValidateRequiredSystemConfig_Call) RunAndReturn(run
 	return _c
 }
 
-type mockConstructorTestingTNewConfigInformerMock interface {
+// NewConfigInformerMock creates a new instance of ConfigInformerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewConfigInformerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewConfigInformerMock creates a new instance of ConfigInformerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewConfigInformerMock(t mockConstructorTestingTNewConfigInformerMock) *ConfigInformerMock {
+}) *ConfigInformerMock {
 	mock := &ConfigInformerMock{}
 	mock.Mock.Test(t)
 

--- a/ebpf/executor_mock.go
+++ b/ebpf/executor_mock.go
@@ -25,6 +25,10 @@ func (_m *ExecutorMock) EXPECT() *ExecutorMock_Expecter {
 func (_m *ExecutorMock) Run(args []string) (int, string, error) {
 	ret := _m.Called(args)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Run")
+	}
+
 	var r0 int
 	var r1 string
 	var r2 error
@@ -80,13 +84,12 @@ func (_c *ExecutorMock_Run_Call) RunAndReturn(run func([]string) (int, string, e
 	return _c
 }
 
-type mockConstructorTestingTNewExecutorMock interface {
+// NewExecutorMock creates a new instance of ExecutorMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewExecutorMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewExecutorMock creates a new instance of ExecutorMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewExecutorMock(t mockConstructorTestingTNewExecutorMock) *ExecutorMock {
+}) *ExecutorMock {
 	mock := &ExecutorMock{}
 	mock.Mock.Test(t)
 

--- a/eventnotifier/notifier_mock.go
+++ b/eventnotifier/notifier_mock.go
@@ -31,6 +31,10 @@ func (_m *NotifierMock) EXPECT() *NotifierMock_Expecter {
 func (_m *NotifierMock) GetNotifierName() string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetNotifierName")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
@@ -72,6 +76,10 @@ func (_c *NotifierMock_GetNotifierName_Call) RunAndReturn(run func() string) *No
 func (_m *NotifierMock) Notify(_a0 v1beta1.Disruption, _a1 v1.Event, _a2 types.NotificationType) error {
 	ret := _m.Called(_a0, _a1, _a2)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Notify")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(v1beta1.Disruption, v1.Event, types.NotificationType) error); ok {
 		r0 = rf(_a0, _a1, _a2)
@@ -112,13 +120,12 @@ func (_c *NotifierMock_Notify_Call) RunAndReturn(run func(v1beta1.Disruption, v1
 	return _c
 }
 
-type mockConstructorTestingTNewNotifierMock interface {
+// NewNotifierMock creates a new instance of NotifierMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewNotifierMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewNotifierMock creates a new instance of NotifierMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewNotifierMock(t mockConstructorTestingTNewNotifierMock) *NotifierMock {
+}) *NotifierMock {
 	mock := &NotifierMock{}
 	mock.Mock.Test(t)
 

--- a/eventnotifier/slack/slack_notifier_mock.go
+++ b/eventnotifier/slack/slack_notifier_mock.go
@@ -28,6 +28,10 @@ func (_m *slackNotifierMock) EXPECT() *slackNotifierMock_Expecter {
 func (_m *slackNotifierMock) GetUserByEmail(email string) (*slack_goslack.User, error) {
 	ret := _m.Called(email)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserByEmail")
+	}
+
 	var r0 *slack_goslack.User
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) (*slack_goslack.User, error)); ok {
@@ -88,6 +92,10 @@ func (_m *slackNotifierMock) PostMessage(channelID string, options ...slack_gosl
 	_ca = append(_ca, channelID)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PostMessage")
+	}
 
 	var r0 string
 	var r1 string
@@ -152,13 +160,12 @@ func (_c *slackNotifierMock_PostMessage_Call) RunAndReturn(run func(string, ...s
 	return _c
 }
 
-type mockConstructorTestingTnewSlackNotifierMock interface {
+// newSlackNotifierMock creates a new instance of slackNotifierMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func newSlackNotifierMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// newSlackNotifierMock creates a new instance of slackNotifierMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func newSlackNotifierMock(t mockConstructorTestingTnewSlackNotifierMock) *slackNotifierMock {
+}) *slackNotifierMock {
 	mock := &slackNotifierMock{}
 	mock.Mock.Test(t)
 

--- a/grpc/disruptionlistener/disruption_listener_client_mock.go
+++ b/grpc/disruptionlistener/disruption_listener_client_mock.go
@@ -39,6 +39,10 @@ func (_m *DisruptionListenerClientMock) Disrupt(ctx context.Context, in *Disrupt
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Disrupt")
+	}
+
 	var r0 *emptypb.Empty
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *DisruptionSpec, ...grpc.CallOption) (*emptypb.Empty, error)); ok {
@@ -109,6 +113,10 @@ func (_m *DisruptionListenerClientMock) ResetDisruptions(ctx context.Context, in
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for ResetDisruptions")
+	}
+
 	var r0 *emptypb.Empty
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*emptypb.Empty, error)); ok {
@@ -168,13 +176,12 @@ func (_c *DisruptionListenerClientMock_ResetDisruptions_Call) RunAndReturn(run f
 	return _c
 }
 
-type mockConstructorTestingTNewDisruptionListenerClientMock interface {
+// NewDisruptionListenerClientMock creates a new instance of DisruptionListenerClientMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewDisruptionListenerClientMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewDisruptionListenerClientMock creates a new instance of DisruptionListenerClientMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewDisruptionListenerClientMock(t mockConstructorTestingTNewDisruptionListenerClientMock) *DisruptionListenerClientMock {
+}) *DisruptionListenerClientMock {
 	mock := &DisruptionListenerClientMock{}
 	mock.Mock.Test(t)
 

--- a/grpc/disruptionlistener/disruption_listener_server_mock.go
+++ b/grpc/disruptionlistener/disruption_listener_server_mock.go
@@ -30,6 +30,10 @@ func (_m *DisruptionListenerServerMock) EXPECT() *DisruptionListenerServerMock_E
 func (_m *DisruptionListenerServerMock) Disrupt(_a0 context.Context, _a1 *DisruptionSpec) (*emptypb.Empty, error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Disrupt")
+	}
+
 	var r0 *emptypb.Empty
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *DisruptionSpec) (*emptypb.Empty, error)); ok {
@@ -84,6 +88,10 @@ func (_c *DisruptionListenerServerMock_Disrupt_Call) RunAndReturn(run func(conte
 // ResetDisruptions provides a mock function with given fields: _a0, _a1
 func (_m *DisruptionListenerServerMock) ResetDisruptions(_a0 context.Context, _a1 *emptypb.Empty) (*emptypb.Empty, error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResetDisruptions")
+	}
 
 	var r0 *emptypb.Empty
 	var r1 error
@@ -168,13 +176,12 @@ func (_c *DisruptionListenerServerMock_mustEmbedUnimplementedDisruptionListenerS
 	return _c
 }
 
-type mockConstructorTestingTNewDisruptionListenerServerMock interface {
+// NewDisruptionListenerServerMock creates a new instance of DisruptionListenerServerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewDisruptionListenerServerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewDisruptionListenerServerMock creates a new instance of DisruptionListenerServerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewDisruptionListenerServerMock(t mockConstructorTestingTNewDisruptionListenerServerMock) *DisruptionListenerServerMock {
+}) *DisruptionListenerServerMock {
 	mock := &DisruptionListenerServerMock{}
 	mock.Mock.Test(t)
 

--- a/grpc/disruptionlistener/unsafe_disruption_listener_server_mock.go
+++ b/grpc/disruptionlistener/unsafe_disruption_listener_server_mock.go
@@ -53,13 +53,12 @@ func (_c *UnsafeDisruptionListenerServerMock_mustEmbedUnimplementedDisruptionLis
 	return _c
 }
 
-type mockConstructorTestingTNewUnsafeDisruptionListenerServerMock interface {
+// NewUnsafeDisruptionListenerServerMock creates a new instance of UnsafeDisruptionListenerServerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewUnsafeDisruptionListenerServerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewUnsafeDisruptionListenerServerMock creates a new instance of UnsafeDisruptionListenerServerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewUnsafeDisruptionListenerServerMock(t mockConstructorTestingTNewUnsafeDisruptionListenerServerMock) *UnsafeDisruptionListenerServerMock {
+}) *UnsafeDisruptionListenerServerMock {
 	mock := &UnsafeDisruptionListenerServerMock{}
 	mock.Mock.Test(t)
 

--- a/injector/cpu_stress_args_builder_mock.go
+++ b/injector/cpu_stress_args_builder_mock.go
@@ -25,6 +25,10 @@ func (_m *CPUStressArgsBuilderMock) EXPECT() *CPUStressArgsBuilderMock_Expecter 
 func (_m *CPUStressArgsBuilderMock) GenerateArgs(_a0 int) []string {
 	ret := _m.Called(_a0)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GenerateArgs")
+	}
+
 	var r0 []string
 	if rf, ok := ret.Get(0).(func(int) []string); ok {
 		r0 = rf(_a0)
@@ -65,13 +69,12 @@ func (_c *CPUStressArgsBuilderMock_GenerateArgs_Call) RunAndReturn(run func(int)
 	return _c
 }
 
-type mockConstructorTestingTNewCPUStressArgsBuilderMock interface {
+// NewCPUStressArgsBuilderMock creates a new instance of CPUStressArgsBuilderMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewCPUStressArgsBuilderMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewCPUStressArgsBuilderMock creates a new instance of CPUStressArgsBuilderMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewCPUStressArgsBuilderMock(t mockConstructorTestingTNewCPUStressArgsBuilderMock) *CPUStressArgsBuilderMock {
+}) *CPUStressArgsBuilderMock {
 	mock := &CPUStressArgsBuilderMock{}
 	mock.Mock.Test(t)
 

--- a/injector/file_writer_mock.go
+++ b/injector/file_writer_mock.go
@@ -29,6 +29,10 @@ func (_m *FileWriterMock) EXPECT() *FileWriterMock_Expecter {
 func (_m *FileWriterMock) Write(path string, mode fs.FileMode, data string) error {
 	ret := _m.Called(path, mode, data)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Write")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, fs.FileMode, string) error); ok {
 		r0 = rf(path, mode, data)
@@ -69,13 +73,12 @@ func (_c *FileWriterMock_Write_Call) RunAndReturn(run func(string, fs.FileMode, 
 	return _c
 }
 
-type mockConstructorTestingTNewFileWriterMock interface {
+// NewFileWriterMock creates a new instance of FileWriterMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewFileWriterMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewFileWriterMock creates a new instance of FileWriterMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewFileWriterMock(t mockConstructorTestingTNewFileWriterMock) *FileWriterMock {
+}) *FileWriterMock {
 	mock := &FileWriterMock{}
 	mock.Mock.Test(t)
 

--- a/injector/injector_cmd_factory_mock.go
+++ b/injector/injector_cmd_factory_mock.go
@@ -34,6 +34,10 @@ func (_m *InjectorCmdFactoryMock) EXPECT() *InjectorCmdFactoryMock_Expecter {
 func (_m *InjectorCmdFactoryMock) NewInjectorBackgroundCmd(deadline time.Time, disruptionArgs api.DisruptionArgs, target string, args []string) (command.BackgroundCmd, context.CancelFunc, error) {
 	ret := _m.Called(deadline, disruptionArgs, target, args)
 
+	if len(ret) == 0 {
+		panic("no return value specified for NewInjectorBackgroundCmd")
+	}
+
 	var r0 command.BackgroundCmd
 	var r1 context.CancelFunc
 	var r2 error
@@ -96,13 +100,12 @@ func (_c *InjectorCmdFactoryMock_NewInjectorBackgroundCmd_Call) RunAndReturn(run
 	return _c
 }
 
-type mockConstructorTestingTNewInjectorCmdFactoryMock interface {
+// NewInjectorCmdFactoryMock creates a new instance of InjectorCmdFactoryMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewInjectorCmdFactoryMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewInjectorCmdFactoryMock creates a new instance of InjectorCmdFactoryMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewInjectorCmdFactoryMock(t mockConstructorTestingTNewInjectorCmdFactoryMock) *InjectorCmdFactoryMock {
+}) *InjectorCmdFactoryMock {
 	mock := &InjectorCmdFactoryMock{}
 	mock.Mock.Test(t)
 

--- a/injector/injector_mock.go
+++ b/injector/injector_mock.go
@@ -28,6 +28,10 @@ func (_m *InjectorMock) EXPECT() *InjectorMock_Expecter {
 func (_m *InjectorMock) Clean() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Clean")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -68,6 +72,10 @@ func (_c *InjectorMock_Clean_Call) RunAndReturn(run func() error) *InjectorMock_
 // GetDisruptionKind provides a mock function with given fields:
 func (_m *InjectorMock) GetDisruptionKind() types.DisruptionKindName {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDisruptionKind")
+	}
 
 	var r0 types.DisruptionKindName
 	if rf, ok := ret.Get(0).(func() types.DisruptionKindName); ok {
@@ -110,6 +118,10 @@ func (_c *InjectorMock_GetDisruptionKind_Call) RunAndReturn(run func() types.Dis
 func (_m *InjectorMock) Inject() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Inject")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -150,6 +162,10 @@ func (_c *InjectorMock_Inject_Call) RunAndReturn(run func() error) *InjectorMock
 // TargetName provides a mock function with given fields:
 func (_m *InjectorMock) TargetName() string {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for TargetName")
+	}
 
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
@@ -221,13 +237,12 @@ func (_c *InjectorMock_UpdateConfig_Call) RunAndReturn(run func(Config)) *Inject
 	return _c
 }
 
-type mockConstructorTestingTNewInjectorMock interface {
+// NewInjectorMock creates a new instance of InjectorMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewInjectorMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewInjectorMock creates a new instance of InjectorMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewInjectorMock(t mockConstructorTestingTNewInjectorMock) *InjectorMock {
+}) *InjectorMock {
 	mock := &InjectorMock{}
 	mock.Mock.Test(t)
 

--- a/injector/link_operation_mock.go
+++ b/injector/link_operation_mock.go
@@ -25,6 +25,10 @@ func (_m *linkOperationMock) EXPECT() *linkOperationMock_Expecter {
 func (_m *linkOperationMock) Execute(_a0 []string, _a1 string, _a2 string) error {
 	ret := _m.Called(_a0, _a1, _a2)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Execute")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string, string, string) error); ok {
 		r0 = rf(_a0, _a1, _a2)
@@ -65,13 +69,12 @@ func (_c *linkOperationMock_Execute_Call) RunAndReturn(run func([]string, string
 	return _c
 }
 
-type mockConstructorTestingTnewLinkOperationMock interface {
+// newLinkOperationMock creates a new instance of linkOperationMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func newLinkOperationMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// newLinkOperationMock creates a new instance of linkOperationMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func newLinkOperationMock(t mockConstructorTestingTnewLinkOperationMock) *linkOperationMock {
+}) *linkOperationMock {
 	mock := &linkOperationMock{}
 	mock.Mock.Test(t)
 

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -44,6 +44,10 @@ func (_m *K8SClientMock) Create(ctx context.Context, obj client.Object, opts ...
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Create")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, client.Object, ...client.CreateOption) error); ok {
 		r0 = rf(ctx, obj, opts...)
@@ -101,6 +105,10 @@ func (_m *K8SClientMock) Delete(ctx context.Context, obj client.Object, opts ...
 	_ca = append(_ca, ctx, obj)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, client.Object, ...client.DeleteOption) error); ok {
@@ -160,6 +168,10 @@ func (_m *K8SClientMock) DeleteAllOf(ctx context.Context, obj client.Object, opt
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAllOf")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, client.Object, ...client.DeleteAllOfOption) error); ok {
 		r0 = rf(ctx, obj, opts...)
@@ -217,6 +229,10 @@ func (_m *K8SClientMock) Get(ctx context.Context, key types.NamespacedName, obj 
 	_ca = append(_ca, ctx, key, obj)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, types.NamespacedName, client.Object, ...client.GetOption) error); ok {
@@ -277,6 +293,10 @@ func (_m *K8SClientMock) List(ctx context.Context, list client.ObjectList, opts 
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, client.ObjectList, ...client.ListOption) error); ok {
 		r0 = rf(ctx, list, opts...)
@@ -335,6 +355,10 @@ func (_m *K8SClientMock) Patch(ctx context.Context, obj client.Object, patch cli
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Patch")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, client.Object, client.Patch, ...client.PatchOption) error); ok {
 		r0 = rf(ctx, obj, patch, opts...)
@@ -387,6 +411,10 @@ func (_c *K8SClientMock_Patch_Call) RunAndReturn(run func(context.Context, clien
 func (_m *K8SClientMock) RESTMapper() meta.RESTMapper {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for RESTMapper")
+	}
+
 	var r0 meta.RESTMapper
 	if rf, ok := ret.Get(0).(func() meta.RESTMapper); ok {
 		r0 = rf()
@@ -429,6 +457,10 @@ func (_c *K8SClientMock_RESTMapper_Call) RunAndReturn(run func() meta.RESTMapper
 // Scheme provides a mock function with given fields:
 func (_m *K8SClientMock) Scheme() *runtime.Scheme {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Scheme")
+	}
 
 	var r0 *runtime.Scheme
 	if rf, ok := ret.Get(0).(func() *runtime.Scheme); ok {
@@ -473,6 +505,10 @@ func (_c *K8SClientMock_Scheme_Call) RunAndReturn(run func() *runtime.Scheme) *K
 func (_m *K8SClientMock) Status() client.SubResourceWriter {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Status")
+	}
+
 	var r0 client.SubResourceWriter
 	if rf, ok := ret.Get(0).(func() client.SubResourceWriter); ok {
 		r0 = rf()
@@ -515,6 +551,10 @@ func (_c *K8SClientMock_Status_Call) RunAndReturn(run func() client.SubResourceW
 // SubResource provides a mock function with given fields: subResource
 func (_m *K8SClientMock) SubResource(subResource string) client.SubResourceClient {
 	ret := _m.Called(subResource)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SubResource")
+	}
 
 	var r0 client.SubResourceClient
 	if rf, ok := ret.Get(0).(func(string) client.SubResourceClient); ok {
@@ -567,6 +607,10 @@ func (_m *K8SClientMock) Update(ctx context.Context, obj client.Object, opts ...
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Update")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, client.Object, ...client.UpdateOption) error); ok {
 		r0 = rf(ctx, obj, opts...)
@@ -614,13 +658,12 @@ func (_c *K8SClientMock_Update_Call) RunAndReturn(run func(context.Context, clie
 	return _c
 }
 
-type mockConstructorTestingTNewK8SClientMock interface {
+// NewK8SClientMock creates a new instance of K8SClientMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewK8SClientMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewK8SClientMock creates a new instance of K8SClientMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewK8SClientMock(t mockConstructorTestingTNewK8SClientMock) *K8SClientMock {
+}) *K8SClientMock {
 	mock := &K8SClientMock{}
 	mock.Mock.Test(t)
 

--- a/mocks/controller.go
+++ b/mocks/controller.go
@@ -39,6 +39,10 @@ func (_m *RuntimeControllerMock) EXPECT() *RuntimeControllerMock_Expecter {
 func (_m *RuntimeControllerMock) GetLogger() logr.Logger {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetLogger")
+	}
+
 	var r0 logr.Logger
 	if rf, ok := ret.Get(0).(func() logr.Logger); ok {
 		r0 = rf()
@@ -79,6 +83,10 @@ func (_c *RuntimeControllerMock_GetLogger_Call) RunAndReturn(run func() logr.Log
 // Reconcile provides a mock function with given fields: _a0, _a1
 func (_m *RuntimeControllerMock) Reconcile(_a0 context.Context, _a1 reconcile.Request) (reconcile.Result, error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reconcile")
+	}
 
 	var r0 reconcile.Result
 	var r1 error
@@ -133,6 +141,10 @@ func (_c *RuntimeControllerMock_Reconcile_Call) RunAndReturn(run func(context.Co
 func (_m *RuntimeControllerMock) Start(ctx context.Context) error {
 	ret := _m.Called(ctx)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Start")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
 		r0 = rf(ctx)
@@ -182,6 +194,10 @@ func (_m *RuntimeControllerMock) Watch(src source.Source, eventhandler handler.E
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Watch")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(source.Source, handler.EventHandler, ...predicate.Predicate) error); ok {
 		r0 = rf(src, eventhandler, predicates...)
@@ -229,13 +245,12 @@ func (_c *RuntimeControllerMock_Watch_Call) RunAndReturn(run func(source.Source,
 	return _c
 }
 
-type mockConstructorTestingTNewRuntimeControllerMock interface {
+// NewRuntimeControllerMock creates a new instance of RuntimeControllerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewRuntimeControllerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewRuntimeControllerMock creates a new instance of RuntimeControllerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewRuntimeControllerMock(t mockConstructorTestingTNewRuntimeControllerMock) *RuntimeControllerMock {
+}) *RuntimeControllerMock {
 	mock := &RuntimeControllerMock{}
 	mock.Mock.Test(t)
 

--- a/mocks/event_recorder.go
+++ b/mocks/event_recorder.go
@@ -156,13 +156,12 @@ func (_c *EventRecorderMock_Eventf_Call) RunAndReturn(run func(runtime.Object, s
 	return _c
 }
 
-type mockConstructorTestingTNewEventRecorderMock interface {
+// NewEventRecorderMock creates a new instance of EventRecorderMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewEventRecorderMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewEventRecorderMock creates a new instance of EventRecorderMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewEventRecorderMock(t mockConstructorTestingTNewEventRecorderMock) *EventRecorderMock {
+}) *EventRecorderMock {
 	mock := &EventRecorderMock{}
 	mock.Mock.Test(t)
 

--- a/mocks/informer.go
+++ b/mocks/informer.go
@@ -30,6 +30,10 @@ func (_m *CacheInformerMock) EXPECT() *CacheInformerMock_Expecter {
 func (_m *CacheInformerMock) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
 	ret := _m.Called(handler)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AddEventHandler")
+	}
+
 	var r0 cache.ResourceEventHandlerRegistration
 	var r1 error
 	if rf, ok := ret.Get(0).(func(cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error)); ok {
@@ -83,6 +87,10 @@ func (_c *CacheInformerMock_AddEventHandler_Call) RunAndReturn(run func(cache.Re
 // AddEventHandlerWithResyncPeriod provides a mock function with given fields: handler, resyncPeriod
 func (_m *CacheInformerMock) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
 	ret := _m.Called(handler, resyncPeriod)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddEventHandlerWithResyncPeriod")
+	}
 
 	var r0 cache.ResourceEventHandlerRegistration
 	var r1 error
@@ -139,6 +147,10 @@ func (_c *CacheInformerMock_AddEventHandlerWithResyncPeriod_Call) RunAndReturn(r
 func (_m *CacheInformerMock) AddIndexers(indexers cache.Indexers) error {
 	ret := _m.Called(indexers)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AddIndexers")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(cache.Indexers) error); ok {
 		r0 = rf(indexers)
@@ -181,6 +193,10 @@ func (_c *CacheInformerMock_AddIndexers_Call) RunAndReturn(run func(cache.Indexe
 func (_m *CacheInformerMock) HasSynced() bool {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for HasSynced")
+	}
+
 	var r0 bool
 	if rf, ok := ret.Get(0).(func() bool); ok {
 		r0 = rf()
@@ -222,6 +238,10 @@ func (_c *CacheInformerMock_HasSynced_Call) RunAndReturn(run func() bool) *Cache
 func (_m *CacheInformerMock) RemoveEventHandler(handle cache.ResourceEventHandlerRegistration) error {
 	ret := _m.Called(handle)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveEventHandler")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(cache.ResourceEventHandlerRegistration) error); ok {
 		r0 = rf(handle)
@@ -260,13 +280,12 @@ func (_c *CacheInformerMock_RemoveEventHandler_Call) RunAndReturn(run func(cache
 	return _c
 }
 
-type mockConstructorTestingTNewCacheInformerMock interface {
+// NewCacheInformerMock creates a new instance of CacheInformerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewCacheInformerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewCacheInformerMock creates a new instance of CacheInformerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewCacheInformerMock(t mockConstructorTestingTNewCacheInformerMock) *CacheInformerMock {
+}) *CacheInformerMock {
 	mock := &CacheInformerMock{}
 	mock.Mock.Test(t)
 

--- a/mocks/reader.go
+++ b/mocks/reader.go
@@ -40,6 +40,10 @@ func (_m *ReaderMock) Get(ctx context.Context, key types.NamespacedName, obj cli
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, types.NamespacedName, client.Object, ...client.GetOption) error); ok {
 		r0 = rf(ctx, key, obj, opts...)
@@ -99,6 +103,10 @@ func (_m *ReaderMock) List(ctx context.Context, list client.ObjectList, opts ...
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, client.ObjectList, ...client.ListOption) error); ok {
 		r0 = rf(ctx, list, opts...)
@@ -146,13 +154,12 @@ func (_c *ReaderMock_List_Call) RunAndReturn(run func(context.Context, client.Ob
 	return _c
 }
 
-type mockConstructorTestingTNewReaderMock interface {
+// NewReaderMock creates a new instance of ReaderMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewReaderMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewReaderMock creates a new instance of ReaderMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewReaderMock(t mockConstructorTestingTNewReaderMock) *ReaderMock {
+}) *ReaderMock {
 	mock := &ReaderMock{}
 	mock.Mock.Test(t)
 

--- a/mocks/resource_event_handler.go
+++ b/mocks/resource_event_handler.go
@@ -121,13 +121,12 @@ func (_c *ResourceEventHandlerMock_OnUpdate_Call) RunAndReturn(run func(interfac
 	return _c
 }
 
-type mockConstructorTestingTNewResourceEventHandlerMock interface {
+// NewResourceEventHandlerMock creates a new instance of ResourceEventHandlerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewResourceEventHandlerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewResourceEventHandlerMock creates a new instance of ResourceEventHandlerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewResourceEventHandlerMock(t mockConstructorTestingTNewResourceEventHandlerMock) *ResourceEventHandlerMock {
+}) *ResourceEventHandlerMock {
 	mock := &ResourceEventHandlerMock{}
 	mock.Mock.Test(t)
 

--- a/mocks/round_tripper.go
+++ b/mocks/round_tripper.go
@@ -29,6 +29,10 @@ func (_m *RoundTripperMock) EXPECT() *RoundTripperMock_Expecter {
 func (_m *RoundTripperMock) RoundTrip(_a0 *http.Request) (*http.Response, error) {
 	ret := _m.Called(_a0)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RoundTrip")
+	}
+
 	var r0 *http.Response
 	var r1 error
 	if rf, ok := ret.Get(0).(func(*http.Request) (*http.Response, error)); ok {
@@ -79,13 +83,12 @@ func (_c *RoundTripperMock_RoundTrip_Call) RunAndReturn(run func(*http.Request) 
 	return _c
 }
 
-type mockConstructorTestingTNewRoundTripperMock interface {
+// NewRoundTripperMock creates a new instance of RoundTripperMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewRoundTripperMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewRoundTripperMock creates a new instance of RoundTripperMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewRoundTripperMock(t mockConstructorTestingTNewRoundTripperMock) *RoundTripperMock {
+}) *RoundTripperMock {
 	mock := &RoundTripperMock{}
 	mock.Mock.Test(t)
 

--- a/mocks/stat_fs.go
+++ b/mocks/stat_fs.go
@@ -29,6 +29,10 @@ func (_m *StatFSMock) EXPECT() *StatFSMock_Expecter {
 func (_m *StatFSMock) Open(name string) (fs.File, error) {
 	ret := _m.Called(name)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Open")
+	}
+
 	var r0 fs.File
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) (fs.File, error)); ok {
@@ -83,6 +87,10 @@ func (_c *StatFSMock_Open_Call) RunAndReturn(run func(string) (fs.File, error)) 
 func (_m *StatFSMock) Stat(name string) (fs.FileInfo, error) {
 	ret := _m.Called(name)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Stat")
+	}
+
 	var r0 fs.FileInfo
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) (fs.FileInfo, error)); ok {
@@ -133,13 +141,12 @@ func (_c *StatFSMock_Stat_Call) RunAndReturn(run func(string) (fs.FileInfo, erro
 	return _c
 }
 
-type mockConstructorTestingTNewStatFSMock interface {
+// NewStatFSMock creates a new instance of StatFSMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewStatFSMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewStatFSMock creates a new instance of StatFSMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewStatFSMock(t mockConstructorTestingTNewStatFSMock) *StatFSMock {
+}) *StatFSMock {
 	mock := &StatFSMock{}
 	mock.Mock.Test(t)
 

--- a/mocks/syncing_source.go
+++ b/mocks/syncing_source.go
@@ -41,6 +41,10 @@ func (_m *SyncingSourceMock) Start(_a0 context.Context, _a1 handler.EventHandler
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Start")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, handler.EventHandler, workqueue.RateLimitingInterface, ...predicate.Predicate) error); ok {
 		r0 = rf(_a0, _a1, _a2, _a3...)
@@ -93,6 +97,10 @@ func (_c *SyncingSourceMock_Start_Call) RunAndReturn(run func(context.Context, h
 func (_m *SyncingSourceMock) WaitForSync(ctx context.Context) error {
 	ret := _m.Called(ctx)
 
+	if len(ret) == 0 {
+		panic("no return value specified for WaitForSync")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
 		r0 = rf(ctx)
@@ -131,13 +139,12 @@ func (_c *SyncingSourceMock_WaitForSync_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-type mockConstructorTestingTNewSyncingSourceMock interface {
+// NewSyncingSourceMock creates a new instance of SyncingSourceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewSyncingSourceMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewSyncingSourceMock creates a new instance of SyncingSourceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewSyncingSourceMock(t mockConstructorTestingTNewSyncingSourceMock) *SyncingSourceMock {
+}) *SyncingSourceMock {
 	mock := &SyncingSourceMock{}
 	mock.Mock.Test(t)
 

--- a/mocks/watcher.go
+++ b/mocks/watcher.go
@@ -30,6 +30,10 @@ func (_m *CacheWatcherMock) EXPECT() *CacheWatcherMock_Expecter {
 func (_m *CacheWatcherMock) Watch(options v1.ListOptions) (watch.Interface, error) {
 	ret := _m.Called(options)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Watch")
+	}
+
 	var r0 watch.Interface
 	var r1 error
 	if rf, ok := ret.Get(0).(func(v1.ListOptions) (watch.Interface, error)); ok {
@@ -80,13 +84,12 @@ func (_c *CacheWatcherMock_Watch_Call) RunAndReturn(run func(v1.ListOptions) (wa
 	return _c
 }
 
-type mockConstructorTestingTNewCacheWatcherMock interface {
+// NewCacheWatcherMock creates a new instance of CacheWatcherMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewCacheWatcherMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewCacheWatcherMock creates a new instance of CacheWatcherMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewCacheWatcherMock(t mockConstructorTestingTNewCacheWatcherMock) *CacheWatcherMock {
+}) *CacheWatcherMock {
 	mock := &CacheWatcherMock{}
 	mock.Mock.Test(t)
 

--- a/netns/manager_mock.go
+++ b/netns/manager_mock.go
@@ -25,6 +25,10 @@ func (_m *ManagerMock) EXPECT() *ManagerMock_Expecter {
 func (_m *ManagerMock) Enter() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Enter")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -66,6 +70,10 @@ func (_c *ManagerMock_Enter_Call) RunAndReturn(run func() error) *ManagerMock_En
 func (_m *ManagerMock) Exit() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Exit")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -103,13 +111,12 @@ func (_c *ManagerMock_Exit_Call) RunAndReturn(run func() error) *ManagerMock_Exi
 	return _c
 }
 
-type mockConstructorTestingTNewManagerMock interface {
+// NewManagerMock creates a new instance of ManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewManagerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewManagerMock creates a new instance of ManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewManagerMock(t mockConstructorTestingTNewManagerMock) *ManagerMock {
+}) *ManagerMock {
 	mock := &ManagerMock{}
 	mock.Mock.Test(t)
 

--- a/network/dns_client_mock.go
+++ b/network/dns_client_mock.go
@@ -29,6 +29,10 @@ func (_m *DNSClientMock) EXPECT() *DNSClientMock_Expecter {
 func (_m *DNSClientMock) Resolve(host string) ([]net.IP, error) {
 	ret := _m.Called(host)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Resolve")
+	}
+
 	var r0 []net.IP
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) ([]net.IP, error)); ok {
@@ -79,13 +83,12 @@ func (_c *DNSClientMock_Resolve_Call) RunAndReturn(run func(string) ([]net.IP, e
 	return _c
 }
 
-type mockConstructorTestingTNewDNSClientMock interface {
+// NewDNSClientMock creates a new instance of DNSClientMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewDNSClientMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewDNSClientMock creates a new instance of DNSClientMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewDNSClientMock(t mockConstructorTestingTNewDNSClientMock) *DNSClientMock {
+}) *DNSClientMock {
 	mock := &DNSClientMock{}
 	mock.Mock.Test(t)
 

--- a/network/executor_mock.go
+++ b/network/executor_mock.go
@@ -25,6 +25,10 @@ func (_m *executorMock) EXPECT() *executorMock_Expecter {
 func (_m *executorMock) Run(args []string) (int, string, error) {
 	ret := _m.Called(args)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Run")
+	}
+
 	var r0 int
 	var r1 string
 	var r2 error
@@ -80,13 +84,12 @@ func (_c *executorMock_Run_Call) RunAndReturn(run func([]string) (int, string, e
 	return _c
 }
 
-type mockConstructorTestingTnewExecutorMock interface {
+// newExecutorMock creates a new instance of executorMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func newExecutorMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// newExecutorMock creates a new instance of executorMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func newExecutorMock(t mockConstructorTestingTnewExecutorMock) *executorMock {
+}) *executorMock {
 	mock := &executorMock{}
 	mock.Mock.Test(t)
 

--- a/network/ip_tables_mock.go
+++ b/network/ip_tables_mock.go
@@ -25,6 +25,10 @@ func (_m *IPTablesMock) EXPECT() *IPTablesMock_Expecter {
 func (_m *IPTablesMock) Clear() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Clear")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -65,6 +69,10 @@ func (_c *IPTablesMock_Clear_Call) RunAndReturn(run func() error) *IPTablesMock_
 // Intercept provides a mock function with given fields: protocol, port, cgroupPath, cgroupClassID, injectorPodIP
 func (_m *IPTablesMock) Intercept(protocol string, port string, cgroupPath string, cgroupClassID string, injectorPodIP string) error {
 	ret := _m.Called(protocol, port, cgroupPath, cgroupClassID, injectorPodIP)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Intercept")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, string, string, string) error); ok {
@@ -112,6 +120,10 @@ func (_c *IPTablesMock_Intercept_Call) RunAndReturn(run func(string, string, str
 func (_m *IPTablesMock) LogConntrack() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for LogConntrack")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -152,6 +164,10 @@ func (_c *IPTablesMock_LogConntrack_Call) RunAndReturn(run func() error) *IPTabl
 // MarkCgroupPath provides a mock function with given fields: cgroupPath, mark
 func (_m *IPTablesMock) MarkCgroupPath(cgroupPath string, mark string) error {
 	ret := _m.Called(cgroupPath, mark)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkCgroupPath")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string) error); ok {
@@ -196,6 +212,10 @@ func (_c *IPTablesMock_MarkCgroupPath_Call) RunAndReturn(run func(string, string
 func (_m *IPTablesMock) MarkClassID(classid string, mark string) error {
 	ret := _m.Called(classid, mark)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MarkClassID")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string) error); ok {
 		r0 = rf(classid, mark)
@@ -239,6 +259,10 @@ func (_c *IPTablesMock_MarkClassID_Call) RunAndReturn(run func(string, string) e
 func (_m *IPTablesMock) RedirectTo(protocol string, port string, destinationIP string) error {
 	ret := _m.Called(protocol, port, destinationIP)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RedirectTo")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
 		r0 = rf(protocol, port, destinationIP)
@@ -279,13 +303,12 @@ func (_c *IPTablesMock_RedirectTo_Call) RunAndReturn(run func(string, string, st
 	return _c
 }
 
-type mockConstructorTestingTNewIPTablesMock interface {
+// NewIPTablesMock creates a new instance of IPTablesMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewIPTablesMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewIPTablesMock creates a new instance of IPTablesMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewIPTablesMock(t mockConstructorTestingTNewIPTablesMock) *IPTablesMock {
+}) *IPTablesMock {
 	mock := &IPTablesMock{}
 	mock.Mock.Test(t)
 

--- a/network/netlink_adapter_mock.go
+++ b/network/netlink_adapter_mock.go
@@ -28,6 +28,10 @@ func (_m *NetlinkAdapterMock) EXPECT() *NetlinkAdapterMock_Expecter {
 func (_m *NetlinkAdapterMock) DefaultRoutes() ([]NetlinkRoute, error) {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for DefaultRoutes")
+	}
+
 	var r0 []NetlinkRoute
 	var r1 error
 	if rf, ok := ret.Get(0).(func() ([]NetlinkRoute, error)); ok {
@@ -80,6 +84,10 @@ func (_c *NetlinkAdapterMock_DefaultRoutes_Call) RunAndReturn(run func() ([]Netl
 // LinkByIndex provides a mock function with given fields: index
 func (_m *NetlinkAdapterMock) LinkByIndex(index int) (NetlinkLink, error) {
 	ret := _m.Called(index)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LinkByIndex")
+	}
 
 	var r0 NetlinkLink
 	var r1 error
@@ -135,6 +143,10 @@ func (_c *NetlinkAdapterMock_LinkByIndex_Call) RunAndReturn(run func(int) (Netli
 func (_m *NetlinkAdapterMock) LinkByName(name string) (NetlinkLink, error) {
 	ret := _m.Called(name)
 
+	if len(ret) == 0 {
+		panic("no return value specified for LinkByName")
+	}
+
 	var r0 NetlinkLink
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) (NetlinkLink, error)); ok {
@@ -189,6 +201,10 @@ func (_c *NetlinkAdapterMock_LinkByName_Call) RunAndReturn(run func(string) (Net
 func (_m *NetlinkAdapterMock) LinkList(useLocalhost bool, log *zap.SugaredLogger) ([]NetlinkLink, error) {
 	ret := _m.Called(useLocalhost, log)
 
+	if len(ret) == 0 {
+		panic("no return value specified for LinkList")
+	}
+
 	var r0 []NetlinkLink
 	var r1 error
 	if rf, ok := ret.Get(0).(func(bool, *zap.SugaredLogger) ([]NetlinkLink, error)); ok {
@@ -240,13 +256,12 @@ func (_c *NetlinkAdapterMock_LinkList_Call) RunAndReturn(run func(bool, *zap.Sug
 	return _c
 }
 
-type mockConstructorTestingTNewNetlinkAdapterMock interface {
+// NewNetlinkAdapterMock creates a new instance of NetlinkAdapterMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewNetlinkAdapterMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewNetlinkAdapterMock creates a new instance of NetlinkAdapterMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewNetlinkAdapterMock(t mockConstructorTestingTNewNetlinkAdapterMock) *NetlinkAdapterMock {
+}) *NetlinkAdapterMock {
 	mock := &NetlinkAdapterMock{}
 	mock.Mock.Test(t)
 

--- a/network/netlink_link_mock.go
+++ b/network/netlink_link_mock.go
@@ -25,6 +25,10 @@ func (_m *NetlinkLinkMock) EXPECT() *NetlinkLinkMock_Expecter {
 func (_m *NetlinkLinkMock) Name() string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Name")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
@@ -65,6 +69,10 @@ func (_c *NetlinkLinkMock_Name_Call) RunAndReturn(run func() string) *NetlinkLin
 // SetTxQLen provides a mock function with given fields: qlen
 func (_m *NetlinkLinkMock) SetTxQLen(qlen int) error {
 	ret := _m.Called(qlen)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetTxQLen")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(int) error); ok {
@@ -108,6 +116,10 @@ func (_c *NetlinkLinkMock_SetTxQLen_Call) RunAndReturn(run func(int) error) *Net
 func (_m *NetlinkLinkMock) TxQLen() int {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for TxQLen")
+	}
+
 	var r0 int
 	if rf, ok := ret.Get(0).(func() int); ok {
 		r0 = rf()
@@ -145,13 +157,12 @@ func (_c *NetlinkLinkMock_TxQLen_Call) RunAndReturn(run func() int) *NetlinkLink
 	return _c
 }
 
-type mockConstructorTestingTNewNetlinkLinkMock interface {
+// NewNetlinkLinkMock creates a new instance of NetlinkLinkMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewNetlinkLinkMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewNetlinkLinkMock creates a new instance of NetlinkLinkMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewNetlinkLinkMock(t mockConstructorTestingTNewNetlinkLinkMock) *NetlinkLinkMock {
+}) *NetlinkLinkMock {
 	mock := &NetlinkLinkMock{}
 	mock.Mock.Test(t)
 

--- a/network/netlink_route_mock.go
+++ b/network/netlink_route_mock.go
@@ -29,6 +29,10 @@ func (_m *NetlinkRouteMock) EXPECT() *NetlinkRouteMock_Expecter {
 func (_m *NetlinkRouteMock) Gateway() net.IP {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Gateway")
+	}
+
 	var r0 net.IP
 	if rf, ok := ret.Get(0).(func() net.IP); ok {
 		r0 = rf()
@@ -72,6 +76,10 @@ func (_c *NetlinkRouteMock_Gateway_Call) RunAndReturn(run func() net.IP) *Netlin
 func (_m *NetlinkRouteMock) Link() NetlinkLink {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Link")
+	}
+
 	var r0 NetlinkLink
 	if rf, ok := ret.Get(0).(func() NetlinkLink); ok {
 		r0 = rf()
@@ -111,13 +119,12 @@ func (_c *NetlinkRouteMock_Link_Call) RunAndReturn(run func() NetlinkLink) *Netl
 	return _c
 }
 
-type mockConstructorTestingTNewNetlinkRouteMock interface {
+// NewNetlinkRouteMock creates a new instance of NetlinkRouteMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewNetlinkRouteMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewNetlinkRouteMock creates a new instance of NetlinkRouteMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewNetlinkRouteMock(t mockConstructorTestingTNewNetlinkRouteMock) *NetlinkRouteMock {
+}) *NetlinkRouteMock {
 	mock := &NetlinkRouteMock{}
 	mock.Mock.Test(t)
 

--- a/network/protocol_string_mock.go
+++ b/network/protocol_string_mock.go
@@ -21,13 +21,12 @@ func (_m *protocolStringMock) EXPECT() *protocolStringMock_Expecter {
 	return &protocolStringMock_Expecter{mock: &_m.Mock}
 }
 
-type mockConstructorTestingTnewProtocolStringMock interface {
+// newProtocolStringMock creates a new instance of protocolStringMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func newProtocolStringMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// newProtocolStringMock creates a new instance of protocolStringMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func newProtocolStringMock(t mockConstructorTestingTnewProtocolStringMock) *protocolStringMock {
+}) *protocolStringMock {
 	mock := &protocolStringMock{}
 	mock.Mock.Test(t)
 

--- a/network/traffic_controller_mock.go
+++ b/network/traffic_controller_mock.go
@@ -31,6 +31,10 @@ func (_m *TrafficControllerMock) EXPECT() *TrafficControllerMock_Expecter {
 func (_m *TrafficControllerMock) AddBPFFilter(ifaces []string, parent string, obj string, flowid string, section string) error {
 	ret := _m.Called(ifaces, parent, obj, flowid, section)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AddBPFFilter")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string, string, string, string, string) error); ok {
 		r0 = rf(ifaces, parent, obj, flowid, section)
@@ -76,6 +80,10 @@ func (_c *TrafficControllerMock_AddBPFFilter_Call) RunAndReturn(run func([]strin
 // AddFilter provides a mock function with given fields: ifaces, parent, handle, srcIP, dstIP, srcPort, dstPort, prot, state, flowid
 func (_m *TrafficControllerMock) AddFilter(ifaces []string, parent string, handle string, srcIP *net.IPNet, dstIP *net.IPNet, srcPort int, dstPort int, prot protocol, state connState, flowid string) (uint32, error) {
 	ret := _m.Called(ifaces, parent, handle, srcIP, dstIP, srcPort, dstPort, prot, state, flowid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddFilter")
+	}
 
 	var r0 uint32
 	var r1 error
@@ -138,6 +146,10 @@ func (_c *TrafficControllerMock_AddFilter_Call) RunAndReturn(run func([]string, 
 func (_m *TrafficControllerMock) AddFwFilter(ifaces []string, parent string, handle string, flowid string) error {
 	ret := _m.Called(ifaces, parent, handle, flowid)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AddFwFilter")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string, string, string, string) error); ok {
 		r0 = rf(ifaces, parent, handle, flowid)
@@ -182,6 +194,10 @@ func (_c *TrafficControllerMock_AddFwFilter_Call) RunAndReturn(run func([]string
 // AddNetem provides a mock function with given fields: ifaces, parent, handle, delay, delayJitter, drop, corrupt, duplicate
 func (_m *TrafficControllerMock) AddNetem(ifaces []string, parent string, handle string, delay time.Duration, delayJitter time.Duration, drop int, corrupt int, duplicate int) error {
 	ret := _m.Called(ifaces, parent, handle, delay, delayJitter, drop, corrupt, duplicate)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddNetem")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string, string, string, time.Duration, time.Duration, int, int, int) error); ok {
@@ -232,6 +248,10 @@ func (_c *TrafficControllerMock_AddNetem_Call) RunAndReturn(run func([]string, s
 func (_m *TrafficControllerMock) AddOutputLimit(ifaces []string, parent string, handle string, bytesPerSec uint) error {
 	ret := _m.Called(ifaces, parent, handle, bytesPerSec)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AddOutputLimit")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string, string, string, uint) error); ok {
 		r0 = rf(ifaces, parent, handle, bytesPerSec)
@@ -276,6 +296,10 @@ func (_c *TrafficControllerMock_AddOutputLimit_Call) RunAndReturn(run func([]str
 // AddPrio provides a mock function with given fields: ifaces, parent, handle, bands, priomap
 func (_m *TrafficControllerMock) AddPrio(ifaces []string, parent string, handle string, bands uint32, priomap [16]uint32) error {
 	ret := _m.Called(ifaces, parent, handle, bands, priomap)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddPrio")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string, string, string, uint32, [16]uint32) error); ok {
@@ -322,6 +346,10 @@ func (_c *TrafficControllerMock_AddPrio_Call) RunAndReturn(run func([]string, st
 // ClearQdisc provides a mock function with given fields: ifaces
 func (_m *TrafficControllerMock) ClearQdisc(ifaces []string) error {
 	ret := _m.Called(ifaces)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ClearQdisc")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string) error); ok {
@@ -371,6 +399,10 @@ func (_m *TrafficControllerMock) ConfigBPFFilter(cmd executor, args ...string) e
 	_ca = append(_ca, cmd)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConfigBPFFilter")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(executor, ...string) error); ok {
@@ -422,6 +454,10 @@ func (_c *TrafficControllerMock_ConfigBPFFilter_Call) RunAndReturn(run func(exec
 func (_m *TrafficControllerMock) DeleteFilter(iface string, priority uint32) error {
 	ret := _m.Called(iface, priority)
 
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteFilter")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, uint32) error); ok {
 		r0 = rf(iface, priority)
@@ -461,13 +497,12 @@ func (_c *TrafficControllerMock_DeleteFilter_Call) RunAndReturn(run func(string,
 	return _c
 }
 
-type mockConstructorTestingTNewTrafficControllerMock interface {
+// NewTrafficControllerMock creates a new instance of TrafficControllerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewTrafficControllerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewTrafficControllerMock creates a new instance of TrafficControllerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewTrafficControllerMock(t mockConstructorTestingTNewTrafficControllerMock) *TrafficControllerMock {
+}) *TrafficControllerMock {
 	mock := &TrafficControllerMock{}
 	mock.Mock.Test(t)
 

--- a/o11y/metrics/sink_mock.go
+++ b/o11y/metrics/sink_mock.go
@@ -31,6 +31,10 @@ func (_m *SinkMock) EXPECT() *SinkMock_Expecter {
 func (_m *SinkMock) Close() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Close")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -72,6 +76,10 @@ func (_c *SinkMock_Close_Call) RunAndReturn(run func() error) *SinkMock_Close_Ca
 func (_m *SinkMock) GetSinkName() string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetSinkName")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
@@ -112,6 +120,10 @@ func (_c *SinkMock_GetSinkName_Call) RunAndReturn(run func() string) *SinkMock_G
 // MetricCleaned provides a mock function with given fields: succeed, kind, tags
 func (_m *SinkMock) MetricCleaned(succeed bool, kind string, tags []string) error {
 	ret := _m.Called(succeed, kind, tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricCleaned")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(bool, string, []string) error); ok {
@@ -157,6 +169,10 @@ func (_c *SinkMock_MetricCleaned_Call) RunAndReturn(run func(bool, string, []str
 func (_m *SinkMock) MetricCleanedForReinjection(succeed bool, kind string, tags []string) error {
 	ret := _m.Called(succeed, kind, tags)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricCleanedForReinjection")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(bool, string, []string) error); ok {
 		r0 = rf(succeed, kind, tags)
@@ -201,6 +217,10 @@ func (_c *SinkMock_MetricCleanedForReinjection_Call) RunAndReturn(run func(bool,
 func (_m *SinkMock) MetricCleanupDuration(duration time.Duration, tags []string) error {
 	ret := _m.Called(duration, tags)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricCleanupDuration")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(time.Duration, []string) error); ok {
 		r0 = rf(duration, tags)
@@ -243,6 +263,10 @@ func (_c *SinkMock_MetricCleanupDuration_Call) RunAndReturn(run func(time.Durati
 // MetricDisruptionCompletedDuration provides a mock function with given fields: duration, tags
 func (_m *SinkMock) MetricDisruptionCompletedDuration(duration time.Duration, tags []string) error {
 	ret := _m.Called(duration, tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricDisruptionCompletedDuration")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(time.Duration, []string) error); ok {
@@ -287,6 +311,10 @@ func (_c *SinkMock_MetricDisruptionCompletedDuration_Call) RunAndReturn(run func
 func (_m *SinkMock) MetricDisruptionOngoingDuration(duration time.Duration, tags []string) error {
 	ret := _m.Called(duration, tags)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricDisruptionOngoingDuration")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(time.Duration, []string) error); ok {
 		r0 = rf(duration, tags)
@@ -329,6 +357,10 @@ func (_c *SinkMock_MetricDisruptionOngoingDuration_Call) RunAndReturn(run func(t
 // MetricDisruptionsCount provides a mock function with given fields: kind, tags
 func (_m *SinkMock) MetricDisruptionsCount(kind types.DisruptionKindName, tags []string) error {
 	ret := _m.Called(kind, tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricDisruptionsCount")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(types.DisruptionKindName, []string) error); ok {
@@ -373,6 +405,10 @@ func (_c *SinkMock_MetricDisruptionsCount_Call) RunAndReturn(run func(types.Disr
 func (_m *SinkMock) MetricDisruptionsGauge(gauge float64) error {
 	ret := _m.Called(gauge)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricDisruptionsGauge")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(float64) error); ok {
 		r0 = rf(gauge)
@@ -414,6 +450,10 @@ func (_c *SinkMock_MetricDisruptionsGauge_Call) RunAndReturn(run func(float64) e
 // MetricInformed provides a mock function with given fields: tags
 func (_m *SinkMock) MetricInformed(tags []string) error {
 	ret := _m.Called(tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricInformed")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string) error); ok {
@@ -457,6 +497,10 @@ func (_c *SinkMock_MetricInformed_Call) RunAndReturn(run func([]string) error) *
 func (_m *SinkMock) MetricInjectDuration(duration time.Duration, tags []string) error {
 	ret := _m.Called(duration, tags)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricInjectDuration")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(time.Duration, []string) error); ok {
 		r0 = rf(duration, tags)
@@ -499,6 +543,10 @@ func (_c *SinkMock_MetricInjectDuration_Call) RunAndReturn(run func(time.Duratio
 // MetricInjected provides a mock function with given fields: succeed, kind, tags
 func (_m *SinkMock) MetricInjected(succeed bool, kind string, tags []string) error {
 	ret := _m.Called(succeed, kind, tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricInjected")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(bool, string, []string) error); ok {
@@ -544,6 +592,10 @@ func (_c *SinkMock_MetricInjected_Call) RunAndReturn(run func(bool, string, []st
 func (_m *SinkMock) MetricOrphanFound(tags []string) error {
 	ret := _m.Called(tags)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricOrphanFound")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string) error); ok {
 		r0 = rf(tags)
@@ -585,6 +637,10 @@ func (_c *SinkMock_MetricOrphanFound_Call) RunAndReturn(run func([]string) error
 // MetricPodsCreated provides a mock function with given fields: target, instanceName, namespace, succeed
 func (_m *SinkMock) MetricPodsCreated(target string, instanceName string, namespace string, succeed bool) error {
 	ret := _m.Called(target, instanceName, namespace, succeed)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricPodsCreated")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, string, bool) error); ok {
@@ -631,6 +687,10 @@ func (_c *SinkMock_MetricPodsCreated_Call) RunAndReturn(run func(string, string,
 func (_m *SinkMock) MetricPodsGauge(gauge float64) error {
 	ret := _m.Called(gauge)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricPodsGauge")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(float64) error); ok {
 		r0 = rf(gauge)
@@ -673,6 +733,10 @@ func (_c *SinkMock_MetricPodsGauge_Call) RunAndReturn(run func(float64) error) *
 func (_m *SinkMock) MetricReconcile() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricReconcile")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -713,6 +777,10 @@ func (_c *SinkMock_MetricReconcile_Call) RunAndReturn(run func() error) *SinkMoc
 // MetricReconcileDuration provides a mock function with given fields: duration, tags
 func (_m *SinkMock) MetricReconcileDuration(duration time.Duration, tags []string) error {
 	ret := _m.Called(duration, tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricReconcileDuration")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(time.Duration, []string) error); ok {
@@ -756,6 +824,10 @@ func (_c *SinkMock_MetricReconcileDuration_Call) RunAndReturn(run func(time.Dura
 // MetricReinjected provides a mock function with given fields: succeed, kind, tags
 func (_m *SinkMock) MetricReinjected(succeed bool, kind string, tags []string) error {
 	ret := _m.Called(succeed, kind, tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricReinjected")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(bool, string, []string) error); ok {
@@ -801,6 +873,10 @@ func (_c *SinkMock_MetricReinjected_Call) RunAndReturn(run func(bool, string, []
 func (_m *SinkMock) MetricRestart() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricRestart")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -841,6 +917,10 @@ func (_c *SinkMock_MetricRestart_Call) RunAndReturn(run func() error) *SinkMock_
 // MetricSelectorCacheGauge provides a mock function with given fields: gauge
 func (_m *SinkMock) MetricSelectorCacheGauge(gauge float64) error {
 	ret := _m.Called(gauge)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricSelectorCacheGauge")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(float64) error); ok {
@@ -884,6 +964,10 @@ func (_c *SinkMock_MetricSelectorCacheGauge_Call) RunAndReturn(run func(float64)
 func (_m *SinkMock) MetricStuckOnRemoval(tags []string) error {
 	ret := _m.Called(tags)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricStuckOnRemoval")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string) error); ok {
 		r0 = rf(tags)
@@ -925,6 +1009,10 @@ func (_c *SinkMock_MetricStuckOnRemoval_Call) RunAndReturn(run func([]string) er
 // MetricStuckOnRemovalGauge provides a mock function with given fields: gauge
 func (_m *SinkMock) MetricStuckOnRemovalGauge(gauge float64) error {
 	ret := _m.Called(gauge)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricStuckOnRemovalGauge")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(float64) error); ok {
@@ -968,6 +1056,10 @@ func (_c *SinkMock_MetricStuckOnRemovalGauge_Call) RunAndReturn(run func(float64
 func (_m *SinkMock) MetricValidationCreated(tags []string) error {
 	ret := _m.Called(tags)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricValidationCreated")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string) error); ok {
 		r0 = rf(tags)
@@ -1009,6 +1101,10 @@ func (_c *SinkMock_MetricValidationCreated_Call) RunAndReturn(run func([]string)
 // MetricValidationDeleted provides a mock function with given fields: tags
 func (_m *SinkMock) MetricValidationDeleted(tags []string) error {
 	ret := _m.Called(tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricValidationDeleted")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string) error); ok {
@@ -1052,6 +1148,10 @@ func (_c *SinkMock_MetricValidationDeleted_Call) RunAndReturn(run func([]string)
 func (_m *SinkMock) MetricValidationFailed(tags []string) error {
 	ret := _m.Called(tags)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricValidationFailed")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string) error); ok {
 		r0 = rf(tags)
@@ -1093,6 +1193,10 @@ func (_c *SinkMock_MetricValidationFailed_Call) RunAndReturn(run func([]string) 
 // MetricValidationUpdated provides a mock function with given fields: tags
 func (_m *SinkMock) MetricValidationUpdated(tags []string) error {
 	ret := _m.Called(tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricValidationUpdated")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string) error); ok {
@@ -1136,6 +1240,10 @@ func (_c *SinkMock_MetricValidationUpdated_Call) RunAndReturn(run func([]string)
 func (_m *SinkMock) MetricWatcherCalls(tags []string) error {
 	ret := _m.Called(tags)
 
+	if len(ret) == 0 {
+		panic("no return value specified for MetricWatcherCalls")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string) error); ok {
 		r0 = rf(tags)
@@ -1174,13 +1282,12 @@ func (_c *SinkMock_MetricWatcherCalls_Call) RunAndReturn(run func([]string) erro
 	return _c
 }
 
-type mockConstructorTestingTNewSinkMock interface {
+// NewSinkMock creates a new instance of SinkMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewSinkMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewSinkMock creates a new instance of SinkMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewSinkMock(t mockConstructorTestingTNewSinkMock) *SinkMock {
+}) *SinkMock {
 	mock := &SinkMock{}
 	mock.Mock.Test(t)
 

--- a/o11y/profiler/sink_mock.go
+++ b/o11y/profiler/sink_mock.go
@@ -25,6 +25,10 @@ func (_m *SinkMock) EXPECT() *SinkMock_Expecter {
 func (_m *SinkMock) GetSinkName() string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetSinkName")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
@@ -94,13 +98,12 @@ func (_c *SinkMock_Stop_Call) RunAndReturn(run func()) *SinkMock_Stop_Call {
 	return _c
 }
 
-type mockConstructorTestingTNewSinkMock interface {
+// NewSinkMock creates a new instance of SinkMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewSinkMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewSinkMock creates a new instance of SinkMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewSinkMock(t mockConstructorTestingTNewSinkMock) *SinkMock {
+}) *SinkMock {
 	mock := &SinkMock{}
 	mock.Mock.Test(t)
 

--- a/process/manager_mock.go
+++ b/process/manager_mock.go
@@ -29,6 +29,10 @@ func (_m *ManagerMock) EXPECT() *ManagerMock_Expecter {
 func (_m *ManagerMock) Exists(pid int) (bool, error) {
 	ret := _m.Called(pid)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Exists")
+	}
+
 	var r0 bool
 	var r1 error
 	if rf, ok := ret.Get(0).(func(int) (bool, error)); ok {
@@ -80,6 +84,10 @@ func (_c *ManagerMock_Exists_Call) RunAndReturn(run func(int) (bool, error)) *Ma
 // Find provides a mock function with given fields: pid
 func (_m *ManagerMock) Find(pid int) (*os.Process, error) {
 	ret := _m.Called(pid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Find")
+	}
 
 	var r0 *os.Process
 	var r1 error
@@ -135,6 +143,10 @@ func (_c *ManagerMock_Find_Call) RunAndReturn(run func(int) (*os.Process, error)
 func (_m *ManagerMock) Prioritize() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Prioritize")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -175,6 +187,10 @@ func (_c *ManagerMock_Prioritize_Call) RunAndReturn(run func() error) *ManagerMo
 // ProcessID provides a mock function with given fields:
 func (_m *ManagerMock) ProcessID() int {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ProcessID")
+	}
 
 	var r0 int
 	if rf, ok := ret.Get(0).(func() int); ok {
@@ -217,6 +233,10 @@ func (_c *ManagerMock_ProcessID_Call) RunAndReturn(run func() int) *ManagerMock_
 func (_m *ManagerMock) SetAffinity(_a0 []int) error {
 	ret := _m.Called(_a0)
 
+	if len(ret) == 0 {
+		panic("no return value specified for SetAffinity")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]int) error); ok {
 		r0 = rf(_a0)
@@ -258,6 +278,10 @@ func (_c *ManagerMock_SetAffinity_Call) RunAndReturn(run func([]int) error) *Man
 // Signal provides a mock function with given fields: process, signal
 func (_m *ManagerMock) Signal(process *os.Process, signal os.Signal) error {
 	ret := _m.Called(process, signal)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Signal")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*os.Process, os.Signal) error); ok {
@@ -302,6 +326,10 @@ func (_c *ManagerMock_Signal_Call) RunAndReturn(run func(*os.Process, os.Signal)
 func (_m *ManagerMock) ThreadID() int {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for ThreadID")
+	}
+
 	var r0 int
 	if rf, ok := ret.Get(0).(func() int); ok {
 		r0 = rf()
@@ -339,13 +367,12 @@ func (_c *ManagerMock_ThreadID_Call) RunAndReturn(run func() int) *ManagerMock_T
 	return _c
 }
 
-type mockConstructorTestingTNewManagerMock interface {
+// NewManagerMock creates a new instance of ManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewManagerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewManagerMock creates a new instance of ManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewManagerMock(t mockConstructorTestingTNewManagerMock) *ManagerMock {
+}) *ManagerMock {
 	mock := &ManagerMock{}
 	mock.Mock.Test(t)
 

--- a/process/runtime_mock.go
+++ b/process/runtime_mock.go
@@ -25,6 +25,10 @@ func (_m *RuntimeMock) EXPECT() *RuntimeMock_Expecter {
 func (_m *RuntimeMock) GOMAXPROCS(_a0 int) int {
 	ret := _m.Called(_a0)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GOMAXPROCS")
+	}
+
 	var r0 int
 	if rf, ok := ret.Get(0).(func(int) int); ok {
 		r0 = rf(_a0)
@@ -127,13 +131,12 @@ func (_c *RuntimeMock_UnlockOSThread_Call) RunAndReturn(run func()) *RuntimeMock
 	return _c
 }
 
-type mockConstructorTestingTNewRuntimeMock interface {
+// NewRuntimeMock creates a new instance of RuntimeMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewRuntimeMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewRuntimeMock creates a new instance of RuntimeMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewRuntimeMock(t mockConstructorTestingTNewRuntimeMock) *RuntimeMock {
+}) *RuntimeMock {
 	mock := &RuntimeMock{}
 	mock.Mock.Test(t)
 

--- a/safemode/safemode_mock.go
+++ b/safemode/safemode_mock.go
@@ -60,13 +60,12 @@ func (_c *SafemodeMock_Init_Call) RunAndReturn(run func(v1beta1.Disruption, clie
 	return _c
 }
 
-type mockConstructorTestingTNewSafemodeMock interface {
+// NewSafemodeMock creates a new instance of SafemodeMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewSafemodeMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewSafemodeMock creates a new instance of SafemodeMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewSafemodeMock(t mockConstructorTestingTNewSafemodeMock) *SafemodeMock {
+}) *SafemodeMock {
 	mock := &SafemodeMock{}
 	mock.Mock.Test(t)
 

--- a/targetselector/target_selector_mock.go
+++ b/targetselector/target_selector_mock.go
@@ -32,6 +32,10 @@ func (_m *TargetSelectorMock) EXPECT() *TargetSelectorMock_Expecter {
 func (_m *TargetSelectorMock) GetMatchingNodesOverTotalNodes(c client.Client, instance *v1beta1.Disruption) (*v1.NodeList, int, error) {
 	ret := _m.Called(c, instance)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetMatchingNodesOverTotalNodes")
+	}
+
 	var r0 *v1.NodeList
 	var r1 int
 	var r2 error
@@ -93,6 +97,10 @@ func (_c *TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call) RunAndReturn(r
 // GetMatchingPodsOverTotalPods provides a mock function with given fields: c, instance
 func (_m *TargetSelectorMock) GetMatchingPodsOverTotalPods(c client.Client, instance *v1beta1.Disruption) (*v1.PodList, int, error) {
 	ret := _m.Called(c, instance)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMatchingPodsOverTotalPods")
+	}
 
 	var r0 *v1.PodList
 	var r1 int
@@ -156,6 +164,10 @@ func (_c *TargetSelectorMock_GetMatchingPodsOverTotalPods_Call) RunAndReturn(run
 func (_m *TargetSelectorMock) TargetIsHealthy(target string, c client.Client, instance *v1beta1.Disruption) error {
 	ret := _m.Called(target, c, instance)
 
+	if len(ret) == 0 {
+		panic("no return value specified for TargetIsHealthy")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, client.Client, *v1beta1.Disruption) error); ok {
 		r0 = rf(target, c, instance)
@@ -196,13 +208,12 @@ func (_c *TargetSelectorMock_TargetIsHealthy_Call) RunAndReturn(run func(string,
 	return _c
 }
 
-type mockConstructorTestingTNewTargetSelectorMock interface {
+// NewTargetSelectorMock creates a new instance of TargetSelectorMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewTargetSelectorMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewTargetSelectorMock creates a new instance of TargetSelectorMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewTargetSelectorMock(t mockConstructorTestingTNewTargetSelectorMock) *TargetSelectorMock {
+}) *TargetSelectorMock {
 	mock := &TargetSelectorMock{}
 	mock.Mock.Test(t)
 

--- a/watchers/cache_context_func_mock.go
+++ b/watchers/cache_context_func_mock.go
@@ -29,6 +29,10 @@ func (_m *CacheContextFuncMock) EXPECT() *CacheContextFuncMock_Expecter {
 func (_m *CacheContextFuncMock) Execute() (context.Context, context.CancelFunc) {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Execute")
+	}
+
 	var r0 context.Context
 	var r1 context.CancelFunc
 	if rf, ok := ret.Get(0).(func() (context.Context, context.CancelFunc)); ok {
@@ -80,13 +84,12 @@ func (_c *CacheContextFuncMock_Execute_Call) RunAndReturn(run func() (context.Co
 	return _c
 }
 
-type mockConstructorTestingTNewCacheContextFuncMock interface {
+// NewCacheContextFuncMock creates a new instance of CacheContextFuncMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewCacheContextFuncMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewCacheContextFuncMock creates a new instance of CacheContextFuncMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewCacheContextFuncMock(t mockConstructorTestingTNewCacheContextFuncMock) *CacheContextFuncMock {
+}) *CacheContextFuncMock {
 	mock := &CacheContextFuncMock{}
 	mock.Mock.Test(t)
 

--- a/watchers/disruptions_watchers_manager_mock.go
+++ b/watchers/disruptions_watchers_manager_mock.go
@@ -30,6 +30,10 @@ func (_m *DisruptionsWatchersManagerMock) EXPECT() *DisruptionsWatchersManagerMo
 func (_m *DisruptionsWatchersManagerMock) CreateAllWatchers(disruption *v1beta1.Disruption, watcherManagerMock Manager, cacheMock cache.Cache) error {
 	ret := _m.Called(disruption, watcherManagerMock, cacheMock)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateAllWatchers")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*v1beta1.Disruption, Manager, cache.Cache) error); ok {
 		r0 = rf(disruption, watcherManagerMock, cacheMock)
@@ -106,6 +110,10 @@ func (_c *DisruptionsWatchersManagerMock_RemoveAllExpiredWatchers_Call) RunAndRe
 func (_m *DisruptionsWatchersManagerMock) RemoveAllOrphanWatchers() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveAllOrphanWatchers")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -176,13 +184,12 @@ func (_c *DisruptionsWatchersManagerMock_RemoveAllWatchers_Call) RunAndReturn(ru
 	return _c
 }
 
-type mockConstructorTestingTNewDisruptionsWatchersManagerMock interface {
+// NewDisruptionsWatchersManagerMock creates a new instance of DisruptionsWatchersManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewDisruptionsWatchersManagerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewDisruptionsWatchersManagerMock creates a new instance of DisruptionsWatchersManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewDisruptionsWatchersManagerMock(t mockConstructorTestingTNewDisruptionsWatchersManagerMock) *DisruptionsWatchersManagerMock {
+}) *DisruptionsWatchersManagerMock {
 	mock := &DisruptionsWatchersManagerMock{}
 	mock.Mock.Test(t)
 

--- a/watchers/factory_mock.go
+++ b/watchers/factory_mock.go
@@ -30,6 +30,10 @@ func (_m *FactoryMock) EXPECT() *FactoryMock_Expecter {
 func (_m *FactoryMock) NewChaosPodWatcher(name string, disruption *v1beta1.Disruption, cacheMock cache.Cache) (Watcher, error) {
 	ret := _m.Called(name, disruption, cacheMock)
 
+	if len(ret) == 0 {
+		panic("no return value specified for NewChaosPodWatcher")
+	}
+
 	var r0 Watcher
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string, *v1beta1.Disruption, cache.Cache) (Watcher, error)); ok {
@@ -86,6 +90,10 @@ func (_c *FactoryMock_NewChaosPodWatcher_Call) RunAndReturn(run func(string, *v1
 func (_m *FactoryMock) NewDisruptionTargetWatcher(name string, enableObserver bool, disruption *v1beta1.Disruption, cacheMock cache.Cache) (Watcher, error) {
 	ret := _m.Called(name, enableObserver, disruption, cacheMock)
 
+	if len(ret) == 0 {
+		panic("no return value specified for NewDisruptionTargetWatcher")
+	}
+
 	var r0 Watcher
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string, bool, *v1beta1.Disruption, cache.Cache) (Watcher, error)); ok {
@@ -139,13 +147,12 @@ func (_c *FactoryMock_NewDisruptionTargetWatcher_Call) RunAndReturn(run func(str
 	return _c
 }
 
-type mockConstructorTestingTNewFactoryMock interface {
+// NewFactoryMock creates a new instance of FactoryMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewFactoryMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewFactoryMock creates a new instance of FactoryMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewFactoryMock(t mockConstructorTestingTNewFactoryMock) *FactoryMock {
+}) *FactoryMock {
 	mock := &FactoryMock{}
 	mock.Mock.Test(t)
 

--- a/watchers/manager_mock.go
+++ b/watchers/manager_mock.go
@@ -25,6 +25,10 @@ func (_m *ManagerMock) EXPECT() *ManagerMock_Expecter {
 func (_m *ManagerMock) AddWatcher(watcher Watcher) error {
 	ret := _m.Called(watcher)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AddWatcher")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(Watcher) error); ok {
 		r0 = rf(watcher)
@@ -66,6 +70,10 @@ func (_c *ManagerMock_AddWatcher_Call) RunAndReturn(run func(Watcher) error) *Ma
 // GetWatcher provides a mock function with given fields: name
 func (_m *ManagerMock) GetWatcher(name string) Watcher {
 	ret := _m.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetWatcher")
+	}
 
 	var r0 Watcher
 	if rf, ok := ret.Get(0).(func(string) Watcher); ok {
@@ -207,6 +215,10 @@ func (_c *ManagerMock_RemoveOrphanWatchers_Call) RunAndReturn(run func()) *Manag
 func (_m *ManagerMock) RemoveWatcher(watcher Watcher) error {
 	ret := _m.Called(watcher)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveWatcher")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(Watcher) error); ok {
 		r0 = rf(watcher)
@@ -245,13 +257,12 @@ func (_c *ManagerMock_RemoveWatcher_Call) RunAndReturn(run func(Watcher) error) 
 	return _c
 }
 
-type mockConstructorTestingTNewManagerMock interface {
+// NewManagerMock creates a new instance of ManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewManagerMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewManagerMock creates a new instance of ManagerMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewManagerMock(t mockConstructorTestingTNewManagerMock) *ManagerMock {
+}) *ManagerMock {
 	mock := &ManagerMock{}
 	mock.Mock.Test(t)
 

--- a/watchers/watcher_metrics_adapter_mock.go
+++ b/watchers/watcher_metrics_adapter_mock.go
@@ -65,13 +65,12 @@ func (_c *WatcherMetricsAdapterMock_OnChange_Call) RunAndReturn(run func(*v1beta
 	return _c
 }
 
-type mockConstructorTestingTNewWatcherMetricsAdapterMock interface {
+// NewWatcherMetricsAdapterMock creates a new instance of WatcherMetricsAdapterMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewWatcherMetricsAdapterMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewWatcherMetricsAdapterMock creates a new instance of WatcherMetricsAdapterMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewWatcherMetricsAdapterMock(t mockConstructorTestingTNewWatcherMetricsAdapterMock) *WatcherMetricsAdapterMock {
+}) *WatcherMetricsAdapterMock {
 	mock := &WatcherMetricsAdapterMock{}
 	mock.Mock.Test(t)
 

--- a/watchers/watcher_mock.go
+++ b/watchers/watcher_mock.go
@@ -60,6 +60,10 @@ func (_c *WatcherMock_Clean_Call) RunAndReturn(run func()) *WatcherMock_Clean_Ca
 func (_m *WatcherMock) GetCacheSource() (source.SyncingSource, error) {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetCacheSource")
+	}
+
 	var r0 source.SyncingSource
 	var r1 error
 	if rf, ok := ret.Get(0).(func() (source.SyncingSource, error)); ok {
@@ -113,6 +117,10 @@ func (_c *WatcherMock_GetCacheSource_Call) RunAndReturn(run func() (source.Synci
 func (_m *WatcherMock) GetConfig() WatcherConfig {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetConfig")
+	}
+
 	var r0 WatcherConfig
 	if rf, ok := ret.Get(0).(func() WatcherConfig); ok {
 		r0 = rf()
@@ -153,6 +161,10 @@ func (_c *WatcherMock_GetConfig_Call) RunAndReturn(run func() WatcherConfig) *Wa
 // GetContextTuple provides a mock function with given fields:
 func (_m *WatcherMock) GetContextTuple() (CtxTuple, error) {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetContextTuple")
+	}
 
 	var r0 CtxTuple
 	var r1 error
@@ -205,6 +217,10 @@ func (_c *WatcherMock_GetContextTuple_Call) RunAndReturn(run func() (CtxTuple, e
 func (_m *WatcherMock) GetName() string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetName")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
@@ -245,6 +261,10 @@ func (_c *WatcherMock_GetName_Call) RunAndReturn(run func() string) *WatcherMock
 // IsExpired provides a mock function with given fields:
 func (_m *WatcherMock) IsExpired() bool {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsExpired")
+	}
 
 	var r0 bool
 	if rf, ok := ret.Get(0).(func() bool); ok {
@@ -287,6 +307,10 @@ func (_c *WatcherMock_IsExpired_Call) RunAndReturn(run func() bool) *WatcherMock
 func (_m *WatcherMock) Start() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Start")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -324,13 +348,12 @@ func (_c *WatcherMock_Start_Call) RunAndReturn(run func() error) *WatcherMock_St
 	return _c
 }
 
-type mockConstructorTestingTNewWatcherMock interface {
+// NewWatcherMock creates a new instance of WatcherMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewWatcherMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewWatcherMock creates a new instance of WatcherMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewWatcherMock(t mockConstructorTestingTNewWatcherMock) *WatcherMock {
+}) *WatcherMock {
 	mock := &WatcherMock{}
 	mock.Mock.Test(t)
 


### PR DESCRIPTION
Upgrade mockery to the [latest version](https://github.com/vektra/mockery/releases/tag/v2.38.0). 