### PR TITLE
fix: add custom chaos types in the clientsets schema

### DIFF
--- a/api/v1beta1/install/install.go
+++ b/api/v1beta1/install/install.go
@@ -17,4 +17,5 @@ import (
 func Install(scheme *runtime.Scheme) {
 	utilruntime.Must(chaosv1beta1.AddToScheme(scheme))
 	utilruntime.Must(scheme.SetVersionPriority(v1beta1.SchemeGroupVersion))
+	utilruntime.Must(chaosv1beta1.ClientSchemeBuilder.AddToScheme(scheme))
 }


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Add the custom chaos types to the new clientsets.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
