### PR TITLE
chaosplt-211: reject notBefore triggers in the past

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -621,7 +621,7 @@ func (s DisruptionSpec) validateGlobalDisruptionScope() (retErr error) {
 		}
 
 		if !s.Triggers.CreatePods.IsZero() && !s.Triggers.CreatePods.NotBefore.IsZero() && s.Triggers.CreatePods.NotBefore.Before(&now) {
-			retErr = multierror.Append(retErr, fmt.Errorf("spec.trigger.createPods.notBefore is %s. only values in the future are accepted", s.Triggers.CreatePods.NotBefore))
+			retErr = multierror.Append(retErr, fmt.Errorf("spec.trigger.createPods.notBefore is %s, which is in the past. only values in the future are accepted", s.Triggers.CreatePods.NotBefore))
 		}
 	}
 

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -613,6 +613,16 @@ func (s DisruptionSpec) validateGlobalDisruptionScope() (retErr error) {
 				retErr = multierror.Append(retErr, fmt.Errorf("spec.trigger.inject.notBefore is %s, which is before your spec.trigger.createPods.notBefore of %s. inject.notBefore must come after createPods.notBefore if both are specified", s.Triggers.Inject.NotBefore, s.Triggers.CreatePods.NotBefore))
 			}
 		}
+
+		now := metav1.Now()
+
+		if !s.Triggers.Inject.IsZero() && !s.Triggers.Inject.NotBefore.IsZero() && s.Triggers.Inject.NotBefore.Before(&now) {
+			retErr = multierror.Append(retErr, fmt.Errorf("spec.trigger.inject.notBefore is %s, which is in the past. only values in the future are accepted", s.Triggers.Inject.NotBefore))
+		}
+
+		if !s.Triggers.CreatePods.IsZero() && !s.Triggers.CreatePods.NotBefore.IsZero() && s.Triggers.CreatePods.NotBefore.Before(&now) {
+			retErr = multierror.Append(retErr, fmt.Errorf("spec.trigger.createPods.notBefore is %s. only values in the future are accepted", s.Triggers.CreatePods.NotBefore))
+		}
 	}
 
 	// Rule: pulse compatibility

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -380,7 +380,7 @@ var _ = Describe("Disruption", func() {
 						},
 					}
 
-					Expect(newDisruption.ValidateCreate().Error()).Should(ContainSubstring("only values in the future are accepted"))
+					Expect(newDisruption.ValidateCreate()).Should(MatchError(ContainSubstring("only values in the future are accepted")))
 				})
 
 				It("triggers.createPods should return an error", func() {
@@ -391,7 +391,7 @@ var _ = Describe("Disruption", func() {
 						},
 					}
 
-					Expect(newDisruption.ValidateCreate().Error()).Should(ContainSubstring("only values in the future are accepted"))
+					Expect(newDisruption.ValidateCreate()).Should(MatchError(ContainSubstring("only values in the future are accepted")))
 				})
 			})
 
@@ -421,7 +421,7 @@ var _ = Describe("Disruption", func() {
 						},
 					}
 
-					Expect(newDisruption.ValidateCreate().Error()).Should(ContainSubstring("inject.notBefore must come after createPods.notBefore if both are specified"))
+					Expect(newDisruption.ValidateCreate()).Should(MatchError(ContainSubstring("inject.notBefore must come after createPods.notBefore if both are specified")))
 				})
 			})
 

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -397,6 +397,7 @@ var _ = Describe("Disruption", func() {
 
 			When("triggers.*.notBefore is in the future", func() {
 				It("should not return an error", func() {
+					ddmarkMock.EXPECT().ValidateStructMultierror(mock.Anything, mock.Anything).Return(&multierror.Error{})
 					newDisruption.Spec.Duration = "30m"
 					newDisruption.Spec.Triggers = DisruptionTriggers{
 						Inject: DisruptionTrigger{

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -405,7 +405,7 @@ var _ = Describe("Disruption", func() {
 						},
 					}
 
-					Expect(newDisruption.ValidateCreate().Error()).ShouldNot(HaveOccurred())
+					Expect(newDisruption.ValidateCreate()).ShouldNot(HaveOccurred())
 				})
 			})
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- reject any notBefore triggers set in the past during ValidateCreate, as there's no valid reason to specify those (they'd just be ignored, at best), so it indicates probably a user mistake

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
