### PR TITLE
Update goreleaser github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
+          distribution: goreleaser
           version: "~> v2"
           args: release --clean --skip=sign
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,9 @@ jobs:
           --set global.oci.registry=datadog --set global.chaos.defaultImage.tag=${GITHUB_REF_NAME}
           > ./chart/install.yaml
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --rm-dist --skip-sign
+          version: "~> v2"
+          args: release --clean --skip=sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- goreleaser 2.x.x is out, we were most recently using 1.251. we are only specifying "latest", so the upgrade happened unexpectedly, and our release of the tag `9.0.3` failed: https://github.com/DataDog/chaos-controller/actions/runs/9748841928/job/27287446127#step:7:53
- Changes were made based on upgrade docs from goreleaser: https://goreleaser.com/blog/goreleaser-v2/#upgrading and deprecation warnings from our last successful release: https://github.com/DataDog/chaos-controller/actions/runs/8986245630/job/24681906353
- We also incremented the version of the goreleaser github action we are using from v1 -> v6
- This is untested, as we'd need to release this PR to test

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
