### PR TITLE
DisruptionCrons should validate their DisruptionTemplates

### DIFF
--- a/api/v1beta1/disruption_cron_webhook.go
+++ b/api/v1beta1/disruption_cron_webhook.go
@@ -66,6 +66,10 @@ func (d *DisruptionCron) ValidateCreate() (admission.Warnings, error) {
 		return nil, err
 	}
 
+	if err := d.Spec.DisruptionTemplate.ValidateSelectorsOptional(false); err != nil {
+		return nil, err
+	}
+
 	// send informative event to disruption cron to broadcast
 	disruptionCronWebhookRecorder.Event(d, Events[EventDisruptionCronCreated].Type, string(EventDisruptionCronCreated), Events[EventDisruptionCronCreated].OnDisruptionTemplateMessage)
 

--- a/api/v1beta1/disruption_cron_webhook.go
+++ b/api/v1beta1/disruption_cron_webhook.go
@@ -7,6 +7,7 @@ package v1beta1
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/DataDog/chaos-controller/utils"
@@ -67,7 +68,7 @@ func (d *DisruptionCron) ValidateCreate() (admission.Warnings, error) {
 	}
 
 	if err := d.Spec.DisruptionTemplate.ValidateSelectorsOptional(false); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error while validating the spec.disruptionTemplate: %w", err)
 	}
 
 	// send informative event to disruption cron to broadcast

--- a/api/v1beta1/disruption_cron_webhook.go
+++ b/api/v1beta1/disruption_cron_webhook.go
@@ -76,12 +76,16 @@ func (d *DisruptionCron) ValidateCreate() (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (d *DisruptionCron) ValidateUpdate(oldObject runtime.Object) (warnings admission.Warnings, err error) {
+func (d *DisruptionCron) ValidateUpdate(oldObject runtime.Object) (admission.Warnings, error) {
 	log := logger.With("disruptionCronName", d.Name, "disruptionCronNamespace", d.Namespace)
 
 	log.Infow("validating updated disruption cron", "spec", d.Spec)
 
 	if err := validateUserInfoImmutable(oldObject.(*DisruptionCron), d); err != nil {
+		return nil, err
+	}
+
+	if err := d.Spec.DisruptionTemplate.ValidateSelectorsOptional(false); err != nil {
 		return nil, err
 	}
 

--- a/api/v1beta1/disruption_cron_webhook_test.go
+++ b/api/v1beta1/disruption_cron_webhook_test.go
@@ -366,9 +366,11 @@ var _ = Describe("DisruptionCron Webhook", func() {
 })
 
 func makeValidDisruptionCron() *DisruptionCron {
+	validDisruption := makeValidNetworkDisruption()
 	return &DisruptionCron{
 		TypeMeta: metav1.TypeMeta{
 			Kind: DisruptionCronKind,
 		},
+		Spec: DisruptionCronSpec{DisruptionTemplate: validDisruption.Spec},
 	}
 }

--- a/api/v1beta1/disruption_cron_webhook_test.go
+++ b/api/v1beta1/disruption_cron_webhook_test.go
@@ -122,6 +122,8 @@ var _ = Describe("DisruptionCron Webhook", func() {
 
 			When("disruptionTemplate is invalid", func() {
 				When("the count is invalid", func() {
+				// Other forms of invalid disruptions are covered by the disruption_webook_test.go
+				// we just want to confirm we do validate the disruptionTemplate as part of the disruption cron webhook
 					It("should return an error", func() {
 						disruptionCron := makeValidDisruptionCron()
 						disruptionCron.Spec.DisruptionTemplate.Count = &intstr.IntOrString{

--- a/api/v1beta1/disruption_cron_webhook_test.go
+++ b/api/v1beta1/disruption_cron_webhook_test.go
@@ -46,9 +46,7 @@ var _ = Describe("DisruptionCron Webhook", func() {
 			When("the controller is not in delete-only mode", func() {
 				It("should send an EventDisruptionCronCreated event to the broadcast", func() {
 					// Arrange
-					disruptionCron := &DisruptionCron{
-						Spec: DisruptionCronSpec{},
-					}
+					disruptionCron := makeValidDisruptionCron()
 
 					By("sending the EventDisruptionCronCreated event to the broadcast")
 					mockEventRecorder := mocks.NewEventRecorderMock(GinkgoT())

--- a/api/v1beta1/disruption_cron_webhook_test.go
+++ b/api/v1beta1/disruption_cron_webhook_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap/zaptest"
 	authV1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -116,6 +117,23 @@ var _ = Describe("DisruptionCron Webhook", func() {
 					Expect(warnings).To(BeNil())
 					Expect(err).Should(HaveOccurred())
 					Expect(err).To(MatchError("the controller is currently in delete-only mode, you can't create new disruption cron for now"))
+				})
+			})
+
+			When("disruptionTemplate is invalid", func() {
+				When("the count is invalid", func() {
+					It("should return an error", func() {
+						disruptionCron := makeValidDisruptionCron()
+						disruptionCron.Spec.DisruptionTemplate.Count = &intstr.IntOrString{
+							StrVal: "2hr",
+						}
+
+						warnings, err := disruptionCron.ValidateCreate()
+
+						Expect(warnings).To(BeNil())
+						Expect(err).Should(HaveOccurred())
+						Expect(err).To(MatchError(ContainSubstring("error while validating the spec.disruptionTemplate")))
+					})
 				})
 			})
 

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -502,7 +502,7 @@ func (s DisruptionSpec) Validate() (retErr error) {
 
 // ValidateSelectorsOptional applies rules for disruption global scope and all subsequent disruption specifications
 func (s DisruptionSpec) ValidateSelectorsOptional(requireSelectors bool) (retErr error) {
-	if err := s.validateGlobalDisruptionScopeSelectorsOptional(requireSelectors); err != nil {
+	if err := s.validateGlobalDisruptionScope(requireSelectors); err != nil {
 		retErr = multierror.Append(retErr, err)
 	}
 
@@ -555,14 +555,8 @@ func AdvancedSelectorsToRequirements(advancedSelectors []metav1.LabelSelectorReq
 	return reqs, nil
 }
 
-// validateGlobalDisruptionScopeSelectorsOptional applies rules for disruption global scope and requires the spec have selectors
-// exists for backwards compatibility
-func (s DisruptionSpec) validateGlobalDisruptionScope() (retErr error) {
-	return s.validateGlobalDisruptionScopeSelectorsOptional(true)
-}
-
-// validateGlobalDisruptionScopeSelectorsOptional applies rules for disruption global scope, leaving selectors optional
-func (s DisruptionSpec) validateGlobalDisruptionScopeSelectorsOptional(requireSelectors bool) (retErr error) {
+// validateGlobalDisruptionScope applies rules for disruption global scope, leaving selectors optional
+func (s DisruptionSpec) validateGlobalDisruptionScope(requireSelectors bool) (retErr error) {
 	if requireSelectors {
 		// Rule: at least one kind of selector is set
 		if s.Selector.AsSelector().Empty() && len(s.AdvancedSelector) == 0 {

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -493,9 +493,16 @@ func (s DisruptionSpec) HashNoCount() (string, error) {
 	return s.Hash()
 }
 
-// Validate applies rules for disruption global scope and all subsequent disruption specifications
+// Validate applies rules for disruption global scope and all subsequent disruption specifications, requiring selectors
+// intended to be called when DisruptionSpec belongs directly to a Disruption
+// also exists for backwards compatibility
 func (s DisruptionSpec) Validate() (retErr error) {
-	if err := s.validateGlobalDisruptionScope(); err != nil {
+	return s.ValidateSelectorsOptional(true)
+}
+
+// ValidateSelectorsOptional applies rules for disruption global scope and all subsequent disruption specifications
+func (s DisruptionSpec) ValidateSelectorsOptional(requireSelectors bool) (retErr error) {
+	if err := s.validateGlobalDisruptionScopeSelectorsOptional(requireSelectors); err != nil {
 		retErr = multierror.Append(retErr, err)
 	}
 
@@ -548,25 +555,33 @@ func AdvancedSelectorsToRequirements(advancedSelectors []metav1.LabelSelectorReq
 	return reqs, nil
 }
 
-// Validate applies rules for disruption global scope
+// validateGlobalDisruptionScopeSelectorsOptional applies rules for disruption global scope and requires the spec have selectors
+// exists for backwards compatibility
 func (s DisruptionSpec) validateGlobalDisruptionScope() (retErr error) {
-	// Rule: at least one kind of selector is set
-	if s.Selector.AsSelector().Empty() && len(s.AdvancedSelector) == 0 {
-		retErr = multierror.Append(retErr, errors.New("either selector or advancedSelector field must be set"))
-	}
+	return s.validateGlobalDisruptionScopeSelectorsOptional(true)
+}
 
-	// Rule: selectors must be valid
-	if !s.Selector.AsSelector().Empty() {
-		_, err := labels.ParseToRequirements(s.Selector.AsSelector().String())
-		if err != nil {
-			retErr = multierror.Append(retErr, err)
+// validateGlobalDisruptionScopeSelectorsOptional applies rules for disruption global scope, leaving selectors optional
+func (s DisruptionSpec) validateGlobalDisruptionScopeSelectorsOptional(requireSelectors bool) (retErr error) {
+	if requireSelectors {
+		// Rule: at least one kind of selector is set
+		if s.Selector.AsSelector().Empty() && len(s.AdvancedSelector) == 0 {
+			retErr = multierror.Append(retErr, errors.New("either selector or advancedSelector field must be set"))
 		}
-	}
 
-	if len(s.AdvancedSelector) > 0 {
-		_, err := AdvancedSelectorsToRequirements(s.AdvancedSelector)
-		if err != nil {
-			retErr = multierror.Append(retErr, err)
+		// Rule: selectors must be valid
+		if !s.Selector.AsSelector().Empty() {
+			_, err := labels.ParseToRequirements(s.Selector.AsSelector().String())
+			if err != nil {
+				retErr = multierror.Append(retErr, err)
+			}
+		}
+
+		if len(s.AdvancedSelector) > 0 {
+			_, err := AdvancedSelectorsToRequirements(s.AdvancedSelector)
+			if err != nil {
+				retErr = multierror.Append(retErr, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Before I update all the unit tests, do we like this approach? DisruptionTemplates won't have any selectors, so I can't call the original Validate functions. But I obviously want to re-use the code, so I've added an optional requireSelectors argument

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
