### PR TITLE
Move expired triggers validation from validateGlobal into just valida…

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -613,16 +613,6 @@ func (s DisruptionSpec) validateGlobalDisruptionScope() (retErr error) {
 				retErr = multierror.Append(retErr, fmt.Errorf("spec.trigger.inject.notBefore is %s, which is before your spec.trigger.createPods.notBefore of %s. inject.notBefore must come after createPods.notBefore if both are specified", s.Triggers.Inject.NotBefore, s.Triggers.CreatePods.NotBefore))
 			}
 		}
-
-		now := metav1.Now()
-
-		if !s.Triggers.Inject.IsZero() && !s.Triggers.Inject.NotBefore.IsZero() && s.Triggers.Inject.NotBefore.Before(&now) {
-			retErr = multierror.Append(retErr, fmt.Errorf("spec.trigger.inject.notBefore is %s, which is in the past. only values in the future are accepted", s.Triggers.Inject.NotBefore))
-		}
-
-		if !s.Triggers.CreatePods.IsZero() && !s.Triggers.CreatePods.NotBefore.IsZero() && s.Triggers.CreatePods.NotBefore.Before(&now) {
-			retErr = multierror.Append(retErr, fmt.Errorf("spec.trigger.createPods.notBefore is %s, which is in the past. only values in the future are accepted", s.Triggers.CreatePods.NotBefore))
-		}
 	}
 
 	// Rule: pulse compatibility

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -204,6 +204,18 @@ func (r *Disruption) ValidateCreate() error {
 		return err
 	}
 
+	if !r.Spec.Triggers.IsZero() {
+		now := metav1.Now()
+
+		if !r.Spec.Triggers.Inject.IsZero() && !r.Spec.Triggers.Inject.NotBefore.IsZero() && r.Spec.Triggers.Inject.NotBefore.Before(&now) {
+			return fmt.Errorf("spec.trigger.inject.notBefore is %s, which is in the past. only values in the future are accepted", r.Spec.Triggers.Inject.NotBefore)
+		}
+
+		if !r.Spec.Triggers.CreatePods.IsZero() && !r.Spec.Triggers.CreatePods.NotBefore.IsZero() && r.Spec.Triggers.CreatePods.NotBefore.Before(&now) {
+			return fmt.Errorf("spec.trigger.createPods.notBefore is %s, which is in the past. only values in the future are accepted", r.Spec.Triggers.CreatePods.NotBefore)
+		}
+	}
+
 	if maxDuration > 0 && r.Spec.Duration.Duration() > maxDuration {
 		return fmt.Errorf("you have specified a duration of %s, but the maximum duration allowed is %s, please specify a duration lower or equal than this value", r.Spec.Duration.Duration(), maxDuration)
 	}

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -103,17 +103,18 @@ var _ = Describe("Disruption", func() {
 		Describe("ValidateCreate-only invariants shouldn't affect Update", func() {
 			When("triggers.*.notBefore is in the past", func() {
 				It("triggers.inject should not return an error", func() {
+					newTime := metav1.NewTime(time.Now().Add(time.Minute * 5 * -1))
 					newDisruption.Spec.Duration = "30m"
 					newDisruption.Spec.Triggers = DisruptionTriggers{
 						Inject: DisruptionTrigger{
-							NotBefore: metav1.NewTime(time.Now().Add(time.Minute * 5 * -1)),
+							NotBefore: newTime,
 						},
 					}
 
 					oldDisruption.Spec.Duration = "30m"
 					oldDisruption.Spec.Triggers = DisruptionTriggers{
 						Inject: DisruptionTrigger{
-							NotBefore: metav1.NewTime(time.Now().Add(time.Minute * 5 * -1)),
+							NotBefore: newTime,
 						},
 					}
 
@@ -122,17 +123,18 @@ var _ = Describe("Disruption", func() {
 				})
 
 				It("triggers.createPods should not return an error", func() {
+					newTime := metav1.NewTime(time.Now().Add(time.Hour * -1))
 					newDisruption.Spec.Duration = "30m"
 					newDisruption.Spec.Triggers = DisruptionTriggers{
 						CreatePods: DisruptionTrigger{
-							NotBefore: metav1.NewTime(time.Now().Add(time.Hour * -1)),
+							NotBefore: newTime,
 						},
 					}
 
 					oldDisruption.Spec.Duration = "30m"
 					oldDisruption.Spec.Triggers = DisruptionTriggers{
 						Inject: DisruptionTrigger{
-							NotBefore: metav1.NewTime(time.Now().Add(time.Minute * 5 * -1)),
+							NotBefore: newTime,
 						},
 					}
 

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -103,40 +103,33 @@ var _ = Describe("Disruption", func() {
 		Describe("ValidateCreate-only invariants shouldn't affect Update", func() {
 			When("triggers.*.notBefore is in the past", func() {
 				It("triggers.inject should not return an error", func() {
-					newTime := metav1.NewTime(time.Now().Add(time.Minute * 5 * -1))
-					newDisruption.Spec.Duration = "30m"
-					newDisruption.Spec.Triggers = DisruptionTriggers{
+					triggers := DisruptionTriggers{
 						Inject: DisruptionTrigger{
-							NotBefore: newTime,
+							NotBefore: metav1.NewTime(time.Now().Add(time.Minute * 5 * -1)),
 						},
 					}
 
+					newDisruption.Spec.Duration = "30m"
+					newDisruption.Spec.Triggers = triggers
+
 					oldDisruption.Spec.Duration = "30m"
-					oldDisruption.Spec.Triggers = DisruptionTriggers{
-						Inject: DisruptionTrigger{
-							NotBefore: newTime,
-						},
-					}
+					oldDisruption.Spec.Triggers = triggers
 
 					err := newDisruption.ValidateUpdate(oldDisruption)
 					Expect(err).Should(Succeed())
 				})
 
 				It("triggers.createPods should not return an error", func() {
-					newTime := metav1.NewTime(time.Now().Add(time.Hour * -1))
-					newDisruption.Spec.Duration = "30m"
-					newDisruption.Spec.Triggers = DisruptionTriggers{
+					triggers := DisruptionTriggers{
 						CreatePods: DisruptionTrigger{
-							NotBefore: newTime,
+							NotBefore: metav1.NewTime(time.Now().Add(time.Hour * -1)),
 						},
 					}
+					newDisruption.Spec.Duration = "30m"
+					newDisruption.Spec.Triggers = triggers
 
 					oldDisruption.Spec.Duration = "30m"
-					oldDisruption.Spec.Triggers = DisruptionTriggers{
-						Inject: DisruptionTrigger{
-							NotBefore: newTime,
-						},
-					}
+					oldDisruption.Spec.Triggers = triggers
 
 					err := newDisruption.ValidateUpdate(oldDisruption)
 					Expect(err).Should(Succeed())


### PR DESCRIPTION
…teCreate

## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Didn't realize this function was called again in validateUpdate. Moved this logic specifically into validateCreate

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
