### PR TITLE
CHAOSPLT-248: Respect annotation filters

### DIFF
--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -97,9 +97,26 @@ var _ = Describe("Disruption Controller", func() {
 			disruption.Spec.Filter = &chaosv1beta1.DisruptionFilter{
 				Annotations: map[string]string{"foo": "baz"},
 			}
+			disruption.Spec.Count = &intstr.IntOrString{Type: intstr.String, StrVal: "100%"}
 		})
 
 		It("should only select half of all pods", func(ctx SpecContext) {
+			DontExpectChaosPods(ctx, disruption, 8)
+			ExpectChaosPods(ctx, disruption, 4)
+		})
+	})
+
+	Context("annotation filters should limit selected targets", func() {
+		BeforeEach(func() {
+			disruption.Spec.Filter = &chaosv1beta1.DisruptionFilter{
+				Annotations: map[string]string{"fob": "baf"},
+			}
+			disruption.Spec.Selector = map[string]string{"second": "true"}
+			disruption.Spec.Count = &intstr.IntOrString{Type: intstr.String, StrVal: "100%"}
+		})
+
+		It("should only select half of all pods", func(ctx SpecContext) {
+			DontExpectChaosPods(ctx, disruption, 8)
 			ExpectChaosPods(ctx, disruption, 4)
 		})
 	})

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Disruption Controller", func() {
 	Context("annotation filters should limit selected targets", func() {
 		BeforeEach(func() {
 			disruption.Spec.Filter = &chaosv1beta1.DisruptionFilter{
-				Annotations: targetPod.Annotations,
+				Annotations: map[string]string{"foo": "baz"},
 			}
 		})
 

--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func main() {
 	}
 
 	// target selector
-	targetSelector := targetselector.NewRunningTargetSelector(cfg.Controller.EnableSafeguards, controllerNodeName)
+	targetSelector := targetselector.NewRunningTargetSelector(cfg.Controller.EnableSafeguards, controllerNodeName, logger)
 
 	var gcPtr *time.Duration
 	if cfg.Controller.ExpiredDisruptionGCDelay >= 0 {

--- a/targetselector/running_target_selector.go
+++ b/targetselector/running_target_selector.go
@@ -57,6 +57,7 @@ func (r runningTargetSelector) GetMatchingPodsOverTotalPods(c client.Client, ins
 
 	runningPods := &corev1.PodList{}
 
+podLoop:
 	for _, pod := range pods.Items {
 		// check the pod is already a disruption target
 		isAlreadyATarget := false
@@ -82,7 +83,7 @@ func (r runningTargetSelector) GetMatchingPodsOverTotalPods(c client.Client, ins
 			for k, v := range instance.Spec.Filter.Annotations {
 				podAnno, ok := pod.Annotations[k]
 				if !ok || podAnno != v {
-					continue
+					continue podLoop
 				}
 			}
 		}
@@ -137,6 +138,7 @@ func (r runningTargetSelector) GetMatchingNodesOverTotalNodes(c client.Client, i
 
 	runningNodes := &corev1.NodeList{}
 
+nodeLoop:
 	for _, node := range nodes.Items {
 		// apply controller safeguards if enabled
 		if r.controllerEnableSafeguards {
@@ -160,7 +162,7 @@ func (r runningTargetSelector) GetMatchingNodesOverTotalNodes(c client.Client, i
 			for k, v := range instance.Spec.Filter.Annotations {
 				nodeAnno, ok := node.Annotations[k]
 				if !ok || nodeAnno != v {
-					continue
+					continue nodeLoop
 				}
 			}
 		}

--- a/targetselector/running_target_selector.go
+++ b/targetselector/running_target_selector.go
@@ -79,10 +79,11 @@ podLoop:
 		}
 
 		if instance.Spec.Filter != nil {
-			r.logger.Debugw("Checking annotations", "pod", pod.Name, "pod.Annotations", pod.Annotations, "spec.Filter", instance.Spec.Filter.Annotations)
+			r.logger.Debugw("checking if pod has filtered annotations", "pod", pod.Name, "pod.Annotations", pod.Annotations, "spec.Filter", instance.Spec.Filter.Annotations)
 			for k, v := range instance.Spec.Filter.Annotations {
 				podAnno, ok := pod.Annotations[k]
 				if !ok || podAnno != v {
+					// This pod doesn't have the annotation specified in our filter, we don't want to include it as a target
 					continue podLoop
 				}
 			}
@@ -159,9 +160,11 @@ nodeLoop:
 		}
 
 		if instance.Spec.Filter != nil {
+			r.logger.Debugw("checking if node has filtered annotations", "node", node.Name, "node.Annotations", node.Annotations, "spec.Filter", instance.Spec.Filter.Annotations)
 			for k, v := range instance.Spec.Filter.Annotations {
 				nodeAnno, ok := node.Annotations[k]
 				if !ok || nodeAnno != v {
+					// This node doesn't have the annotation specified in our filter, we don't want to include it as a target
 					continue nodeLoop
 				}
 			}

--- a/targetselector/running_target_selector_test.go
+++ b/targetselector/running_target_selector_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/chaos-controller/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -137,7 +138,7 @@ var _ = Describe("Helpers", func() {
 	var targetSelector TargetSelector
 
 	BeforeEach(func() {
-		targetSelector = NewRunningTargetSelector(false, "foo")
+		targetSelector = NewRunningTargetSelector(false, "foo", zaptest.NewLogger(GinkgoT()).Sugar())
 
 		c = fakeClient{}
 
@@ -375,7 +376,7 @@ var _ = Describe("Helpers", func() {
 
 		Context("with controller safeguards enabled", func() {
 			BeforeEach(func() {
-				targetSelector = NewRunningTargetSelector(true, "runningNode")
+				targetSelector = NewRunningTargetSelector(true, "runningNode", zaptest.NewLogger(GinkgoT()).Sugar())
 			})
 
 			It("should exclude the pods running on the same node as the controller from targets", func() {
@@ -440,7 +441,7 @@ var _ = Describe("Helpers", func() {
 
 		Context("with controller safeguards enabled", func() {
 			BeforeEach(func() {
-				targetSelector = NewRunningTargetSelector(true, "runningNode")
+				targetSelector = NewRunningTargetSelector(true, "runningNode", zaptest.NewLogger(GinkgoT()).Sugar())
 			})
 
 			It("should exclude the controller node from targets", func() {

--- a/targetselector/running_target_selector_test.go
+++ b/targetselector/running_target_selector_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/chaos-controller/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,7 +137,7 @@ var _ = Describe("Helpers", func() {
 	var targetSelector TargetSelector
 
 	BeforeEach(func() {
-		targetSelector = NewRunningTargetSelector(false, "foo", zaptest.NewLogger(GinkgoT()).Sugar())
+		targetSelector = NewRunningTargetSelector(false, "foo", logger)
 
 		c = fakeClient{}
 
@@ -376,7 +375,7 @@ var _ = Describe("Helpers", func() {
 
 		Context("with controller safeguards enabled", func() {
 			BeforeEach(func() {
-				targetSelector = NewRunningTargetSelector(true, "runningNode", zaptest.NewLogger(GinkgoT()).Sugar())
+				targetSelector = NewRunningTargetSelector(true, "runningNode", logger)
 			})
 
 			It("should exclude the pods running on the same node as the controller from targets", func() {
@@ -441,7 +440,7 @@ var _ = Describe("Helpers", func() {
 
 		Context("with controller safeguards enabled", func() {
 			BeforeEach(func() {
-				targetSelector = NewRunningTargetSelector(true, "runningNode", zaptest.NewLogger(GinkgoT()).Sugar())
+				targetSelector = NewRunningTargetSelector(true, "runningNode", logger)
 			})
 
 			It("should exclude the controller node from targets", func() {

--- a/targetselector/targetselector_suite_test.go
+++ b/targetselector/targetselector_suite_test.go
@@ -3,16 +3,24 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
-package targetselector_test
+package targetselector
 
 import (
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
+
+var logger *zap.SugaredLogger
 
 func TestTargetselector(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Targetselector Suite")
 }
+
+var _ = BeforeSuite(func(ctx SpecContext) {
+	logger = zaptest.NewLogger(GinkgoT()).Sugar()
+})


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Fixes the code in running_target_selector so that we respect annotation filters
- Adds a logger to running_target_selector
- Complicates the test code in disruption_controller_test.go so that the tests actually fail when the feature is broken, see the branch philip.thompson/chaosplt-248-3. I'm testing in the 248-4 branch if we actually need these longer DontExpect calls

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
