### PR TITLE
Send userGroups info in http notifications

### DIFF
--- a/eventnotifier/http/http.go
+++ b/eventnotifier/http/http.go
@@ -55,6 +55,7 @@ type HTTPNotifierEvent struct {
 	TargetsCount       int                    `jsonapi:"attribute" json:"targets_count"`
 	Username           string                 `jsonapi:"attribute" json:"username,omitempty"`
 	UserEmail          string                 `jsonapi:"attribute" json:"user_email,omitempty"`
+	UserGroups         string                 `jsonapi:"attribute" json:"user_groups,omitempty"`
 }
 
 // New HTTP Notifier
@@ -118,21 +119,11 @@ func (n *Notifier) GetNotifierName() string {
 
 // Notify generates a notification for generic k8s Warning events
 func (n *Notifier) Notify(dis v1beta1.Disruption, event corev1.Event, notifType types.NotificationType) error {
-	emailAddr := &mail.Address{}
-
-	if userInfo, err := dis.UserInfo(); err != nil {
-		n.logger.Warnw("http notifier: no user info in disruption", "disruptionName", dis.Name, "disruptionNamespace", dis.Namespace, "error", err)
-	} else {
-		if userInfoEmailAddr, err := mail.ParseAddress(userInfo.Username); err != nil {
-			n.logger.Warnw("http notifier: user info username is not a valid email address", "disruptionName", dis.Name, "disruptionNamespace", dis.Namespace, "error", err, "username", userInfo.Username)
-		} else {
-			emailAddr = userInfoEmailAddr
-		}
-	}
+	username, userEmail, userGroups := n.getUserDetails(dis)
 
 	disruptionStr, err := json.Marshal(dis)
 	if err != nil {
-		return fmt.Errorf("http notifier: couldn't send notification: %w", err)
+		return fmt.Errorf("http notifier: couldn't marshal disruption: %w", err)
 	}
 
 	now := time.Now()
@@ -149,8 +140,9 @@ func (n *Notifier) Notify(dis v1beta1.Disruption, event corev1.Event, notifType 
 		Cluster:            n.common.ClusterName,
 		Namespace:          dis.Namespace,
 		TargetsCount:       len(dis.Status.TargetInjections),
-		Username:           emailAddr.Name,
-		UserEmail:          emailAddr.Address,
+		Username:           username,
+		UserEmail:          userEmail,
+		UserGroups:         userGroups,
 	}
 
 	jsonNotif, err := jsonapi.Marshal(&notif)
@@ -184,4 +176,49 @@ func (n *Notifier) Notify(dis v1beta1.Disruption, event corev1.Event, notifType 
 	}
 
 	return nil
+}
+
+// getUserDetails retrieves the user details associated with a given disruption.
+// It returns the username, the email address, and a JSON string of user groups.
+// On error, it logs a warning and returns empty values for the fields.
+func (n *Notifier) getUserDetails(dis v1beta1.Disruption) (username, emailAddr string, userGroups string) {
+	userInfo, err := dis.UserInfo()
+	if err != nil {
+		n.logger.Warnw("http notifier: no user info in disruption", "disruptionName", dis.Name, "disruptionNamespace", dis.Namespace, "error", err)
+		return "", "", ""
+	}
+
+	username = userInfo.Username
+	emailAddr, err = n.extractEmail(username)
+
+	if err != nil {
+		n.logger.Warnw("http notifier: user info username is not a valid email address", "disruptionName", dis.Name, "disruptionNamespace", dis.Namespace, "error", err, "username", username)
+	}
+
+	userGroups, err = n.marshalUserGroups(userInfo.Groups)
+	if err != nil {
+		n.logger.Warnw("http notifier: couldn't marshal user groups", "disruptionName", dis.Name, "disruptionNamespace", dis.Namespace, "error", err)
+	}
+
+	return username, emailAddr, userGroups
+}
+
+// extractEmail tries to parse the provided username as an email address and returns it if valid.
+func (n *Notifier) extractEmail(username string) (string, error) {
+	emailAddr, err := mail.ParseAddress(username)
+	if err != nil {
+		return "", err
+	}
+
+	return emailAddr.Address, nil
+}
+
+// marshalUserGroups converts user groups to a JSON string.
+func (n *Notifier) marshalUserGroups(groups []string) (string, error) {
+	groupsBytes, err := json.Marshal(groups)
+	if err != nil {
+		return "", err
+	}
+
+	return string(groupsBytes), nil
 }

--- a/eventnotifier/http/http.go
+++ b/eventnotifier/http/http.go
@@ -181,7 +181,7 @@ func (n *Notifier) Notify(dis v1beta1.Disruption, event corev1.Event, notifType 
 // getUserDetails retrieves the user details associated with a given disruption.
 // It returns the username, the email address, and a JSON string of user groups.
 // On error, it logs a warning and returns empty values for the fields.
-func (n *Notifier) getUserDetails(dis v1beta1.Disruption) (username, emailAddr string, userGroups string) {
+func (n *Notifier) getUserDetails(dis v1beta1.Disruption) (username, emailAddr, userGroups string) {
 	userInfo, err := dis.UserInfo()
 	if err != nil {
 		n.logger.Warnw("http notifier: no user info in disruption", "disruptionName", dis.Name, "disruptionNamespace", dis.Namespace, "error", err)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

This PR enhances the event notifier's HTTP notifications by explicitly including user groups along with the already available username and user email. If any information is missing, it will be omitted.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
