### PR TITLE
fix: handle nil pod watcher to avoid SIGSEV

### DIFF
--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -348,6 +348,13 @@ func initPodWatch(resourceVersion string) (<-chan watch.Event, error) {
 		ResourceVersion:     resourceVersion,
 		AllowWatchBookmarks: true,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	if podWatcher == nil {
+		return nil, fmt.Errorf("unable to watch pod %s in namespace %s", disruptionArgs.TargetName, disruptionArgs.DisruptionNamespace)
+	}
 
 	return podWatcher.ResultChan(), err
 }


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- `Handle nil pod watcher to avoid SIGSEV into the injector program`

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
