### PR TITLE
[CHAOSPLT-147] Metrics for Cron and Rollout Controllers

### DIFF
--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -207,7 +207,6 @@ func GetMostRecentScheduleTime(log *zap.SugaredLogger, disruptions *chaosv1beta1
 			}
 		}
 	}
-
 	return mostRecentScheduleTime
 }
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -94,7 +94,7 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	r.log = r.BaseLog.With("disruptionName", req.Name, "disruptionNamespace", req.Namespace)
 
 	// reconcile metrics
-	r.handleMetricSinkError(r.MetricsSink.MetricReconcile())
+	r.handleMetricSinkError(r.MetricsSink.MetricReconcile([]string{"controller", r.MetricsSink.GetSinkName()}))
 
 	defer func(tsStart time.Time) {
 		tags := []string{}

--- a/controllers/disruption_rollout_controller.go
+++ b/controllers/disruption_rollout_controller.go
@@ -7,6 +7,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/DataDog/chaos-controller/o11y/metrics"
 	"math/rand"
 	"time"
 
@@ -19,10 +20,11 @@ import (
 )
 
 type DisruptionRolloutReconciler struct {
-	Client  client.Client
-	Scheme  *runtime.Scheme
-	BaseLog *zap.SugaredLogger
-	log     *zap.SugaredLogger
+	Client      client.Client
+	Scheme      *runtime.Scheme
+	BaseLog     *zap.SugaredLogger
+	log         *zap.SugaredLogger
+	MetricsSink metrics.Sink
 }
 
 func (r *DisruptionRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
@@ -31,6 +33,18 @@ func (r *DisruptionRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	instance := &chaosv1beta1.DisruptionRollout{}
 	randSource := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// reconcile metrics
+	r.handleMetricSinkError(r.MetricsSink.MetricReconcile([]string{"rolloutName:" + instance.Name, "namespace:", instance.Namespace}))
+
+	defer func(tsStart time.Time) {
+		tags := []string{}
+		if instance.Name != "" {
+			tags = append(tags, "rolloutName:"+instance.Name, "namespace:"+instance.Namespace)
+		}
+
+		r.handleMetricSinkError(r.MetricsSink.MetricReconcileDuration(time.Since(tsStart), tags))
+	}(time.Now())
 
 	// Fetch DisruptionRollout instance
 	if err := r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
@@ -107,6 +121,8 @@ func (r *DisruptionRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	if tooLate {
+		// TODO: Add MetricTooLate
+		r.handleMetricSinkError(r.MetricsSink.MetricTooLate([]string{"rolloutName:" + instance.Name, "namespace:", instance.Namespace, "targetName:", instance.Spec.TargetResource.Name}))
 		r.log.Infow("missed schedule to start a disruption, sleeping",
 			"LastContainerChangeTime", instance.Status.LastContainerChangeTime,
 			"DelayedStartTolerance", instance.Spec.DelayedStartTolerance)
@@ -127,7 +143,8 @@ func (r *DisruptionRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		r.log.Warnw("unable to create Disruption for DisruptionRollout", "disruption", disruption, "err", err)
 		return ctrl.Result{}, err
 	}
-
+	// TODO: Add MetricDisruptionScheduled here
+	r.handleMetricSinkError(r.MetricsSink.MetricDisruptionScheduled([]string{"rolloutName:" + instance.Name, "namespace:", instance.Namespace, "targetName:", instance.Spec.TargetResource.Name, "disruptionName:", disruption.Name}))
 	r.log.Infow("created Disruption for DisruptionRollout run", "disruptionName", disruption.Name)
 
 	// ------------------------------------------------------------------ //
@@ -138,7 +155,6 @@ func (r *DisruptionRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Add the start time of the just initiated disruption to the status
 	instance.Status.LastScheduleTime = &metav1.Time{Time: scheduledTime}
-
 	if err := r.Client.Status().Update(ctx, instance); err != nil {
 		r.log.Warnw("unable to update LastScheduleTime of DisruptionCron status", "err", err)
 		return ctrl.Result{}, err
@@ -177,7 +193,8 @@ func (r *DisruptionRolloutReconciler) updateTargetResourcePreviouslyMissing(ctx 
 
 		if instance.Status.TargetResourcePreviouslyMissing == nil {
 			r.log.Warnw("target is missing for the first time, updating status")
-
+			// TODO: Add MetricTargetMissing here
+			r.handleMetricSinkError(r.MetricsSink.MetricTargetMissing(0, []string{"rolloutName:" + instance.Name, "namespace:", instance.Namespace, "targetName:", instance.Spec.TargetResource.Name}))
 			return targetResourceExists, disruptionRolloutDeleted, r.handleTargetResourceFirstMissing(ctx, instance)
 		}
 
@@ -186,12 +203,14 @@ func (r *DisruptionRolloutReconciler) updateTargetResourcePreviouslyMissing(ctx 
 				"timeMissing", time.Since(instance.Status.TargetResourcePreviouslyMissing.Time))
 
 			disruptionRolloutDeleted = true
-
+			// TODO: Add MetricTargetMissing here with time ^
+			r.handleMetricSinkError(r.MetricsSink.MetricTargetMissing(time.Since(instance.Status.TargetResourcePreviouslyMissing.Time), []string{"rolloutName:" + instance.Name, "namespace:", instance.Namespace, "targetName:", instance.Spec.TargetResource.Name}))
 			return targetResourceExists, disruptionRolloutDeleted, r.handleTargetResourceMissingPastExpiration(ctx, instance)
 		}
 	} else if instance.Status.TargetResourcePreviouslyMissing != nil {
 		r.log.Infow("target was previously missing, but now present. updating the status accordingly")
-
+		// TODO: Add MetricTargetFound here
+		r.handleMetricSinkError(r.MetricsSink.MetricMissingTargetFound([]string{"rolloutName:" + instance.Name, "namespace:", instance.Namespace, "targetName:", instance.Spec.TargetResource.Name}))
 		return targetResourceExists, disruptionRolloutDeleted, r.handleTargetResourceNowPresent(ctx, instance)
 	}
 
@@ -228,6 +247,13 @@ func (r *DisruptionRolloutReconciler) handleTargetResourceNowPresent(ctx context
 	}
 
 	return nil
+}
+
+// handleMetricSinkError logs the given metric sink error if it is not nil
+func (r *DisruptionRolloutReconciler) handleMetricSinkError(err error) {
+	if err != nil {
+		r.log.Errorw("error sending a metric", "error", err)
+	}
 }
 
 // targetResourceUpdated checks whether the target resource has been updated or not.

--- a/examples/disruption_crons/disruption_cron_network_drop.yaml
+++ b/examples/disruption_crons/disruption_cron_network_drop.yaml
@@ -9,7 +9,7 @@ metadata:
   name: network-drop
   namespace: chaos-demo
 spec:
-  schedule: "*/15 * * * *"
+  schedule: "*/2 * * * *"
   targetResource:
     kind: deployment
     name: demo-curl

--- a/o11y/metrics/datadog/datadog.go
+++ b/o11y/metrics/datadog/datadog.go
@@ -16,13 +16,16 @@ import (
 )
 
 const (
-	metricPrefixInjector   = "chaos.injector."
-	metricPrefixController = "chaos.controller."
+	metricPrefixInjector          = "chaos.injector."
+	metricPrefixController        = "chaos.controller."
+	metricPrefixRolloutController = "chaos.rollout.controller."
+	metricPrefixCronController    = "chaos.cron.controller."
 )
 
 // Sink describes a Datadog sink (statsd)
 type Sink struct {
 	client *statsd.Client
+	prefix string
 }
 
 // New instantiate a new datadog statsd provider
@@ -34,9 +37,31 @@ func New(app types.SinkApp) (Sink, error) {
 		return Sink{}, err
 	}
 
+	prefix, err := GetPrefixFromApp(app)
+	if err != nil {
+		return Sink{}, err
+	}
+
 	return Sink{
 		client: instance,
+		prefix: prefix,
 	}, nil
+}
+
+// GetPrefixFromApp returns the datadog metrics prefix given the App
+func GetPrefixFromApp(app types.SinkApp) (string, error) {
+	switch app {
+	case types.SinkAppController:
+		return metricPrefixController, nil
+	case types.SinkAppRolloutController:
+		return metricPrefixRolloutController, nil
+	case types.SinkAppCronController:
+		return metricPrefixCronController, nil
+	case types.SinkAppInjector:
+		return metricPrefixInjector, nil
+	default:
+		return "", fmt.Errorf("unknown sink app")
+	}
 }
 
 // Close closes the statsd client
@@ -55,7 +80,7 @@ func (d Sink) MetricInjected(succeed bool, kind string, tags []string) error {
 	t := []string{"status:" + status, "kind:" + kind}
 	t = append(t, tags...)
 
-	return d.metricWithStatus(metricPrefixInjector+"injected", t)
+	return d.metricWithStatus(d.prefix+"injected", t)
 }
 
 // MetricReinjected increments the reinjected metric
@@ -64,7 +89,7 @@ func (d Sink) MetricReinjected(succeed bool, kind string, tags []string) error {
 	t := []string{"status:" + status, "kind:" + kind}
 	t = append(t, tags...)
 
-	return d.metricWithStatus(metricPrefixInjector+"reinjected", t)
+	return d.metricWithStatus(d.prefix+"reinjected", t)
 }
 
 // MetricCleanedForReinjection increments the cleanedForReinjection metric
@@ -73,7 +98,7 @@ func (d Sink) MetricCleanedForReinjection(succeed bool, kind string, tags []stri
 	t := []string{"status:" + status, "kind:" + kind}
 	t = append(t, tags...)
 
-	return d.metricWithStatus(metricPrefixInjector+"cleaned_for_reinjection", t)
+	return d.metricWithStatus(d.prefix+"cleaned_for_reinjection", t)
 }
 
 // MetricCleaned increments the cleaned metric
@@ -82,37 +107,37 @@ func (d Sink) MetricCleaned(succeed bool, kind string, tags []string) error {
 	t := []string{"status:" + status, "kind:" + kind}
 	t = append(t, tags...)
 
-	return d.metricWithStatus(metricPrefixInjector+"cleaned", t)
+	return d.metricWithStatus(d.prefix+"cleaned", t)
 }
 
 // MetricReconcile increment reconcile metric
-func (d Sink) MetricReconcile() error {
-	return d.metricWithStatus(metricPrefixController+"reconcile", []string{})
+func (d Sink) MetricReconcile(tags []string) error {
+	return d.metricWithStatus(d.prefix+"reconcile", tags)
 }
 
 // MetricReconcileDuration send timing metric for reconcile loop
 func (d Sink) MetricReconcileDuration(duration time.Duration, tags []string) error {
-	return d.timing(metricPrefixController+"reconcile.duration", duration, tags)
+	return d.timing(d.prefix+"reconcile.duration", duration, tags)
 }
 
 // MetricCleanupDuration send timing metric for cleanup duration
 func (d Sink) MetricCleanupDuration(duration time.Duration, tags []string) error {
-	return d.timing(metricPrefixController+"cleanup.duration", duration, tags)
+	return d.timing(d.prefix+"cleanup.duration", duration, tags)
 }
 
 // MetricInjectDuration send timing metric for inject duration
 func (d Sink) MetricInjectDuration(duration time.Duration, tags []string) error {
-	return d.timing(metricPrefixController+"inject.duration", duration, tags)
+	return d.timing(d.prefix+"inject.duration", duration, tags)
 }
 
 // MetricDisruptionCompletedDuration sends timing metric for entire disruption duration
 func (d Sink) MetricDisruptionCompletedDuration(duration time.Duration, tags []string) error {
-	return d.timing(metricPrefixController+"disruption.completed_duration", duration, tags)
+	return d.timing(d.prefix+"disruption.completed_duration", duration, tags)
 }
 
 // MetricDisruptionOngoingDuration sends timing metric for disruption duration so far
 func (d Sink) MetricDisruptionOngoingDuration(duration time.Duration, tags []string) error {
-	return d.timing(metricPrefixController+"disruption.ongoing_duration", duration, tags)
+	return d.timing(d.prefix+"disruption.ongoing_duration", duration, tags)
 }
 
 // MetricPodsCreated increment pods.created metric
@@ -120,78 +145,106 @@ func (d Sink) MetricPodsCreated(target, instanceName, namespace string, succeed 
 	status := boolToStatus(succeed)
 	tags := []string{"target:" + target, "disruptionName:" + instanceName, "status:" + status, "namespace:" + namespace}
 
-	return d.metricWithStatus(metricPrefixController+"pods.created", tags)
+	return d.metricWithStatus(d.prefix+"pods.created", tags)
 }
 
 // MetricStuckOnRemoval increments disruptions.stuck_on_removal metric
 func (d Sink) MetricStuckOnRemoval(tags []string) error {
-	return d.metricWithStatus(metricPrefixController+"disruptions.stuck_on_removal", tags)
+	return d.metricWithStatus(d.prefix+"disruptions.stuck_on_removal", tags)
 }
 
 // MetricStuckOnRemovalGauge sends disruptions.stuck_on_removal_total metric containing the gauge of stuck disruptions
 func (d Sink) MetricStuckOnRemovalGauge(gauge float64) error {
-	return d.client.Gauge(metricPrefixController+"disruptions.stuck_on_removal_total", gauge, []string{}, 1)
+	return d.client.Gauge(d.prefix+"disruptions.stuck_on_removal_total", gauge, []string{}, 1)
 }
 
 // MetricDisruptionsGauge sends the disruptions.gauge metric counting ongoing disruptions
 func (d Sink) MetricDisruptionsGauge(gauge float64) error {
-	return d.client.Gauge(metricPrefixController+"disruptions.gauge", gauge, []string{}, 1)
+	return d.client.Gauge(d.prefix+"disruptions.gauge", gauge, []string{}, 1)
 }
 
 // MetricDisruptionsCount counts finished disruptions, and tags the disruption kind
 func (d Sink) MetricDisruptionsCount(kind chaostypes.DisruptionKindName, tags []string) error {
 	tags = append(tags, fmt.Sprintf("disruption_kind:%s", kind))
-	return d.metricWithStatus(metricPrefixController+"disruptions.count", tags)
+	return d.metricWithStatus(d.prefix+"disruptions.count", tags)
 }
 
 // MetricPodsGauge sends the pods.gauge metric counting existing chaos pods
 func (d Sink) MetricPodsGauge(gauge float64) error {
-	return d.client.Gauge(metricPrefixController+"pods.gauge", gauge, []string{}, 1)
+	return d.client.Gauge(d.prefix+"pods.gauge", gauge, []string{}, 1)
 }
 
 // MetricRestart sends an increment of the controller restart metric
 func (d Sink) MetricRestart() error {
-	return d.metricWithStatus(metricPrefixController+"restart", []string{})
+	return d.metricWithStatus(d.prefix+"restart", []string{})
 }
 
 // MetricValidationFailed increments the failed validation metric
 func (d Sink) MetricValidationFailed(tags []string) error {
-	return d.metricWithStatus(metricPrefixController+"validation.failed", tags)
+	return d.metricWithStatus(d.prefix+"validation.failed", tags)
 }
 
 // MetricValidationCreated increments the created validation metric
 func (d Sink) MetricValidationCreated(tags []string) error {
-	return d.metricWithStatus(metricPrefixController+"validation.created", tags)
+	return d.metricWithStatus(d.prefix+"validation.created", tags)
 }
 
 // MetricValidationUpdated increments the updated validation metric
 func (d Sink) MetricValidationUpdated(tags []string) error {
-	return d.metricWithStatus(metricPrefixController+"validation.updated", tags)
+	return d.metricWithStatus(d.prefix+"validation.updated", tags)
 }
 
 // MetricValidationDeleted increments the deleted validation metric
 func (d Sink) MetricValidationDeleted(tags []string) error {
-	return d.metricWithStatus(metricPrefixController+"validation.deleted", tags)
+	return d.metricWithStatus(d.prefix+"validation.deleted", tags)
 }
 
 // MetricInformed increments when the pod informer receives an event to process before reconciliation
 func (d Sink) MetricInformed(tags []string) error {
-	return d.metricWithStatus(metricPrefixController+"informed", tags)
+	return d.metricWithStatus(d.prefix+"informed", tags)
 }
 
 // MetricOrphanFound increments when a chaos pod without a corresponding disruption resource is found
 func (d Sink) MetricOrphanFound(tags []string) error {
-	return d.metricWithStatus(metricPrefixController+"orphan.found", tags)
+	return d.metricWithStatus(d.prefix+"orphan.found", tags)
 }
 
 // MetricWatcherCalls is a counter of watcher calls.
 func (d Sink) MetricWatcherCalls(tags []string) error {
-	return d.metricWithStatus(metricPrefixController+"watcher.calls_total", tags)
+	return d.metricWithStatus(d.prefix+"watcher.calls_total", tags)
 }
 
 // MetricSelectorCacheGauge reports how many caches are still in the cache array to prevent leaks
 func (d Sink) MetricSelectorCacheGauge(gauge float64) error {
-	return d.client.Gauge(metricPrefixController+"selector.cache.gauge", gauge, []string{}, 1)
+	return d.client.Gauge(d.prefix+"selector.cache.gauge", gauge, []string{}, 1)
+}
+
+// MetricTooLate reports when a scheduled disruption misses its aloted time to be scheduled
+// specific to cron and rollout controllers
+func (d Sink) MetricTooLate(tags []string) error {
+	return d.metricWithStatus(d.prefix+"schedule.too_late", tags)
+}
+
+// MetricTargetMissing reports when a scheduled Disruption can not find its specific target
+// either for the first time or multiple times. A deletion occurs on the final alert
+func (d Sink) MetricTargetMissing(duration time.Duration, tags []string) error {
+	return d.timing(d.prefix+"schedule.target_missing", duration, tags)
+}
+
+// MetricMissingTargetFound reports when a scheduled Disruption which had initially been deemed missing
+// is "found" and running in the kubernetes namespace
+func (d Sink) MetricMissingTargetFound(tags []string) error {
+	return d.metricWithStatus(d.prefix+"schedule.missing_target_found", tags)
+}
+
+// MetricNextScheduledTime reports the duration until the next scheduled disruption will run
+func (d Sink) MetricNextScheduledTime(duration time.Duration, tags []string) error {
+	return d.timing(d.prefix+"schedule.next_scheduled", duration, tags)
+}
+
+// MetricDisruptionScheduled reports when a new disruption is scheduled
+func (d Sink) MetricDisruptionScheduled(tags []string) error {
+	return d.metricWithStatus(d.prefix+"schedule.disruption_scheduled", tags)
 }
 
 func boolToStatus(succeed bool) string {

--- a/o11y/metrics/metrics.go
+++ b/o11y/metrics/metrics.go
@@ -27,7 +27,7 @@ type Sink interface {
 	MetricInjected(succeed bool, kind string, tags []string) error
 	MetricReinjected(succeed bool, kind string, tags []string) error
 	MetricPodsCreated(target, instanceName, namespace string, succeed bool) error
-	MetricReconcile() error
+	MetricReconcile(tags []string) error
 	MetricReconcileDuration(duration time.Duration, tags []string) error
 	MetricDisruptionCompletedDuration(duration time.Duration, tags []string) error
 	MetricDisruptionOngoingDuration(duration time.Duration, tags []string) error
@@ -45,6 +45,11 @@ type Sink interface {
 	MetricValidationDeleted(tags []string) error
 	MetricInformed(tags []string) error
 	MetricOrphanFound(tags []string) error
+	MetricTooLate(tags []string) error
+	MetricTargetMissing(duration time.Duration, tags []string) error
+	MetricMissingTargetFound(tags []string) error
+	MetricNextScheduledTime(time time.Duration, tags []string) error
+	MetricDisruptionScheduled(tags []string) error
 }
 
 // GetSink returns an initiated sink

--- a/o11y/metrics/noop/noop.go
+++ b/o11y/metrics/noop/noop.go
@@ -93,8 +93,8 @@ func (n Sink) MetricDisruptionOngoingDuration(duration time.Duration, tags []str
 }
 
 // MetricReconcile increment reconcile metric
-func (n Sink) MetricReconcile() error {
-	fmt.Println("NOOP: MetricReconcile +1")
+func (n Sink) MetricReconcile(tags []string) error {
+	n.log.Debugf("NOOP: MetricReconcile +1 %s\n", tags)
 
 	return nil
 }
@@ -201,6 +201,44 @@ func (n Sink) MetricWatcherCalls(tags []string) error {
 // MetricSelectorCacheGauge reports how many caches are still in the cache array to prevent leaks
 func (n Sink) MetricSelectorCacheGauge(gauge float64) error {
 	n.log.Debugf("NOOP: MetricSelectorCacheGauge %f\n", gauge)
+
+	return nil
+}
+
+// MetricTooLate reports when a scheduled disruption misses its aloted time to be scheduled
+// specific to cron and rollout controllers
+func (n Sink) MetricTooLate(tags []string) error {
+	n.log.Debugf("NOOP: MetricTooLate %s\n", tags)
+
+	return nil
+}
+
+// MetricTargetMissing reports when a scheduled Disruption can not find its specific target
+// either for the first time or multiple times. A deletion occurs on the final alert
+func (n Sink) MetricTargetMissing(duration time.Duration, tags []string) error {
+	n.log.Debugf("NOOP: MetricTargetMissing %v,%s\n", duration, tags)
+
+	return nil
+}
+
+// MetricMissingTargetFound reports when a scheduled Disruption which had initially been deemed missing
+// is "found" and running in the kubernetes namespace
+func (n Sink) MetricMissingTargetFound(tags []string) error {
+	n.log.Debugf("NOOP: MetricMissingTargetFound %s\n", tags)
+
+	return nil
+}
+
+// MetricNextScheduledTime reports the duration until the next scheduled disruption will run
+func (n Sink) MetricNextScheduledTime(duration time.Duration, tags []string) error {
+	n.log.Debugf("NOOP: MetricNextScheduledRun %v, s%s\n", duration, tags)
+
+	return nil
+}
+
+// MetricDisruptionScheduled reports when a new disruption is scheduled
+func (n Sink) MetricDisruptionScheduled(tags []string) error {
+	n.log.Debugf("NOOP: MetricDisruptionScheduled %s\n", tags)
 
 	return nil
 }

--- a/o11y/metrics/sink_mock.go
+++ b/o11y/metrics/sink_mock.go
@@ -326,6 +326,48 @@ func (_c *SinkMock_MetricDisruptionOngoingDuration_Call) RunAndReturn(run func(t
 	return _c
 }
 
+// MetricDisruptionScheduled provides a mock function with given fields: tags
+func (_m *SinkMock) MetricDisruptionScheduled(tags []string) error {
+	ret := _m.Called(tags)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]string) error); ok {
+		r0 = rf(tags)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SinkMock_MetricDisruptionScheduled_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MetricDisruptionScheduled'
+type SinkMock_MetricDisruptionScheduled_Call struct {
+	*mock.Call
+}
+
+// MetricDisruptionScheduled is a helper method to define mock.On call
+//   - tags []string
+func (_e *SinkMock_Expecter) MetricDisruptionScheduled(tags interface{}) *SinkMock_MetricDisruptionScheduled_Call {
+	return &SinkMock_MetricDisruptionScheduled_Call{Call: _e.mock.On("MetricDisruptionScheduled", tags)}
+}
+
+func (_c *SinkMock_MetricDisruptionScheduled_Call) Run(run func(tags []string)) *SinkMock_MetricDisruptionScheduled_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]string))
+	})
+	return _c
+}
+
+func (_c *SinkMock_MetricDisruptionScheduled_Call) Return(_a0 error) *SinkMock_MetricDisruptionScheduled_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SinkMock_MetricDisruptionScheduled_Call) RunAndReturn(run func([]string) error) *SinkMock_MetricDisruptionScheduled_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MetricDisruptionsCount provides a mock function with given fields: kind, tags
 func (_m *SinkMock) MetricDisruptionsCount(kind types.DisruptionKindName, tags []string) error {
 	ret := _m.Called(kind, tags)
@@ -540,6 +582,91 @@ func (_c *SinkMock_MetricInjected_Call) RunAndReturn(run func(bool, string, []st
 	return _c
 }
 
+// MetricMissingTargetFound provides a mock function with given fields: tags
+func (_m *SinkMock) MetricMissingTargetFound(tags []string) error {
+	ret := _m.Called(tags)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]string) error); ok {
+		r0 = rf(tags)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SinkMock_MetricMissingTargetFound_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MetricMissingTargetFound'
+type SinkMock_MetricMissingTargetFound_Call struct {
+	*mock.Call
+}
+
+// MetricMissingTargetFound is a helper method to define mock.On call
+//   - tags []string
+func (_e *SinkMock_Expecter) MetricMissingTargetFound(tags interface{}) *SinkMock_MetricMissingTargetFound_Call {
+	return &SinkMock_MetricMissingTargetFound_Call{Call: _e.mock.On("MetricMissingTargetFound", tags)}
+}
+
+func (_c *SinkMock_MetricMissingTargetFound_Call) Run(run func(tags []string)) *SinkMock_MetricMissingTargetFound_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]string))
+	})
+	return _c
+}
+
+func (_c *SinkMock_MetricMissingTargetFound_Call) Return(_a0 error) *SinkMock_MetricMissingTargetFound_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SinkMock_MetricMissingTargetFound_Call) RunAndReturn(run func([]string) error) *SinkMock_MetricMissingTargetFound_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MetricNextScheduledTime provides a mock function with given fields: _a0, tags
+func (_m *SinkMock) MetricNextScheduledTime(_a0 time.Duration, tags []string) error {
+	ret := _m.Called(_a0, tags)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(time.Duration, []string) error); ok {
+		r0 = rf(_a0, tags)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SinkMock_MetricNextScheduledTime_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MetricNextScheduledTime'
+type SinkMock_MetricNextScheduledTime_Call struct {
+	*mock.Call
+}
+
+// MetricNextScheduledTime is a helper method to define mock.On call
+//   - _a0 time.Duration
+//   - tags []string
+func (_e *SinkMock_Expecter) MetricNextScheduledTime(_a0 interface{}, tags interface{}) *SinkMock_MetricNextScheduledTime_Call {
+	return &SinkMock_MetricNextScheduledTime_Call{Call: _e.mock.On("MetricNextScheduledTime", _a0, tags)}
+}
+
+func (_c *SinkMock_MetricNextScheduledTime_Call) Run(run func(_a0 time.Duration, tags []string)) *SinkMock_MetricNextScheduledTime_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(time.Duration), args[1].([]string))
+	})
+	return _c
+}
+
+func (_c *SinkMock_MetricNextScheduledTime_Call) Return(_a0 error) *SinkMock_MetricNextScheduledTime_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SinkMock_MetricNextScheduledTime_Call) RunAndReturn(run func(time.Duration, []string) error) *SinkMock_MetricNextScheduledTime_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MetricOrphanFound provides a mock function with given fields: tags
 func (_m *SinkMock) MetricOrphanFound(tags []string) error {
 	ret := _m.Called(tags)
@@ -669,13 +796,13 @@ func (_c *SinkMock_MetricPodsGauge_Call) RunAndReturn(run func(float64) error) *
 	return _c
 }
 
-// MetricReconcile provides a mock function with given fields:
-func (_m *SinkMock) MetricReconcile() error {
-	ret := _m.Called()
+// MetricReconcile provides a mock function with given fields: tags
+func (_m *SinkMock) MetricReconcile(tags []string) error {
+	ret := _m.Called(tags)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func([]string) error); ok {
+		r0 = rf(tags)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -689,13 +816,14 @@ type SinkMock_MetricReconcile_Call struct {
 }
 
 // MetricReconcile is a helper method to define mock.On call
-func (_e *SinkMock_Expecter) MetricReconcile() *SinkMock_MetricReconcile_Call {
-	return &SinkMock_MetricReconcile_Call{Call: _e.mock.On("MetricReconcile")}
+//   - tags []string
+func (_e *SinkMock_Expecter) MetricReconcile(tags interface{}) *SinkMock_MetricReconcile_Call {
+	return &SinkMock_MetricReconcile_Call{Call: _e.mock.On("MetricReconcile", tags)}
 }
 
-func (_c *SinkMock_MetricReconcile_Call) Run(run func()) *SinkMock_MetricReconcile_Call {
+func (_c *SinkMock_MetricReconcile_Call) Run(run func(tags []string)) *SinkMock_MetricReconcile_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].([]string))
 	})
 	return _c
 }
@@ -705,7 +833,7 @@ func (_c *SinkMock_MetricReconcile_Call) Return(_a0 error) *SinkMock_MetricRecon
 	return _c
 }
 
-func (_c *SinkMock_MetricReconcile_Call) RunAndReturn(run func() error) *SinkMock_MetricReconcile_Call {
+func (_c *SinkMock_MetricReconcile_Call) RunAndReturn(run func([]string) error) *SinkMock_MetricReconcile_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -960,6 +1088,91 @@ func (_c *SinkMock_MetricStuckOnRemovalGauge_Call) Return(_a0 error) *SinkMock_M
 }
 
 func (_c *SinkMock_MetricStuckOnRemovalGauge_Call) RunAndReturn(run func(float64) error) *SinkMock_MetricStuckOnRemovalGauge_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MetricTargetMissing provides a mock function with given fields: duration, tags
+func (_m *SinkMock) MetricTargetMissing(duration time.Duration, tags []string) error {
+	ret := _m.Called(duration, tags)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(time.Duration, []string) error); ok {
+		r0 = rf(duration, tags)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SinkMock_MetricTargetMissing_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MetricTargetMissing'
+type SinkMock_MetricTargetMissing_Call struct {
+	*mock.Call
+}
+
+// MetricTargetMissing is a helper method to define mock.On call
+//   - duration time.Duration
+//   - tags []string
+func (_e *SinkMock_Expecter) MetricTargetMissing(duration interface{}, tags interface{}) *SinkMock_MetricTargetMissing_Call {
+	return &SinkMock_MetricTargetMissing_Call{Call: _e.mock.On("MetricTargetMissing", duration, tags)}
+}
+
+func (_c *SinkMock_MetricTargetMissing_Call) Run(run func(duration time.Duration, tags []string)) *SinkMock_MetricTargetMissing_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(time.Duration), args[1].([]string))
+	})
+	return _c
+}
+
+func (_c *SinkMock_MetricTargetMissing_Call) Return(_a0 error) *SinkMock_MetricTargetMissing_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SinkMock_MetricTargetMissing_Call) RunAndReturn(run func(time.Duration, []string) error) *SinkMock_MetricTargetMissing_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MetricTooLate provides a mock function with given fields: tags
+func (_m *SinkMock) MetricTooLate(tags []string) error {
+	ret := _m.Called(tags)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]string) error); ok {
+		r0 = rf(tags)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SinkMock_MetricTooLate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MetricTooLate'
+type SinkMock_MetricTooLate_Call struct {
+	*mock.Call
+}
+
+// MetricTooLate is a helper method to define mock.On call
+//   - tags []string
+func (_e *SinkMock_Expecter) MetricTooLate(tags interface{}) *SinkMock_MetricTooLate_Call {
+	return &SinkMock_MetricTooLate_Call{Call: _e.mock.On("MetricTooLate", tags)}
+}
+
+func (_c *SinkMock_MetricTooLate_Call) Run(run func(tags []string)) *SinkMock_MetricTooLate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]string))
+	})
+	return _c
+}
+
+func (_c *SinkMock_MetricTooLate_Call) Return(_a0 error) *SinkMock_MetricTooLate_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SinkMock_MetricTooLate_Call) RunAndReturn(run func([]string) error) *SinkMock_MetricTooLate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/o11y/metrics/types/types.go
+++ b/o11y/metrics/types/types.go
@@ -23,6 +23,12 @@ const (
 	// SinkAppController is the chaos controller
 	SinkAppController SinkApp = "chaos-controller"
 
+	// SinkAppRolloutController is the rollout controller
+	SinkAppRolloutController SinkApp = "chaos-rollout-controller"
+
+	// SinkAppCronController is the cront controller
+	SinkAppCronController SinkApp = "chaos-cron-controller"
+
 	// SinkAppInjector is the chaos injector
 	SinkAppInjector SinkApp = "chaos-injector"
 )


### PR DESCRIPTION
## What does this PR do?

- [X] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
1. Adds new Metrics specific to Rollout and Cron controllers
    - **MetricDisruptionScheduled**: When a new disruption is scheduled for a specific target
    - **MetricNextScheduledTime**: The time difference between now and the next scheduled disruption
    - **MetricMissingTargetFound**: When a Missing Target is "seen" by the controller once again
    - **MetricTargetMissing**: When a Target is identified as Missing (which may occur several times for the same Target)
    - **MetricTooLate**: When the controller misses its opportunity to schedule a new disruption and waits for the next opportunity.
2. Refactor MetricSink by adding a `prefix` attribute
    - Given the old sink implementation considered there to only be one controller, we now find ourselves with 3 and therefore we need a way to differentiate metrics between the 3 controllers. Using a `prefix` attribute solves this.
## Code Quality Checklist

- [X] The documentation is up to date.
- [X] My code is sufficiently commented and passes continuous integration checks.
- [X] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
