### PR TITLE
CHAOSPLT-218: feat - add a max disruption duration

### DIFF
--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -46,6 +46,7 @@ var (
 	defaultNamespaceThreshold     float64
 	defaultClusterThreshold       float64
 	handlerEnabled                bool
+	maxDuration                   time.Duration
 	defaultDuration               time.Duration
 	cloudServicesProvidersManager cloudservice.CloudServicesProvidersManager
 	chaosNamespace                string
@@ -75,6 +76,7 @@ func (r *Disruption) SetupWebhookWithManager(setupWebhookConfig utils.SetupWebho
 	defaultClusterThreshold = float64(setupWebhookConfig.ClusterThresholdFlag) / 100.0
 	handlerEnabled = setupWebhookConfig.HandlerEnabledFlag
 	defaultDuration = setupWebhookConfig.DefaultDurationFlag
+	maxDuration = setupWebhookConfig.MaxDurationFlag
 	cloudServicesProvidersManager = setupWebhookConfig.CloudServicesProvidersManager
 	chaosNamespace = setupWebhookConfig.ChaosNamespace
 	safemodeEnvironment = setupWebhookConfig.Environment
@@ -187,6 +189,10 @@ func (r *Disruption) ValidateCreate() error {
 		}
 
 		return err
+	}
+
+	if r.Spec.Duration.Duration() > maxDuration {
+		return fmt.Errorf("the maximum duration allowed is %s, please specify a duration lower or equal than this value", maxDuration)
 	}
 
 	multiErr := ddmarkClient.ValidateStructMultierror(r.Spec, "validation_webhook")

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -192,7 +192,7 @@ func (r *Disruption) ValidateCreate() error {
 	}
 
 	if maxDuration > 0 && r.Spec.Duration.Duration() > maxDuration {
-		return fmt.Errorf("the maximum duration allowed is %s, please specify a duration lower or equal than this value", maxDuration)
+		return fmt.Errorf("you have specified a duration of %s, but the maximum duration allowed is %s, please specify a duration lower or equal than this value", r.Spec.Duration.Duration(), maxDuration)
 	}
 
 	multiErr := ddmarkClient.ValidateStructMultierror(r.Spec, "validation_webhook")

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -191,7 +191,7 @@ func (r *Disruption) ValidateCreate() error {
 		return err
 	}
 
-	if r.Spec.Duration.Duration() > maxDuration {
+	if maxDuration > 0 && r.Spec.Duration.Duration() > maxDuration {
 		return fmt.Errorf("the maximum duration allowed is %s, please specify a duration lower or equal than this value", maxDuration)
 	}
 

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -294,6 +294,33 @@ var _ = Describe("Disruption", func() {
 				})
 			})
 
+			When("disruption spec duration is greater than the max default duration", func() {
+				var originalMaxDefaultDuration time.Duration
+
+				BeforeEach(func() {
+					originalMaxDefaultDuration = maxDuration
+				})
+
+				It("should return an error", func() {
+					// Arrange
+					invalidDisruption := newDisruption.DeepCopy()
+					maxDuration = time.Hour * 1
+					invalidDisruption.Spec.Duration = "2h"
+
+					// Action
+					err := invalidDisruption.ValidateCreate()
+
+					// Assert
+					Expect(err).Should(HaveOccurred())
+					Expect(err).To(MatchError("the maximum duration allowed is 1h0m0s, please specify a duration lower or equal than this value"))
+					Expect(ddmarkMock.AssertNumberOfCalls(GinkgoT(), "ValidateStructMultierror", 0)).To(BeTrue())
+				})
+
+				AfterEach(func() {
+					maxDuration = originalMaxDefaultDuration
+				})
+			})
+
 			When("disruption selectors are invalid", func() {
 				It("should return an error", func() {
 					invalidDisruption := newDisruption.DeepCopy()

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Disruption", func() {
 
 					// Assert
 					Expect(err).Should(HaveOccurred())
-					Expect(err).To(MatchError("the maximum duration allowed is 1h0m0s, please specify a duration lower or equal than this value"))
+					Expect(err).To(MatchError("you have specified a duration of 2h0m0s, but the maximum duration allowed is 1h0m0s, please specify a duration lower or equal than this value"))
 					Expect(ddmarkMock.AssertNumberOfCalls(GinkgoT(), "ValidateStructMultierror", 0)).To(BeTrue())
 				})
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -47,6 +47,9 @@ data:
           ipRangesURL: {{ .Values.controller.cloudProviders.datadog.ipRangesURL }}
       deleteOnly: {{ .Values.controller.deleteOnly }}
       defaultDuration: {{ .Values.controller.defaultDuration }}
+      {{- if .Values.controller.maxDuration }}
+      maxDuration: {{ .Values.controller.maxDuration }}
+      {{- end }}
       expiredDisruptionGCDelay: {{ .Values.controller.expiredDisruptionGCDelay }}
       userInfoHook: {{ .Values.controller.userInfoHook }}
       webhook:

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -47,9 +47,7 @@ data:
           ipRangesURL: {{ .Values.controller.cloudProviders.datadog.ipRangesURL }}
       deleteOnly: {{ .Values.controller.deleteOnly }}
       defaultDuration: {{ .Values.controller.defaultDuration }}
-      {{- if .Values.controller.maxDuration }}
       maxDuration: {{ .Values.controller.maxDuration }}
-      {{- end }}
       expiredDisruptionGCDelay: {{ .Values.controller.expiredDisruptionGCDelay }}
       userInfoHook: {{ .Values.controller.userInfoHook }}
       webhook:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,6 +56,7 @@ controller:
       enabled: true # enable the provider
       ipRangesURL: "https://ip-ranges.datadoghq.com/" # URL to the IP ranges file (format must be the expected one, defaults is the public file provided by the cloud provider)
   defaultDuration: 1h # default spec.duration for a disruption with none specified
+  maxDuration: # maximum spec.duration for a disruption (example: 1h)
   expiredDisruptionGCDelay: 10m # time after a disruption expires before deleting it
   userInfoHook: true
   webhook: # admission webhook configuration

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,7 +56,7 @@ controller:
       enabled: true # enable the provider
       ipRangesURL: "https://ip-ranges.datadoghq.com/" # URL to the IP ranges file (format must be the expected one, defaults is the public file provided by the cloud provider)
   defaultDuration: 1h # default spec.duration for a disruption with none specified
-  maxDuration: # maximum spec.duration for a disruption (example: 1h)
+  maxDuration: 2h # maximum spec.duration for a disruption
   expiredDisruptionGCDelay: 10m # time after a disruption expires before deleting it
   userInfoHook: true
   webhook: # admission webhook configuration

--- a/config/config.go
+++ b/config/config.go
@@ -461,7 +461,7 @@ func New(logger *zap.SugaredLogger, osArgs []string) (config, error) {
 	}
 
 	if cfg.Controller.DefaultDuration > 0 && cfg.Controller.MaxDuration > 0 && cfg.Controller.DefaultDuration > cfg.Controller.MaxDuration {
-		return cfg, fmt.Errorf("defaultDuration must be less than or equal to maxDuration")
+		return cfg, fmt.Errorf("defaultDuration of %s, must be less than or equal to the maxDuration %s", cfg.Controller.DefaultDuration, cfg.Controller.MaxDuration)
 	}
 
 	return cfg, nil

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type controllerConfig struct {
 	MetricsBindAddr           string                          `json:"metricsBindAddr"`
 	MetricsSink               string                          `json:"metricsSink"`
 	ExpiredDisruptionGCDelay  time.Duration                   `json:"expiredDisruptionGCDelay"`
+	MaxDuration               time.Duration                   `json:"maxDuration"`
 	DefaultDuration           time.Duration                   `json:"defaultDuration"`
 	DeleteOnly                bool                            `json:"deleteOnly"`
 	EnableSafeguards          bool                            `json:"enableSafeguards"`
@@ -142,6 +143,12 @@ func New(logger *zap.SugaredLogger, osArgs []string) (config, error) {
 	mainFS.DurationVar(&cfg.Controller.DefaultDuration, "default-duration", time.Hour, "Default duration for a disruption with none specified")
 
 	if err := viper.BindPFlag("controller.defaultDuration", mainFS.Lookup("default-duration")); err != nil {
+		return cfg, err
+	}
+
+	mainFS.DurationVar(&cfg.Controller.MaxDuration, "max-duration", time.Hour, "Max duration for a disruption to timeout")
+
+	if err := viper.BindPFlag("controller.maxDuration", mainFS.Lookup("max-duration")); err != nil {
 		return cfg, err
 	}
 
@@ -451,6 +458,10 @@ func New(logger *zap.SugaredLogger, osArgs []string) (config, error) {
 
 	if !cfg.Controller.UserInfoHook && cfg.Controller.Notifiers.Slack.Enabled {
 		return cfg, fmt.Errorf("cannot enable slack notifier without enabling the user info webhook")
+	}
+
+	if cfg.Controller.DefaultDuration > 0 && cfg.Controller.MaxDuration > 0 && cfg.Controller.DefaultDuration > cfg.Controller.MaxDuration {
+		return cfg, fmt.Errorf("defaultDuration must be less than or equal to maxDuration")
 	}
 
 	return cfg, nil

--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,7 @@ type controllerConfig struct {
 	MetricsBindAddr           string                          `json:"metricsBindAddr"`
 	MetricsSink               string                          `json:"metricsSink"`
 	ExpiredDisruptionGCDelay  time.Duration                   `json:"expiredDisruptionGCDelay"`
-	MaxDuration               time.Duration                   `json:"maxDuration"`
+	MaxDuration               time.Duration                   `json:"maxDuration,omitempty"`
 	DefaultDuration           time.Duration                   `json:"defaultDuration"`
 	DeleteOnly                bool                            `json:"deleteOnly"`
 	EnableSafeguards          bool                            `json:"enableSafeguards"`
@@ -146,7 +146,7 @@ func New(logger *zap.SugaredLogger, osArgs []string) (config, error) {
 		return cfg, err
 	}
 
-	mainFS.DurationVar(&cfg.Controller.MaxDuration, "max-duration", time.Hour, "Max duration for a disruption to timeout")
+	mainFS.DurationVar(&cfg.Controller.MaxDuration, "max-duration", 0, "Max duration for a disruption to timeout")
 
 	if err := viper.BindPFlag("controller.maxDuration", mainFS.Lookup("max-duration")); err != nil {
 		return cfg, err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,6 +35,11 @@ var _ = Describe("Config", func() {
 				_, err := config.New(logger, []string{"--config", "testdata/invalid.yaml"})
 				Expect(err).Should(MatchError(ContainSubstring("error loading configuration file: While parsing config: yaml: unmarshal errors:")))
 			})
+
+			It("fails with a defaultDuration greater than the maxDuration", func() {
+				_, err := config.New(logger, []string{"--config", "testdata/default-duration-too-big.yaml"})
+				Expect(err).Should(MatchError("defaultDuration must be less than or equal to maxDuration"))
+			})
 		})
 
 		Context("without configuration", func() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@
 package config_test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/DataDog/chaos-controller/config"
@@ -38,7 +39,7 @@ var _ = Describe("Config", func() {
 
 			It("fails with a defaultDuration greater than the maxDuration", func() {
 				_, err := config.New(logger, []string{"--config", "testdata/default-duration-too-big.yaml"})
-				Expect(err).Should(MatchError("defaultDuration must be less than or equal to maxDuration"))
+				Expect(err).Should(MatchError(fmt.Sprintf("defaultDuration of %s, must be less than or equal to the maxDuration %s", "3m0s", "2m0s")))
 			})
 		})
 

--- a/config/testdata/default-duration-too-big.yaml
+++ b/config/testdata/default-duration-too-big.yaml
@@ -1,0 +1,65 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2024 Datadog, Inc.
+controller:
+  deleteOnly: true
+  defaultDuration: 3m
+  maxDuration: 2m
+  enableSafeguards: false
+  enableObserver: false
+  expiredDisruptionGCDelay: 10m
+  metricsBindAddr: 127.0.0.1:8080
+  leaderElection: true
+  metricsSink: datadog
+  profilerSink: notdatadog
+  userInfoHook: true
+  notifiers:
+    common:
+      clusterName: some-cluster-name
+    noop:
+      enabled: true
+    slack:
+      enabled: true
+      mirrorSlackChannelId: WOPIEQQET
+      tokenFilepath: /random-file-path
+    http:
+      enabled: true
+      headers: [a, b, c]
+      headersFilepath: /header-file-path/below/me
+      url: https://example.com/webhook
+    datadog:
+      enabled: true
+  cloudProviders:
+    disableAll: true
+    pullInterval: 15m
+    aws:
+      enabled: false
+      ipRangesURL: https://example.com/aws-ip-ranges-url
+    gcp:
+      enabled: false
+      ipRangesURL: https://example.com/gcp-ip-ranges-url
+    datadog:
+      enabled: false
+      ipRangesURL: https://example.com/datadog-ip-ranges-url
+  safeMode:
+    enable: false
+    environment: my-safe-env-value
+    namespaceThreshold: 79
+    clusterThreshold: 61
+  webhook:
+    certDir: /var/data/cert/cert.pem
+    host: another-host
+    port: 7443
+injector:
+  image: datadog.io/chaos-injector:not-latest
+  imagePullSecrets: some-pull-secret
+  serviceAccount: chaos-injector-custom-sa
+  chaosNamespace: chaos-engineering-custom-ns
+  dnsDisruption:
+    dnsServer: ""
+    kubeDns: "all"
+handler:
+  enabled: true
+  image: other.io/chaos-handler:not-latest-again
+  timeout: 1m30s

--- a/main.go
+++ b/main.go
@@ -339,6 +339,7 @@ func main() {
 		DeleteOnlyFlag:                cfg.Controller.DeleteOnly,
 		HandlerEnabledFlag:            cfg.Handler.Enabled,
 		DefaultDurationFlag:           cfg.Controller.DefaultDuration,
+		MaxDurationFlag:               cfg.Controller.MaxDuration,
 		ChaosNamespace:                cfg.Injector.ChaosNamespace,
 		CloudServicesProvidersManager: cloudProviderManager,
 		Environment:                   cfg.Controller.SafeMode.Environment,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -51,6 +51,7 @@ type SetupWebhookWithManagerConfig struct {
 	DeleteOnlyFlag                bool
 	HandlerEnabledFlag            bool
 	DefaultDurationFlag           time.Duration
+	MaxDurationFlag               time.Duration
 	ChaosNamespace                string
 	CloudServicesProvidersManager cloudservice.CloudServicesProvidersManager
 	Environment                   string


### PR DESCRIPTION
## What does this PR do?

Injector timeout has a maximum value defined at the cluster level, preventing mistakenly overridden timeout value on production clusters

- [x] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Add a `MaxDuration` config parameter in order to preventing mistakenly overridden timeout value on production clusters.

> Configuration example

``` yaml
# Unless explicitly stated otherwise all files in this repository are licensed
# under the Apache License Version 2.0.
# This product includes software developed at Datadog (https://www.datadoghq.com/).
# Copyright 2024 Datadog, Inc.

controller:
  ...
  defaultDuration: 10m
  maxDuration: 30m
  ...
```

> When the `defaultDuration` > `maxDuration`

In this scenario the chaos-controller will not start and return the following error:

``` json
{"level":"info","ts":1705675559458.9348,"caller":"config/config.go:435","message":"loading configuration file","config":"/etc/chaos-controller/config.yaml"}
{"level":"fatal","ts":1705675559466.059,"caller":"chaos-controller/main.go:79","message":"unable to create a valid configuration","error":"defaultDuration of 2h0m0s, must be less than or equal to the maxDuration 1h0m0s","stacktrace":"main.main\n\t/Users/aymeric.daurelle/Projects/chaos-controller/main.go:79\nruntime.main\n\t/opt/homebrew/Cellar/go/1.21.5/libexec/src/runtime/proc.go:267"}
```

Highlight error message:`defaultDuration of 2h0m0s, must be less than or equal to the maxDuration 1h0m0s`

> When the `Disruption.Spec.Duration` > `maxDuration`

The disruption will not be created in this scenario.

``` text
Error from server (you have specified a duration of 2h0m0s, but the maximum duration allowed is 1h0m0s, please specify a duration lower or equal than this value): error when creating "examples/disk_failure.yaml": admission webhook "chaos-controller-webhook-service.chaos-engineering.svc" denied the request: you have specified a duration of 2h0m0s, but the maximum duration allowed is 1h0m0s, please specify a duration lower or equal than this value
``` 

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
