### PR TITLE
Chaosplt-216: Allow for including custom error messages in the chart

### DIFF
--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -147,22 +147,23 @@ func (r *Disruption) ValidateCreate() error {
 
 	if safemodeEnvironment != "" {
 		disruptionEnv, ok := r.Annotations[SafemodeEnvironmentAnnotation]
+
 		if !ok {
-			return fmt.Errorf("your disruption does not specify the environment it expects to run in, but this controller requires it to do. Set an annotation on this disruption with the key `%s` and the value `\"%s\"` to run in this kubernetes cluster. Be sure that you intend to run this disruption in %s %s",
+			return fmt.Errorf("your disruption does not specify the environment it expects to run in, but this controller requires it to do. Set an annotation on this disruption with the key `%s` and the value `\"%s\"` to run in this kubernetes cluster. Be sure that you intend to run this disruption in %s. %s",
 				SafemodeEnvironmentAnnotation,
 				safemodeEnvironment,
 				safemodeEnvironment,
-				customErrors["safemodeEnvironment"],
+				customErrors["safemodeenvironment"],
 			)
 		}
 
 		if disruptionEnv != safemodeEnvironment {
-			return fmt.Errorf("disruption is configured to run in \"%s\" but has been applied in \"%s\".  Set an annotation on this disruption with the key `%s` and the value `\"%s\"` to run in this kubernetes cluster, and double check your kubecontext is what you expect %s",
+			return fmt.Errorf("disruption is configured to run in \"%s\" but has been applied in \"%s\".  Set an annotation on this disruption with the key `%s` and the value `\"%s\"` to run in this kubernetes cluster, and double check your kubecontext is what you expect. %s",
 				disruptionEnv,
 				safemodeEnvironment,
 				SafemodeEnvironmentAnnotation,
 				safemodeEnvironment,
-				customErrors["safemodeEnvironment"],
+				customErrors["safemodeenvironment"],
 			)
 		}
 	}

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -54,6 +54,7 @@ var (
 	safemodeEnvironment             string
 	permittedUserGroups             map[string]struct{}
 	permittedUserGroupWarningString string
+	customErrors                    map[string]string
 )
 
 const SafemodeEnvironmentAnnotation = GroupName + "/environment"
@@ -82,7 +83,12 @@ func (r *Disruption) SetupWebhookWithManager(setupWebhookConfig utils.SetupWebho
 	cloudServicesProvidersManager = setupWebhookConfig.CloudServicesProvidersManager
 	chaosNamespace = setupWebhookConfig.ChaosNamespace
 	safemodeEnvironment = setupWebhookConfig.Environment
+	customErrors = map[string]string{}
 	permittedUserGroups = map[string]struct{}{}
+
+	for k, v := range setupWebhookConfig.CustomErrors {
+		customErrors[k] = v
+	}
 
 	for _, group := range setupWebhookConfig.PermittedUserGroups {
 		permittedUserGroups[group] = struct{}{}

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -148,19 +148,21 @@ func (r *Disruption) ValidateCreate() error {
 	if safemodeEnvironment != "" {
 		disruptionEnv, ok := r.Annotations[SafemodeEnvironmentAnnotation]
 		if !ok {
-			return fmt.Errorf("your disruption does not specify the environment it expects to run in, but this controller requires it to do. Set an annotation on this disruption with the key `%s` and the value `\"%s\"` to run in this kubernetes cluster. Be sure that you intend to run this disruption in %s",
+			return fmt.Errorf("your disruption does not specify the environment it expects to run in, but this controller requires it to do. Set an annotation on this disruption with the key `%s` and the value `\"%s\"` to run in this kubernetes cluster. Be sure that you intend to run this disruption in %s %s",
 				SafemodeEnvironmentAnnotation,
 				safemodeEnvironment,
 				safemodeEnvironment,
+				customErrors["safemodeEnvironment"],
 			)
 		}
 
 		if disruptionEnv != safemodeEnvironment {
-			return fmt.Errorf("disruption is configured to run in \"%s\" but has been applied in \"%s\".  Set an annotation on this disruption with the key `%s` and the value `\"%s\"` to run in this kubernetes cluster, and double check your kubecontext is what you expect",
+			return fmt.Errorf("disruption is configured to run in \"%s\" but has been applied in \"%s\".  Set an annotation on this disruption with the key `%s` and the value `\"%s\"` to run in this kubernetes cluster, and double check your kubecontext is what you expect %s",
 				disruptionEnv,
 				safemodeEnvironment,
 				SafemodeEnvironmentAnnotation,
 				safemodeEnvironment,
+				customErrors["safemodeEnvironment"],
 			)
 		}
 	}

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -54,7 +54,7 @@ var (
 	safemodeEnvironment             string
 	permittedUserGroups             map[string]struct{}
 	permittedUserGroupWarningString string
-	customErrors                    map[string]string
+	customErrors                    utils.CustomErrors
 )
 
 const SafemodeEnvironmentAnnotation = GroupName + "/environment"
@@ -83,12 +83,8 @@ func (r *Disruption) SetupWebhookWithManager(setupWebhookConfig utils.SetupWebho
 	cloudServicesProvidersManager = setupWebhookConfig.CloudServicesProvidersManager
 	chaosNamespace = setupWebhookConfig.ChaosNamespace
 	safemodeEnvironment = setupWebhookConfig.Environment
-	customErrors = map[string]string{}
+	customErrors = setupWebhookConfig.CustomErrors
 	permittedUserGroups = map[string]struct{}{}
-
-	for k, v := range setupWebhookConfig.CustomErrors {
-		customErrors[k] = v
-	}
 
 	for _, group := range setupWebhookConfig.PermittedUserGroups {
 		permittedUserGroups[group] = struct{}{}
@@ -153,7 +149,7 @@ func (r *Disruption) ValidateCreate() error {
 				SafemodeEnvironmentAnnotation,
 				safemodeEnvironment,
 				safemodeEnvironment,
-				customErrors["safemodeenvironment"],
+				customErrors.SafemodeEnvironment,
 			)
 		}
 
@@ -163,7 +159,7 @@ func (r *Disruption) ValidateCreate() error {
 				safemodeEnvironment,
 				SafemodeEnvironmentAnnotation,
 				safemodeEnvironment,
-				customErrors["safemodeenvironment"],
+				customErrors.SafemodeEnvironment,
 			)
 		}
 	}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -66,6 +66,12 @@ data:
       disruptionCronEnabled: {{ .Values.controller.disruptionCronEnabled }}
       disruptionRolloutEnabled: {{ .Values.controller.disruptionRolloutEnabled }}
       disruptionDeletionTimeout: {{ .Values.controller.disruptionDeletionTimeout }}
+      {{- if .Values.controller.customErrors }}
+      customErrors:
+        {{- range $key, $val := .Values.controller.customErrors }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+      {{- end }}
     injector:
       image: {{ template "chaos-controller.format-image" deepCopy .Values.global.chaos.defaultImage | merge .Values.global.oci | merge .Values.injector.image }}
       imagePullSecrets: {{ .Values.injector.image.pullSecrets }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -78,8 +78,8 @@ controller:
   disruptionCronEnabled: true
   disruptionRolloutEnabled: false
   disruptionDeletionTimeout: 15m # The duration after which a disruption will be marked as "stuck on removal" if its removal process exceeds this duration.
-  customErrors: # these keys must be lowercased
-    safemodeenvironment: "Check out https://github.com/DataDog/chaos-controller/blob/f6adf086c559854790994acaa097a7b76d6624d3/docs/safemode.md#explicit-disruption-environments for more info"
+  customErrors:
+    safemodeEnvironment: "Check out https://github.com/DataDog/chaos-controller/blob/f6adf086c559854790994acaa097a7b76d6624d3/docs/safemode.md#explicit-disruption-environments for more info"
 
 injector:
   image:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -78,7 +78,8 @@ controller:
   disruptionCronEnabled: true
   disruptionRolloutEnabled: false
   disruptionDeletionTimeout: 15m # The duration after which a disruption will be marked as "stuck on removal" if its removal process exceeds this duration.
-  customErrors: {}
+  customErrors: # these keys must be lowercased
+    safemodeenvironment: "Check out https://github.com/DataDog/chaos-controller/blob/f6adf086c559854790994acaa097a7b76d6624d3/docs/safemode.md#explicit-disruption-environments for more info"
 
 injector:
   image:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -78,6 +78,7 @@ controller:
   disruptionCronEnabled: true
   disruptionRolloutEnabled: false
   disruptionDeletionTimeout: 15m # The duration after which a disruption will be marked as "stuck on removal" if its removal process exceeds this duration.
+  customErrors: {}
 
 injector:
   image:

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type controllerConfig struct {
 	DisruptionCronEnabled     bool                            `json:"disruptionCronEnabled"`
 	DisruptionRolloutEnabled  bool                            `json:"disruptionRolloutEnabled"`
 	DisruptionDeletionTimeout time.Duration                   `json:"disruptionDeletionTimeout"`
+	CustomErrors              map[string]string               `json:"customErrors"`
 }
 
 type controllerWebhookConfig struct {
@@ -429,6 +430,12 @@ func New(logger *zap.SugaredLogger, osArgs []string) (config, error) {
 	mainFS.DurationVar(&cfg.Controller.DisruptionDeletionTimeout, "disruption-deletion-timeout", DefaultDisruptionDeletionTimeout, "If the deletion time of the disruption is greater than the delete timeout, the disruption is marked as stuck on removal")
 
 	if err := viper.BindPFlag("controller.disruptionDeletionTimeout", mainFS.Lookup("disruption-deletion-timeout")); err != nil {
+		return cfg, err
+	}
+
+	mainFS.StringToStringVar(&cfg.Controller.CustomErrors, "custom-errors", map[string]string{}, "Allows you to specify custom error messages")
+
+	if err := viper.BindPFlag("controller.customErrors", mainFS.Lookup("custom-errors")); err != nil {
 		return cfg, err
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 
 	cloudtypes "github.com/DataDog/chaos-controller/cloudservice/types"
 	"github.com/DataDog/chaos-controller/eventnotifier"
+	"github.com/DataDog/chaos-controller/utils"
 	"go.uber.org/zap"
 
 	"github.com/fsnotify/fsnotify"
@@ -44,7 +45,7 @@ type controllerConfig struct {
 	DisruptionCronEnabled     bool                            `json:"disruptionCronEnabled"`
 	DisruptionRolloutEnabled  bool                            `json:"disruptionRolloutEnabled"`
 	DisruptionDeletionTimeout time.Duration                   `json:"disruptionDeletionTimeout"`
-	CustomErrors              map[string]string               `json:"customErrors"`
+	CustomErrors              utils.CustomErrors              `json:"customErrors"`
 }
 
 type controllerWebhookConfig struct {
@@ -433,9 +434,9 @@ func New(logger *zap.SugaredLogger, osArgs []string) (config, error) {
 		return cfg, err
 	}
 
-	mainFS.StringToStringVar(&cfg.Controller.CustomErrors, "custom-errors", map[string]string{}, "Allows you to specify custom error messages")
+	mainFS.StringVar(&cfg.Controller.CustomErrors.SafemodeEnvironment, "custom-errors-safemode-environment", "", "Allows you to specify custom error messages")
 
-	if err := viper.BindPFlag("controller.customErrors", mainFS.Lookup("custom-errors")); err != nil {
+	if err := viper.BindPFlag("controller.customErrors.safemodeEnvironment", mainFS.Lookup("custom-errors-safemode-environment")); err != nil {
 		return cfg, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -344,6 +344,7 @@ func main() {
 		CloudServicesProvidersManager: cloudProviderManager,
 		Environment:                   cfg.Controller.SafeMode.Environment,
 		PermittedUserGroups:           cfg.Controller.SafeMode.PermittedUserGroups,
+		CustomErrors:                  cfg.Controller.CustomErrors,
 	}
 	if err = (&chaosv1beta1.Disruption{}).SetupWebhookWithManager(setupWebhookConfig); err != nil {
 		logger.Fatalw("unable to create webhook", "webhook", chaosv1beta1.DisruptionKind, "error", err)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -39,6 +39,10 @@ func Contains(s []string, str string) bool {
 	return false
 }
 
+type CustomErrors struct {
+	SafemodeEnvironment string `json:"safemodeEnvironment"`
+}
+
 type SetupWebhookWithManagerConfig struct {
 	Manager                       ctrl.Manager
 	Logger                        *zap.SugaredLogger
@@ -56,5 +60,5 @@ type SetupWebhookWithManagerConfig struct {
 	CloudServicesProvidersManager cloudservice.CloudServicesProvidersManager
 	Environment                   string
 	PermittedUserGroups           []string
-	CustomErrors                  map[string]string
+	CustomErrors                  CustomErrors
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -56,4 +56,5 @@ type SetupWebhookWithManagerConfig struct {
 	CloudServicesProvidersManager cloudservice.CloudServicesProvidersManager
 	Environment                   string
 	PermittedUserGroups           []string
+	CustomErrors                  map[string]string
 }


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- This allows for customization of errors based on installation specific config.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
