### PR TITLE
fix: SEGFAULT error during cmd keepalive process

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -221,9 +221,9 @@ func (w *backgroundCmd) sendSIGCONTSignal() (exit bool, err error) {
 	case <-w.chQuit:
 		close(w.chQuit)
 		w.log.Debug("background process exited, stopping to monitor background process, ticker removed")
+
 		return true, nil
 	case <-w.ticker.C:
-		// continue
 	}
 
 	proc, err := w.processManager.Find(w.pid)

--- a/command/command.go
+++ b/command/command.go
@@ -190,7 +190,7 @@ func (w *backgroundCmd) KeepAlive() {
 
 	w.ticker = time.NewTicker(cmdKeepAliveTickDuration)
 
-	w.keepAliveQuit = make(chan int)
+	w.keepAliveQuit = make(chan int, 1) // we need a buffered channel so the sender doesn't block
 
 	w.log.Debug("monitoring sending SIGCONT signal to process every 1s")
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -241,7 +241,7 @@ var _ = Describe("BackgroundCmd", func() {
 					SetupMockExpect(cmd, manager, &os.Process{}, syscall.SIGCONT, nil, nil, times)
 
 					sut.KeepAlive()
-					sut.KeepAlive() // we call it twice voluntarily to ensure a single goroutine is created
+					sut.KeepAlive() // we call it twice voluntarily to test the invariant that only a single goroutine is created
 
 					// Wait enough interval to have at least expected calls (times + 20%)
 					<-time.After(cmdKeepAliveTickDuration*time.Duration(times) + cmdBootstrapAllowedDuration/5)

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -240,7 +240,7 @@ var _ = Describe("BackgroundCmd", func() {
 				SetupMockExpect(cmd, manager, proc, syscall.SIGCONT, findErr, signalErr, times)
 
 				sut.KeepAlive()
-				sut.KeepAlive() // we call it twice volountarily to ensure a single goroutine is created
+				//sut.KeepAlive() // we call it twice voluntarily to ensure a single goroutine is created
 
 				// Wait enough interval to have at least expected calls (times + 20%)
 				<-time.After(cmdKeepAliveTickDuration*time.Duration(times) + cmdBootstrapAllowedDuration/5)

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -251,7 +251,7 @@ var _ = Describe("BackgroundCmd", func() {
 					Expect(underSut).ToNot(BeNil())
 
 					// Stop timer ASAP to have realistic amount of calls
-					underSut.chQuit <- 0
+					underSut.chKeepAliveQuit <- 0
 				},
 				Entry("Send a signal two times", 2),
 				Entry("Send a signal three times", 3),

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -255,7 +255,7 @@ var _ = Describe("BackgroundCmd", func() {
 				},
 				Entry("Send a signal two times", 2),
 				Entry("Send a signal three times", 3),
-				Entry("Send a signal three times", 1),
+				Entry("Send a signal one times", 1),
 				Entry("Send a signal four times", 4),
 			)
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -265,7 +265,7 @@ var _ = Describe("BackgroundCmd", func() {
 					SetupMockExpect(cmd, manager, proc, syscall.SIGCONT, findErr, signalErr, times)
 
 					sut.KeepAlive()
-					sut.KeepAlive() // we call it twice voluntarily to ensure a single goroutine is created
+					sut.KeepAlive() // we call it twice voluntarily to test the invariant that only a single goroutine is created
 
 					// Wait enough interval to have at least expected calls (times + 20%)
 					<-time.After(cmdKeepAliveTickDuration*time.Duration(times) + cmdBootstrapAllowedDuration/5)

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -234,28 +234,50 @@ var _ = Describe("BackgroundCmd", func() {
 			}
 		}
 
-		DescribeTable(
-			"KeepAlive",
-			func(proc *os.Process, findErr, signalErr error, times int) {
-				SetupMockExpect(cmd, manager, proc, syscall.SIGCONT, findErr, signalErr, times)
+		Describe("KeepAlive", func() {
+			DescribeTable(
+				"success cases",
+				func(times int) {
+					SetupMockExpect(cmd, manager, &os.Process{}, syscall.SIGCONT, nil, nil, times)
 
-				sut.KeepAlive()
-				sut.KeepAlive() // we call it twice voluntarily to ensure a single goroutine is created
+					sut.KeepAlive()
+					sut.KeepAlive() // we call it twice voluntarily to ensure a single goroutine is created
 
-				// Wait enough interval to have at least expected calls (times + 20%)
-				<-time.After(cmdKeepAliveTickDuration*time.Duration(times) + cmdBootstrapAllowedDuration/5)
+					// Wait enough interval to have at least expected calls (times + 20%)
+					<-time.After(cmdKeepAliveTickDuration*time.Duration(times) + cmdBootstrapAllowedDuration/5)
 
-				underSut, ok := sut.(*backgroundCmd)
-				Expect(ok).To(BeTrue())
-				Expect(underSut).ToNot(BeNil())
+					underSut, ok := sut.(*backgroundCmd)
+					Expect(ok).To(BeTrue())
+					Expect(underSut).ToNot(BeNil())
 
-				// Stop timer ASAP to have realistic amount of calls
-				underSut.resetTicker()
-			},
-			Entry("Send a signal several times", &os.Process{}, nil, nil, 2),
-			Entry("Find fails once", nil, errors.New("find fails"), nil, 1),
-			Entry("Signal fails once", &os.Process{}, nil, errors.New("signal fails"), 1),
-		)
+					// Stop timer ASAP to have realistic amount of calls
+					underSut.chQuit <- 0
+				},
+				Entry("Send a signal two times", 2),
+				Entry("Send a signal three times", 3),
+				Entry("Send a signal three times", 1),
+				Entry("Send a signal four times", 4),
+			)
+
+			DescribeTable(
+				"Error cases",
+				func(proc *os.Process, findErr, signalErr error, times int) {
+					SetupMockExpect(cmd, manager, proc, syscall.SIGCONT, findErr, signalErr, times)
+
+					sut.KeepAlive()
+					sut.KeepAlive() // we call it twice voluntarily to ensure a single goroutine is created
+
+					// Wait enough interval to have at least expected calls (times + 20%)
+					<-time.After(cmdKeepAliveTickDuration*time.Duration(times) + cmdBootstrapAllowedDuration/5)
+
+					underSut, ok := sut.(*backgroundCmd)
+					Expect(ok).To(BeTrue())
+					Expect(underSut).ToNot(BeNil())
+				},
+				Entry("Find fails once", nil, errors.New("find fails"), nil, 1),
+				Entry("Signal fails once", &os.Process{}, nil, errors.New("signal fails"), 1),
+			)
+		})
 
 		DescribeTable(
 			"Stop",

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -251,7 +251,7 @@ var _ = Describe("BackgroundCmd", func() {
 					Expect(underSut).ToNot(BeNil())
 
 					// Stop timer ASAP to have realistic amount of calls
-					underSut.chKeepAliveQuit <- 0
+					underSut.keepAliveQuit <- 0
 				},
 				Entry("Send a signal two times", 2),
 				Entry("Send a signal three times", 3),

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -240,7 +240,7 @@ var _ = Describe("BackgroundCmd", func() {
 				SetupMockExpect(cmd, manager, proc, syscall.SIGCONT, findErr, signalErr, times)
 
 				sut.KeepAlive()
-				//sut.KeepAlive() // we call it twice voluntarily to ensure a single goroutine is created
+				sut.KeepAlive() // we call it twice voluntarily to ensure a single goroutine is created
 
 				// Wait enough interval to have at least expected calls (times + 20%)
 				<-time.After(cmdKeepAliveTickDuration*time.Duration(times) + cmdBootstrapAllowedDuration/5)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The goroutine launched by the `KeppAlive` command program, get the result from a nil ticker channel because the unlock command is released too early. 

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
