### PR TITLE
Change makefile default for E2E_TEST_CLUSTER_NAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ LIMA_INSTANCE ?= $(shell whoami | tr "." "-")
 
 # cluster name is used by e2e-test to target the node with a disruption
 # CI need to be able to override this value
-E2E_TEST_CLUSTER_NAME ?= $(LIMA_INSTANCE)
+E2E_TEST_CLUSTER_NAME ?= lima-$(LIMA_INSTANCE)
 E2E_TEST_KUBECTL_CONTEXT ?= lima
 
 KUBECTL ?= limactl shell $(LIMA_INSTANCE) sudo kubectl


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- I was debugging some e2e-tests locally and found one that consistently fails for me. `[It] Disruption Controller node level should target the node` always fails to find any targets. It's looking for a node that matches the selector `"kubernetes.io/hostname": clusterName` where `clusterName` is the value from the env var `E2E_TEST_CLUSTER_NAME`. But `make lima-start` is creating for me a lima cluster where the node's hostname is `lima-philip-thompson`, not `philip-thompson`. Given this is the only place I observed `E2E_TEST_CLUSTER_NAME` be accessed, i felt it simplest to change the local default.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
