### PR TITLE
chaosplt-216: add to the safemode env docs

### DIFF
--- a/docs/safemode.md
+++ b/docs/safemode.md
@@ -14,6 +14,17 @@ The chaos-controller operates within the boundaries of a single kubernetes clust
 intended for a given cluster cannot be accidentally run anywhere else, especially across the dev/prod boundary. Operators of the chaos-controller can optionally set the
 `controller.safeMode.specifiedEnvironment` field in the config map to a string of their choice. Disruptions will then be rejected if they do not have a `chaos.datadoghq.com/environment` annotation set to an identical string.
 
+For example, if your controller's specifiedEnvironment field was set to `production`, Disruptions would need their environment annotation to match:
+```yaml
+metadata:
+  annotations:
+    chaos.datadoghq.com/environment: "production"
+```
+
+Any disruptions lacking this annotation, or using a different value, such as `dev`, would be rejected at admission.
+
+[See an example.](../examples/safemode_environment.yaml)
+
 ## Ignoring Safety Nets
 
 Because the list of safety nets to be implemented will grow in the future, there will surely be overlap with safety nets which will make it difficult for a user who is confident a specific safety net is not necessary but unsure if others will be.

--- a/examples/safemode_environment.yaml
+++ b/examples/safemode_environment.yaml
@@ -1,0 +1,20 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2024 Datadog, Inc.
+
+apiVersion: chaos.datadoghq.com/v1beta1
+kind: Disruption
+metadata:
+  name: safemode-environment
+  namespace: chaos-demo
+  annotations:
+    chaos.datadoghq.com/environment: "lima" # See ../docs/safemode.md for more info. The appropriate value for this annotation depends on the chaos-controller's configuration for your specific installation.
+spec:
+  level: pod
+  selector:
+    app: demo-curl
+  count: 1
+  network:
+    delay: 1000 # delay (in milliseconds) to add to outgoing packets, 10% of jitter will be added by default
+    delayJitter: 5 # (optional) add X % (1-100) of delay as jitter to delay (+- X% ms to original delay), defaults to 10%


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Add an example file
- Add to the docs in `safemode.md` about using the environment annotation, to make it clearer for users
- Once this is merged, I intend to get the permalink to this github doc and include that as part of our error message explaining how to set the field. Sadly that will be a two-step PR (this PR is step one)

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
