### PR TITLE
Debian 11 will be EOL soon. Move to Debian 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ executors:
     docker:
       # This is circle ci images, provides default tool installed (like docker) to ease step definition and avoid apt-get/update things
       # https://circleci.com/docs/circleci-images/#next-gen-language-images
-      - image: cimg/go:1.22.1
+      - image: cimg/go:1.22.5
     resource_class: 2xlarge
   python:
     <<: *working_directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ executors:
   ubuntu:
     <<: *working_directory
     machine:
-      image: ubuntu-2204:2024.01.2
+      image: ubuntu-2404:2024.05.1
     resource_class: xlarge # if you change the resource_class here, please adapt Makefile/minikube start cpu/memory accordingly
 jobs:
   # prepares the CI environment by checking out the code,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: '>=1.22.5'
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOARCH = $(shell go env GOARCH)
 
 # change also circleci go build version "cimb/go:" if you change the version below
 # https://github.com/DataDog/chaos-controller/blob/main/.circleci/config.yml#L85
-BUILDGOVERSION = 1.22.1
+BUILDGOVERSION = 1.22.5
 
 # GOBIN can be provided (gitlab), defined (custom user setup), or empty/guessed (default go setup)
 GOBIN ?= $(shell go env GOBIN)

--- a/bin/handler/Dockerfile
+++ b/bin/handler/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch as handler
+FROM scratch AS handler
 
 ARG TARGETARCH
 COPY handler_${TARGETARCH} /usr/local/bin/handler

--- a/bin/injector/Dockerfile
+++ b/bin/injector/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10 as binaries
+FROM ubuntu:23.10 AS binaries
 
 RUN apt-get update && \
     # iproute2 => tc

--- a/bin/injector/Dockerfile
+++ b/bin/injector/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     mv bpftool /usr/bin/bpftool-amd64
 
 
-FROM gcr.io/distroless/python3-debian11:latest
+FROM gcr.io/distroless/python3-debian12:latest
 
 ARG TARGETARCH
 
@@ -51,7 +51,7 @@ ENTRYPOINT ["/usr/local/bin/chaos-injector"]
 
 LABEL baseimage.os="debian"
 LABEL baseimage.isgbi="custom"
-LABEL baseimage.name="gcr.io/distroless/python3-debian11:latest"
+LABEL baseimage.name="gcr.io/distroless/python3-debian12:latest"
 
 ARG BUILDSTAMP
 LABEL baseimage.buildstamp="${BUILDSTAMP}"

--- a/bin/manager/Dockerfile
+++ b/bin/manager/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILDGOVERSION
-FROM golang:${BUILDGOVERSION} as go
+FROM golang:${BUILDGOVERSION} AS go
 FROM gcr.io/distroless/base-debian12:nonroot
 
 ARG TARGETARCH

--- a/bin/manager/Dockerfile
+++ b/bin/manager/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILDGOVERSION
 FROM golang:${BUILDGOVERSION} as go
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM gcr.io/distroless/base-debian12:nonroot
 
 ARG TARGETARCH
 COPY manager_${TARGETARCH} /usr/local/bin/manager
@@ -13,7 +13,7 @@ ENTRYPOINT ["/usr/local/bin/manager"]
 
 LABEL baseimage.os="debian"
 LABEL baseimage.isgbi="custom"
-LABEL baseimage.name="gcr.io/distroless/base-debian11:nonroot"
+LABEL baseimage.name="gcr.io/distroless/base-debian12:nonroot"
 
 ARG BUILDSTAMP
 LABEL baseimage.buildstamp="${BUILDSTAMP}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/chaos-controller
 
-go 1.21
+go 1.22
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Updates all docker files to use debian 12 base images from gcr distroless
  - According to https://github.com/GoogleContainerTools/distroless , these should be kept up to date with upstream debian images, so I believe we'll get cve fixes again that we weren't, because debian11 was approaching (and soon will be) EOL
- Build releases using go 1.22.5
- Closes #884 

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
