### PR TITLE
CHAOSPLT-308: Change DisruptionSpec's Triggers field to a pointer

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -58,7 +58,7 @@ type DisruptionSpec struct {
 	Unsafemode      *UnsafemodeSpec   `json:"unsafeMode,omitempty"`      // unsafemode spec used to turn off safemode safety nets
 	StaticTargeting bool              `json:"staticTargeting,omitempty"` // enable dynamic targeting and cluster observation
 	// +nullable
-	Triggers DisruptionTriggers `json:"triggers,omitempty"` // alter the pre-injection lifecycle
+	Triggers *DisruptionTriggers `json:"triggers,omitempty"` // alter the pre-injection lifecycle
 	// +nullable
 	Pulse    *DisruptionPulse   `json:"pulse,omitempty"`    // enable pulsing diruptions and specify the duration of the active state and the dormant state of the pulsing duration
 	Duration DisruptionDuration `json:"duration,omitempty"` // time from disruption creation until chaos pods are deleted and no more are created
@@ -302,7 +302,7 @@ type Disruption struct {
 func (r *Disruption) TimeToInject() time.Time {
 	triggers := r.Spec.Triggers
 
-	if triggers.IsZero() {
+	if triggers == nil || triggers.IsZero() {
 		return r.CreationTimestamp.Time
 	}
 
@@ -334,7 +334,7 @@ func (r *Disruption) TimeToInject() time.Time {
 func (r *Disruption) TimeToCreatePods() time.Time {
 	triggers := r.Spec.Triggers
 
-	if triggers.IsZero() {
+	if triggers == nil || triggers.IsZero() {
 		return r.CreationTimestamp.Time
 	}
 
@@ -610,7 +610,7 @@ func (s DisruptionSpec) validateGlobalDisruptionScope() (retErr error) {
 	}
 
 	// Rule: DisruptionTrigger
-	if !s.Triggers.IsZero() {
+	if s.Triggers != nil && !s.Triggers.IsZero() {
 		if !s.Triggers.Inject.IsZero() && !s.Triggers.CreatePods.IsZero() {
 			if !s.Triggers.Inject.NotBefore.IsZero() && !s.Triggers.CreatePods.NotBefore.IsZero() && s.Triggers.Inject.NotBefore.Before(&s.Triggers.CreatePods.NotBefore) {
 				retErr = multierror.Append(retErr, fmt.Errorf("spec.trigger.inject.notBefore is %s, which is before your spec.trigger.createPods.notBefore of %s. inject.notBefore must come after createPods.notBefore if both are specified", s.Triggers.Inject.NotBefore, s.Triggers.CreatePods.NotBefore))

--- a/api/v1beta1/disruption_types_test.go
+++ b/api/v1beta1/disruption_types_test.go
@@ -313,7 +313,7 @@ var _ = Describe("Disruption", func() {
 			builderstest.NewDisruptionBuilder(), defaultCreationTimestamp),
 		Entry(
 			"should return triggers.createPods if triggers.inject is nil",
-			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(DisruptionTriggers{
+			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(&DisruptionTriggers{
 				CreatePods: DisruptionTrigger{
 					NotBefore: metav1.NewTime(notBeforeTime),
 					Offset:    "",
@@ -321,7 +321,7 @@ var _ = Describe("Disruption", func() {
 			}), notBeforeTime),
 		Entry(
 			"should return inject.notBefore if set",
-			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(DisruptionTriggers{
+			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(&DisruptionTriggers{
 				Inject: DisruptionTrigger{
 					NotBefore: metav1.NewTime(notBeforeTime),
 					Offset:    "",
@@ -333,7 +333,7 @@ var _ = Describe("Disruption", func() {
 			}), notBeforeTime),
 		Entry(
 			"should return a time after creationTimestamp if inject.offset is set",
-			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(DisruptionTriggers{
+			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(&DisruptionTriggers{
 				Inject: DisruptionTrigger{
 					NotBefore: metav1.Time{},
 					Offset:    "1m",
@@ -341,14 +341,14 @@ var _ = Describe("Disruption", func() {
 			}), notBeforeTime),
 		Entry(
 			"should return creationTimestamp if inject.NotBefore is before creationTimestamp",
-			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(DisruptionTriggers{
+			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(&DisruptionTriggers{
 				CreatePods: DisruptionTrigger{
 					NotBefore: metav1.NewTime(defaultCreationTimestamp.Add(-time.Minute)),
 				},
 			}), defaultCreationTimestamp),
 		Entry(
 			"should return creationTimestamp + 5 minutes if createPods.offset is set",
-			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(DisruptionTriggers{
+			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(&DisruptionTriggers{
 				CreatePods: DisruptionTrigger{
 					NotBefore: metav1.Time{},
 					Offset:    "5m",
@@ -356,7 +356,7 @@ var _ = Describe("Disruption", func() {
 			}), defaultCreationTimestamp.Add(time.Minute*5)),
 		Entry(
 			"should return creationTimestamp + 5 minutes if createPods.NotBefore is before creationTimestamp",
-			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(DisruptionTriggers{
+			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(&DisruptionTriggers{
 				CreatePods: DisruptionTrigger{
 					NotBefore: metav1.NewTime(defaultCreationTimestamp.Add(-time.Minute * 5)),
 				},
@@ -376,7 +376,7 @@ var _ = Describe("Disruption", func() {
 			defaultCreationTimestamp),
 		Entry(
 			"should return creationTimestamp if triggers.createPods is nil",
-			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(DisruptionTriggers{
+			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(&DisruptionTriggers{
 				Inject: DisruptionTrigger{
 					Offset: "15m",
 				},
@@ -384,7 +384,7 @@ var _ = Describe("Disruption", func() {
 			defaultCreationTimestamp),
 		Entry(
 			"should return createPods.notBefore if set",
-			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(DisruptionTriggers{
+			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(&DisruptionTriggers{
 				Inject: DisruptionTrigger{
 					Offset: "15m",
 				},
@@ -396,7 +396,7 @@ var _ = Describe("Disruption", func() {
 			notBeforeTime),
 		Entry(
 			"should return a time after creationTimestamp if createPods.offset is set",
-			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(DisruptionTriggers{
+			builderstest.NewDisruptionBuilder().WithDisruptionTriggers(&DisruptionTriggers{
 				CreatePods: DisruptionTrigger{
 					NotBefore: metav1.Time{},
 					Offset:    "5m",

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -205,7 +205,7 @@ func (r *Disruption) ValidateCreate() (admission.Warnings, error) {
 		return nil, err
 	}
 
-	if !r.Spec.Triggers.IsZero() {
+	if r.Spec.Triggers != nil && !r.Spec.Triggers.IsZero() {
 		now := metav1.Now()
 
 		if !r.Spec.Triggers.Inject.IsZero() && !r.Spec.Triggers.Inject.NotBefore.IsZero() && r.Spec.Triggers.Inject.NotBefore.Before(&now) {

--- a/api/v1beta1/disruption_webhook_test.go
+++ b/api/v1beta1/disruption_webhook_test.go
@@ -112,10 +112,10 @@ var _ = Describe("Disruption", func() {
 					}
 
 					newDisruption.Spec.Duration = "30m"
-					newDisruption.Spec.Triggers = triggers
+					newDisruption.Spec.Triggers = &triggers
 
 					oldDisruption.Spec.Duration = "30m"
-					oldDisruption.Spec.Triggers = triggers
+					oldDisruption.Spec.Triggers = &triggers
 
 					_, err := newDisruption.ValidateUpdate(oldDisruption)
 					Expect(err).Should(Succeed())
@@ -128,10 +128,10 @@ var _ = Describe("Disruption", func() {
 						},
 					}
 					newDisruption.Spec.Duration = "30m"
-					newDisruption.Spec.Triggers = triggers
+					newDisruption.Spec.Triggers = &triggers
 
 					oldDisruption.Spec.Duration = "30m"
-					oldDisruption.Spec.Triggers = triggers
+					oldDisruption.Spec.Triggers = &triggers
 
 					_, err := newDisruption.ValidateUpdate(oldDisruption)
 					Expect(err).Should(Succeed())
@@ -419,7 +419,7 @@ var _ = Describe("Disruption", func() {
 			When("triggers.*.notBefore is in the past", func() {
 				It("triggers.inject should return an error", func() {
 					newDisruption.Spec.Duration = "30m"
-					newDisruption.Spec.Triggers = DisruptionTriggers{
+					newDisruption.Spec.Triggers = &DisruptionTriggers{
 						Inject: DisruptionTrigger{
 							NotBefore: metav1.NewTime(time.Now().Add(time.Minute * 5 * -1)),
 						},
@@ -431,7 +431,7 @@ var _ = Describe("Disruption", func() {
 
 				It("triggers.createPods should return an error", func() {
 					newDisruption.Spec.Duration = "30m"
-					newDisruption.Spec.Triggers = DisruptionTriggers{
+					newDisruption.Spec.Triggers = &DisruptionTriggers{
 						CreatePods: DisruptionTrigger{
 							NotBefore: metav1.NewTime(time.Now().Add(time.Hour * -1)),
 						},
@@ -446,7 +446,7 @@ var _ = Describe("Disruption", func() {
 				It("should not return an error", func() {
 					ddmarkMock.EXPECT().ValidateStructMultierror(mock.Anything, mock.Anything).Return(&multierror.Error{})
 					newDisruption.Spec.Duration = "30m"
-					newDisruption.Spec.Triggers = DisruptionTriggers{
+					newDisruption.Spec.Triggers = &DisruptionTriggers{
 						Inject: DisruptionTrigger{
 							NotBefore: metav1.NewTime(time.Now().Add(time.Minute * 5)),
 						},
@@ -460,7 +460,7 @@ var _ = Describe("Disruption", func() {
 			When("triggers.inject.notBefore is before triggers.createPods.notBefore", func() {
 				It("should return an error", func() {
 					newDisruption.Spec.Duration = "30m"
-					newDisruption.Spec.Triggers = DisruptionTriggers{
+					newDisruption.Spec.Triggers = &DisruptionTriggers{
 						Inject: DisruptionTrigger{
 							NotBefore: metav1.NewTime(time.Now().Add(time.Minute * 5)),
 						},

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -589,7 +589,11 @@ func (in *DisruptionSpec) DeepCopyInto(out *DisruptionSpec) {
 		*out = new(UnsafemodeSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	in.Triggers.DeepCopyInto(&out.Triggers)
+	if in.Triggers != nil {
+		in, out := &in.Triggers, &out.Triggers
+		*out = new(DisruptionTriggers)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Pulse != nil {
 		in, out := &in.Pulse, &out.Pulse
 		*out = new(DisruptionPulse)

--- a/builderstest/disruption.go
+++ b/builderstest/disruption.go
@@ -34,7 +34,7 @@ func NewDisruptionBuilder() *DisruptionBuilder {
 }
 
 // WithDisruptionTriggers sets the specified triggers of disruption.
-func (b *DisruptionBuilder) WithDisruptionTriggers(triggers v1beta1.DisruptionTriggers) *DisruptionBuilder {
+func (b *DisruptionBuilder) WithDisruptionTriggers(triggers *v1beta1.DisruptionTriggers) *DisruptionBuilder {
 	b.modifiers = append(
 		b.modifiers,
 		func() {

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,4 +5,4 @@
 apiVersion: v2
 name: chaos-controller
 description: Datadog Chaos Controller chart
-version: 2.7.0
+version: 3.0.0


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Contrast with #871
  - There is no change in yaml spec, nor any change in behavior or loss of functionality. We are only making a breaking change of the go struct by changing DisruptionSpec's Triggers field into a pointer. This will let the `omitempty` tag work, so we don't export empty values for `spec.triggers` when printing a disruption as json or yaml

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
