### PR TITLE
CHAOSPLT-216: Allow for requiring specific user groups before creating a disruption

### DIFF
--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -352,6 +352,7 @@ func (r *Disruption) validateUserInfoGroup() error {
 	}
 
 	logger.Warnw("rejecting user from creating this disruption", "permittedUserGroups", permittedUserGroups, "userGroups", userInfo.Groups)
+
 	return fmt.Errorf("lacking sufficient authorization to create disruptions. your user groups are %s, but you must be in one of the following groups: %s", userInfo.Groups, permittedUserGroupWarningString)
 }
 

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -329,6 +329,9 @@ You first need to remove those chaos pods (and potentially their finalizers) to 
 	return nil
 }
 
+// validateUserInfoGroup checks that if permittedUserGroups is set, which is controlled in controller.safeMode.permittedUserGroups in the configmap,
+// then we will return an error if the user in r.UserInfo does not belong to any groups. If permittedUserGroups is unset, or if the user belongs to one of those
+// groups, then we will return nil
 func (r *Disruption) validateUserInfoGroup() error {
 	if len(permittedUserGroups) == 0 {
 		return nil

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -83,9 +83,11 @@ func (r *Disruption) SetupWebhookWithManager(setupWebhookConfig utils.SetupWebho
 	chaosNamespace = setupWebhookConfig.ChaosNamespace
 	safemodeEnvironment = setupWebhookConfig.Environment
 	permittedUserGroups = map[string]struct{}{}
+
 	for _, group := range setupWebhookConfig.PermittedUserGroups {
 		permittedUserGroups[group] = struct{}{}
 	}
+
 	permittedUserGroupWarningString = strings.Join(setupWebhookConfig.PermittedUserGroups, ",")
 
 	return ctrl.NewWebhookManagedBy(setupWebhookConfig.Manager).
@@ -343,6 +345,8 @@ func (r *Disruption) validateUserInfoGroup() error {
 		_, ok := permittedUserGroups[group]
 		if ok {
 			validGroupFound = true
+
+			logger.Debugw("permitting user disruption creation, due to group membership", "group", group)
 		}
 	}
 

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -352,7 +352,7 @@ func (r *Disruption) validateUserInfoGroup() error {
 
 	if !validGroupFound {
 		logger.Warnw("rejecting user from creating this disruption", "permittedUserGroups", permittedUserGroups, "userGroups", userInfo.Groups)
-		return fmt.Errorf("lackng sufficient authorization to create disruptions. your user groups are %s, but you must be in one of the following groups: %s", userInfo.Groups, permittedUserGroupWarningString)
+		return fmt.Errorf("lacking sufficient authorization to create disruptions. your user groups are %s, but you must be in one of the following groups: %s", userInfo.Groups, permittedUserGroupWarningString)
 	}
 
 	return nil

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -346,16 +346,13 @@ func (r *Disruption) validateUserInfoGroup() error {
 		_, ok := permittedUserGroups[group]
 		if ok {
 			logger.Debugw("permitting user disruption creation, due to group membership", "group", group)
-			
+
 			return nil
 		}
 	}
 
 	logger.Warnw("rejecting user from creating this disruption", "permittedUserGroups", permittedUserGroups, "userGroups", userInfo.Groups)
 	return fmt.Errorf("lacking sufficient authorization to create disruptions. your user groups are %s, but you must be in one of the following groups: %s", userInfo.Groups, permittedUserGroupWarningString)
-	}
-
-	return nil
 }
 
 // validateUserInfoImmutable checks that no changes have been made to the oldDisruption's UserInfo in the latest update

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -342,20 +342,17 @@ func (r *Disruption) validateUserInfoGroup() error {
 		return err
 	}
 
-	validGroupFound := false
-
 	for _, group := range userInfo.Groups {
 		_, ok := permittedUserGroups[group]
 		if ok {
-			validGroupFound = true
-
 			logger.Debugw("permitting user disruption creation, due to group membership", "group", group)
+			
+			return nil
 		}
 	}
 
-	if !validGroupFound {
-		logger.Warnw("rejecting user from creating this disruption", "permittedUserGroups", permittedUserGroups, "userGroups", userInfo.Groups)
-		return fmt.Errorf("lacking sufficient authorization to create disruptions. your user groups are %s, but you must be in one of the following groups: %s", userInfo.Groups, permittedUserGroupWarningString)
+	logger.Warnw("rejecting user from creating this disruption", "permittedUserGroups", permittedUserGroups, "userGroups", userInfo.Groups)
+	return fmt.Errorf("lacking sufficient authorization to create disruptions. your user groups are %s, but you must be in one of the following groups: %s", userInfo.Groups, permittedUserGroupWarningString)
 	}
 
 	return nil

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -233,7 +233,7 @@ func (r *Disruption) ValidateUpdate(old runtime.Object) error {
 
 	oldDisruption := old.(*Disruption)
 
-	if err := r.validateUserInfo(oldDisruption); err != nil {
+	if err := r.validateUserInfoImmutable(oldDisruption); err != nil {
 		return err
 	}
 
@@ -316,7 +316,8 @@ You first need to remove those chaos pods (and potentially their finalizers) to 
 	return nil
 }
 
-func (r *Disruption) validateUserInfo(oldDisruption *Disruption) error {
+// validateUserInfoImmutable checks that no changes have been made to the oldDisruption's UserInfo in the latest update
+func (r *Disruption) validateUserInfoImmutable(oldDisruption *Disruption) error {
 	oldUserInfo, err := oldDisruption.UserInfo()
 	if err != nil {
 		return nil

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -399,6 +399,7 @@ var _ = Describe("Disruption", func() {
 				})
 
 				It("should not return an error if they are within a permitted group", func() {
+					ddmarkMock.EXPECT().ValidateStructMultierror(mock.Anything, mock.Anything).Return(&multierror.Error{})
 					permittedUserGroups = map[string]struct{}{}
 					permittedUserGroups["some"] = struct{}{}
 					permittedUserGroupWarningString = "some"
@@ -406,6 +407,7 @@ var _ = Describe("Disruption", func() {
 					err := newDisruption.ValidateCreate()
 
 					Expect(err).ShouldNot(HaveOccurred())
+					Expect(ddmarkMock.AssertNumberOfCalls(GinkgoT(), "ValidateStructMultierror", 1)).To(BeTrue())
 				})
 			})
 		})

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -219,6 +219,7 @@ var _ = Describe("Disruption", func() {
 		Describe("general errors expectations", func() {
 			BeforeEach(func() {
 				k8sClient = makek8sClientWithDisruptionPod()
+				recorder = record.NewFakeRecorder(1)
 				tracerSink = tracernoop.New(logger)
 				deleteOnly = false
 			})

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -529,6 +529,7 @@ func makeValidNetworkDisruption() *Disruption {
 				IntVal: 1,
 			},
 			Network: &NetworkDisruptionSpec{
+				Drop:  100,
 				Hosts: []NetworkDisruptionHostSpec{{Port: 80}},
 			},
 			Selector: labels.Set{

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -528,7 +528,7 @@ func makeValidNetworkDisruption() *Disruption {
 				IntVal: 1,
 			},
 			Network: &NetworkDisruptionSpec{
-				Drop: 100,
+				Hosts: []NetworkDisruptionHostSpec{{Port: 80}},
 			},
 			Selector: labels.Set{
 				"name":      "random",

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -402,7 +402,8 @@ var _ = Describe("Disruption", func() {
 					ddmarkMock.EXPECT().ValidateStructMultierror(mock.Anything, mock.Anything).Return(&multierror.Error{})
 					permittedUserGroups = map[string]struct{}{}
 					permittedUserGroups["some"] = struct{}{}
-					permittedUserGroupWarningString = "some"
+					permittedUserGroups["any"] = struct{}{}
+					permittedUserGroupWarningString = "some, any"
 
 					err := newDisruption.ValidateCreate()
 

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -231,6 +231,7 @@ var _ = Describe("Disruption", func() {
 			AfterEach(func() {
 				k8sClient = nil
 				newDisruption = nil
+				permittedUserGroups = map[string]struct{}{}
 			})
 
 			When("disruption has delete-only mode enable", func() {

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -56,6 +56,10 @@ data:
         port: {{ .Values.controller.webhook.port }}
       safeMode:
         enable: {{ .Values.controller.safeMode.enable }}
+        permittedUserGroups:
+          {{- range $index, $group := .Values.controller.safeMode.permittedUserGroups }}
+          - {{ $group | quote }}
+          {{- end }}
         environment: {{ tpl .Values.controller.safeMode.environment . }}
         namespaceThreshold: {{ .Values.controller.safeMode.namespaceThreshold }}
         clusterThreshold: {{ .Values.controller.safeMode.clusterThreshold }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -66,6 +66,8 @@ controller:
     port: 9443 # port to use to serve requests
   safeMode:
     environment: ""
+    permittedUserGroups:
+      - system:serviceaccounts
     enable: false
     namespaceThreshold: 80
     clusterThreshold: 66

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -66,7 +66,7 @@ controller:
     port: 9443 # port to use to serve requests
   safeMode:
     environment: ""
-    permittedUserGroups:
+    permittedUserGroups: # (optional) specify a list of strings which represent user info groups. if set, a user must belong to at least one in order to create a Disruption
       - system:authenticated
     enable: false
     namespaceThreshold: 80

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -67,7 +67,7 @@ controller:
   safeMode:
     environment: ""
     permittedUserGroups:
-      - system:serviceaccounts
+      - system:authenticated
     enable: false
     namespaceThreshold: 80
     clusterThreshold: 66

--- a/config/config.go
+++ b/config/config.go
@@ -53,10 +53,11 @@ type controllerWebhookConfig struct {
 }
 
 type safeModeConfig struct {
-	Environment        string `json:"environment"`
-	Enable             bool   `json:"enable"`
-	NamespaceThreshold int    `json:"namespaceThreshold"`
-	ClusterThreshold   int    `json:"clusterThreshold"`
+	Environment         string   `json:"environment"`
+	PermittedUserGroups []string `json:"permittedUserGroups"`
+	Enable              bool     `json:"enable"`
+	NamespaceThreshold  int      `json:"namespaceThreshold"`
+	ClusterThreshold    int      `json:"clusterThreshold"`
 }
 
 type injectorConfig struct {
@@ -317,6 +318,12 @@ func New(logger *zap.SugaredLogger, osArgs []string) (config, error) {
 	mainFS.StringVar(&cfg.Controller.SafeMode.Environment, "safemode-environment", "", "Specify the 'location' this controller is run in. All disruptions must have an annotation of chaos.datadoghq.com/environment configured with this location to be allowed to create")
 
 	if err := viper.BindPFlag("controller.safeMode.environment", mainFS.Lookup("safemode-environment")); err != nil {
+		return cfg, err
+	}
+
+	mainFS.StringSliceVar(&cfg.Controller.SafeMode.PermittedUserGroups, "permitted-user-groups", []string{}, "Set of user groups which, if set, a user must belong to at least one in order to create a disruption")
+
+	if err := viper.BindPFlag("controller.safeMode.permittedUserGroups", mainFS.Lookup("permitted-user-groups")); err != nil {
 		return cfg, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -343,6 +343,7 @@ func main() {
 		ChaosNamespace:                cfg.Injector.ChaosNamespace,
 		CloudServicesProvidersManager: cloudProviderManager,
 		Environment:                   cfg.Controller.SafeMode.Environment,
+		PermittedUserGroups:           cfg.Controller.SafeMode.PermittedUserGroups,
 	}
 	if err = (&chaosv1beta1.Disruption{}).SetupWebhookWithManager(setupWebhookConfig); err != nil {
 		logger.Fatalw("unable to create webhook", "webhook", chaosv1beta1.DisruptionKind, "error", err)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -55,4 +55,5 @@ type SetupWebhookWithManagerConfig struct {
 	ChaosNamespace                string
 	CloudServicesProvidersManager cloudservice.CloudServicesProvidersManager
 	Environment                   string
+	PermittedUserGroups           []string
 }


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Allow for specifying a list of user groups in the chart. ValidateCreate in the admission webhook will reject any disruption coming from a user who does not belong to at least one of these groups

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
