### PR TITLE
Reduce warning and error logs from notifiers

### DIFF
--- a/api/v1beta1/disruption_cron_webhook.go
+++ b/api/v1beta1/disruption_cron_webhook.go
@@ -67,7 +67,7 @@ func (d *DisruptionCron) ValidateCreate() (admission.Warnings, error) {
 	}
 
 	// send informative event to disruption cron to broadcast
-	disruptionCronWebhookRecorder.AnnotatedEventf(d, d.Annotations, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
+	disruptionCronWebhookRecorder.AnnotatedEventf(d, d.GetAnnotations(), Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
 
 	return nil, nil
 }

--- a/api/v1beta1/disruption_cron_webhook.go
+++ b/api/v1beta1/disruption_cron_webhook.go
@@ -67,7 +67,7 @@ func (d *DisruptionCron) ValidateCreate() (admission.Warnings, error) {
 	}
 
 	// send informative event to disruption cron to broadcast
-	disruptionCronWebhookRecorder.Event(d, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
+	disruptionCronWebhookRecorder.AnnotatedEventf(d, d.Annotations, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
 
 	return nil, nil
 }

--- a/api/v1beta1/disruption_cron_webhook_test.go
+++ b/api/v1beta1/disruption_cron_webhook_test.go
@@ -52,7 +52,7 @@ var _ = Describe("DisruptionCron Webhook", func() {
 
 					By("sending the EventDisruptionCronCreated event to the broadcast")
 					mockEventRecorder := mocks.NewEventRecorderMock(GinkgoT())
-					mockEventRecorder.EXPECT().Event(disruptionCron, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
+					mockEventRecorder.EXPECT().AnnotatedEventf(disruptionCron, map[string]string{}, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
 					disruptionCronWebhookRecorder = mockEventRecorder
 
 					// Act
@@ -84,7 +84,7 @@ var _ = Describe("DisruptionCron Webhook", func() {
 
 						By("sending the EventDisruptionCronCreated event to the broadcast")
 						mockEventRecorder := mocks.NewEventRecorderMock(GinkgoT())
-						mockEventRecorder.EXPECT().Event(disruptionCron, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
+						mockEventRecorder.EXPECT().AnnotatedEventf(disruptionCron, map[string]string{}, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
 						disruptionCronWebhookRecorder = mockEventRecorder
 
 						// Act
@@ -108,7 +108,7 @@ var _ = Describe("DisruptionCron Webhook", func() {
 
 					By("not emit an event to the broadcast")
 					mockEventRecorder := mocks.NewEventRecorderMock(GinkgoT())
-					mockEventRecorder.AssertNotCalled(GinkgoT(), "Event", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+					mockEventRecorder.AssertNotCalled(GinkgoT(), "AnnotatedEventf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 					disruptionCronWebhookRecorder = mockEventRecorder
 
 					// Act
@@ -135,7 +135,7 @@ var _ = Describe("DisruptionCron Webhook", func() {
 
 						By("not emit an event to the broadcast")
 						mockEventRecorder := mocks.NewEventRecorderMock(GinkgoT())
-						mockEventRecorder.AssertNotCalled(GinkgoT(), "Event", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+						mockEventRecorder.AssertNotCalled(GinkgoT(), "AnnotatedEventf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 						disruptionCronWebhookRecorder = mockEventRecorder
 
 						// Act
@@ -159,7 +159,7 @@ var _ = Describe("DisruptionCron Webhook", func() {
 
 						By("not emit an event to the broadcast")
 						mockEventRecorder := mocks.NewEventRecorderMock(GinkgoT())
-						mockEventRecorder.AssertNotCalled(GinkgoT(), "Event", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+						mockEventRecorder.AssertNotCalled(GinkgoT(), "AnnotatedEventf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 						disruptionCronWebhookRecorder = mockEventRecorder
 
 						// Act

--- a/api/v1beta1/disruption_cron_webhook_test.go
+++ b/api/v1beta1/disruption_cron_webhook_test.go
@@ -52,7 +52,7 @@ var _ = Describe("DisruptionCron Webhook", func() {
 
 					By("sending the EventDisruptionCronCreated event to the broadcast")
 					mockEventRecorder := mocks.NewEventRecorderMock(GinkgoT())
-					mockEventRecorder.EXPECT().AnnotatedEventf(disruptionCron, nil, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
+					mockEventRecorder.EXPECT().AnnotatedEventf(disruptionCron, mock.Anything, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
 					disruptionCronWebhookRecorder = mockEventRecorder
 
 					// Act
@@ -84,7 +84,7 @@ var _ = Describe("DisruptionCron Webhook", func() {
 
 						By("sending the EventDisruptionCronCreated event to the broadcast")
 						mockEventRecorder := mocks.NewEventRecorderMock(GinkgoT())
-						mockEventRecorder.EXPECT().AnnotatedEventf(disruptionCron, nil, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
+						mockEventRecorder.EXPECT().AnnotatedEventf(disruptionCron, mock.Anything, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
 						disruptionCronWebhookRecorder = mockEventRecorder
 
 						// Act

--- a/api/v1beta1/disruption_cron_webhook_test.go
+++ b/api/v1beta1/disruption_cron_webhook_test.go
@@ -52,7 +52,7 @@ var _ = Describe("DisruptionCron Webhook", func() {
 
 					By("sending the EventDisruptionCronCreated event to the broadcast")
 					mockEventRecorder := mocks.NewEventRecorderMock(GinkgoT())
-					mockEventRecorder.EXPECT().AnnotatedEventf(disruptionCron, map[string]string{}, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
+					mockEventRecorder.EXPECT().AnnotatedEventf(disruptionCron, nil, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
 					disruptionCronWebhookRecorder = mockEventRecorder
 
 					// Act
@@ -84,7 +84,7 @@ var _ = Describe("DisruptionCron Webhook", func() {
 
 						By("sending the EventDisruptionCronCreated event to the broadcast")
 						mockEventRecorder := mocks.NewEventRecorderMock(GinkgoT())
-						mockEventRecorder.EXPECT().AnnotatedEventf(disruptionCron, map[string]string{}, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
+						mockEventRecorder.EXPECT().AnnotatedEventf(disruptionCron, nil, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
 						disruptionCronWebhookRecorder = mockEventRecorder
 
 						// Act

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -250,7 +250,7 @@ func (r *Disruption) ValidateCreate() (admission.Warnings, error) {
 	}
 
 	// send informative event to disruption to broadcast
-	recorder.Event(r, Events[EventDisruptionCreated].Type, string(EventDisruptionCreated), Events[EventDisruptionCreated].OnDisruptionTemplateMessage)
+	recorder.AnnotatedEventf(r, r.Annotations, Events[EventDisruptionCreated].Type, string(EventDisruptionCreated), Events[EventDisruptionCreated].OnDisruptionTemplateMessage)
 
 	return nil, nil
 }

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -250,7 +250,7 @@ func (r *Disruption) ValidateCreate() (admission.Warnings, error) {
 	}
 
 	// send informative event to disruption to broadcast
-	recorder.AnnotatedEventf(r, r.Annotations, Events[EventDisruptionCreated].Type, string(EventDisruptionCreated), Events[EventDisruptionCreated].OnDisruptionTemplateMessage)
+	recorder.AnnotatedEventf(r, r.GetAnnotations(), Events[EventDisruptionCreated].Type, string(EventDisruptionCreated), Events[EventDisruptionCreated].OnDisruptionTemplateMessage)
 
 	return nil, nil
 }

--- a/eventbroadcaster/notifiersink.go
+++ b/eventbroadcaster/notifiersink.go
@@ -46,7 +46,7 @@ func (s *NotifierSink) Create(event *corev1.Event) (*corev1.Event, error) {
 
 	obj, err := s.getObject(event)
 	if err != nil {
-		s.logger.Warn(err)
+		s.logger.Debug(err) // Involved object is a target Pod or Node, we don't send notifications for these.
 
 		return event, nil
 	}

--- a/eventnotifier/slack/slack.go
+++ b/eventnotifier/slack/slack.go
@@ -241,7 +241,7 @@ func (n *Notifier) buildSlackMessage(obj client.Object, event corev1.Event, noti
 	}
 
 	if err != nil {
-		logger.Errorw("unable to retrieve user info", "error", err)
+		logger.Warnw("unable to retrieve user info", "error", err)
 	}
 
 	return slackMessage{


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- We're no longer warning on every event that comes from the controller's `recordEventOnTarget`
- We're no longer logging an error when the user info is missing in a slack notification, as that happens once for every disruption
- Includes the resource annotations in the Create event sent by the validation webhooks. This makes sure the UserInfo is available in the notifier

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
