### PR TITLE
CHAOSPLT-115: Warn users who set count to 100

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -168,7 +168,7 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, fmt.Errorf("error handling chaos pods termination: %w", err)
 	}
 
-	if err := r.sendWarnings(instance); err != nil {
+	if err := r.sendWarningsOnDisruptionSpec(instance); err != nil {
 		r.log.Errorw("unable to send user warnings", "err", err)
 	}
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -891,6 +891,8 @@ func (r *DisruptionReconciler) sendWarnings(instance *chaosv1beta1.Disruption) e
 	value, isPercent, err := chaosv1beta1.GetIntOrPercentValueSafely(instance.Spec.Count)
 	if err == nil && !isPercent && value == 100 {
 		r.recordEventOnDisruption(instance, chaosv1beta1.EventInvalidSpecDisruption, "disruption count was set to the integer 100, but you likely intended it to be the string \"100%\"", "")
+	} else if err != nil {
+		return err
 	}
 
 	return nil

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -885,7 +885,7 @@ func (r *DisruptionReconciler) recordEventOnDisruption(instance *chaosv1beta1.Di
 	}
 }
 
-// sendWarnings is used to send users warnings about their disruption spec that we're unable to detect or warn about in the validation webhook
+// sendWarningsOnDisruptionSpec is used to send users warnings about their disruption spec that we're unable to detect or warn about in the validation webhook
 func (r *DisruptionReconciler) sendWarningsOnDisruptionSpec(instance *chaosv1beta1.Disruption) error {
 	// warn users who have set their count to 100. this is almost always accidental, and causes unexpected behaviors with the injection status
 	value, isPercent, err := chaosv1beta1.GetIntOrPercentValueSafely(instance.Spec.Count)

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -168,10 +168,8 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, fmt.Errorf("error handling chaos pods termination: %w", err)
 	}
 
-	// warn users who have set their count to 100. this is almost always accidental, and causes unexpected behaviors with the injection status
-	value, isPercent, err := chaosv1beta1.GetIntOrPercentValueSafely(instance.Spec.Count)
-	if err == nil && !isPercent && value == 100 {
-		r.recordEventOnDisruption(instance, chaosv1beta1.EventInvalidSpecDisruption, "disruption count was set to the integer 100, but you likely intended it to be the string \"100%\"", "")
+	if err := r.sendWarnings(instance); err != nil {
+		r.log.Errorw("unable to send user warnings", "err", err)
 	}
 
 	// check whether the object is being deleted or not
@@ -885,6 +883,17 @@ func (r *DisruptionReconciler) recordEventOnDisruption(instance *chaosv1beta1.Di
 	} else {
 		r.Recorder.Event(instance, disEvent.Type, string(disEvent.Reason), message)
 	}
+}
+
+// sendWarnings is used to send users warnings about their disruption spec that we're unable to detect or warn about in the validation webhook
+func (r *DisruptionReconciler) sendWarnings(instance *chaosv1beta1.Disruption) error {
+	// warn users who have set their count to 100. this is almost always accidental, and causes unexpected behaviors with the injection status
+	value, isPercent, err := chaosv1beta1.GetIntOrPercentValueSafely(instance.Spec.Count)
+	if err == nil && !isPercent && value == 100 {
+		r.recordEventOnDisruption(instance, chaosv1beta1.EventInvalidSpecDisruption, "disruption count was set to the integer 100, but you likely intended it to be the string \"100%\"", "")
+	}
+
+	return nil
 }
 
 func (r *DisruptionReconciler) emitKindCountMetrics(instance *chaosv1beta1.Disruption) {

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -886,7 +886,7 @@ func (r *DisruptionReconciler) recordEventOnDisruption(instance *chaosv1beta1.Di
 }
 
 // sendWarnings is used to send users warnings about their disruption spec that we're unable to detect or warn about in the validation webhook
-func (r *DisruptionReconciler) sendWarnings(instance *chaosv1beta1.Disruption) error {
+func (r *DisruptionReconciler) sendWarningsOnDisruptionSpec(instance *chaosv1beta1.Disruption) error {
 	// warn users who have set their count to 100. this is almost always accidental, and causes unexpected behaviors with the injection status
 	value, isPercent, err := chaosv1beta1.GetIntOrPercentValueSafely(instance.Spec.Count)
 	if err == nil && !isPercent && value == 100 {


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
-  Send the user a warning when they specify an integer count of `100`. Due to notifier aggregation, they will only receive this once

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
