### PR TITLE
Fix warning log in slack event notifier

### DIFF
--- a/eventnotifier/slack/slack.go
+++ b/eventnotifier/slack/slack.go
@@ -143,7 +143,7 @@ func (n *Notifier) notifyForDisruption(dis *v1beta1.Disruption, event corev1.Eve
 		return nil
 	}
 
-	if err := n.sendMessageToUserChannel(dis, slackMsg, logger); err != nil {
+	if err := n.sendMessageToUserChannel(slackMsg, logger); err != nil {
 		return fmt.Errorf("slack notifier: %w", err)
 	}
 
@@ -169,7 +169,7 @@ func (n *Notifier) notifyForDisruptionCron(disruptionCron *v1beta1.DisruptionCro
 		}
 	}
 
-	if err := n.sendMessageToUserChannel(disruptionCron, slackMsg, logger); err != nil {
+	if err := n.sendMessageToUserChannel(slackMsg, logger); err != nil {
 		return fmt.Errorf("slack notifier: %w", err)
 	}
 
@@ -178,12 +178,10 @@ func (n *Notifier) notifyForDisruptionCron(disruptionCron *v1beta1.DisruptionCro
 	return nil
 }
 
-func (n *Notifier) sendMessageToUserChannel(obj client.Object, slackMsg slackMessage, logger *zap.SugaredLogger) error {
-	objKind := obj.GetObjectKind().GroupVersionKind().Kind
-
+func (n *Notifier) sendMessageToUserChannel(slackMsg slackMessage, logger *zap.SugaredLogger) error {
 	emailAddr, err := mail.ParseAddress(slackMsg.UserInfo.Username)
 	if err != nil {
-		logger.Warnf("invalid user info email in %s %s: %s", objKind, obj.GetName(), err.Error())
+		logger.Warnw("username could not be parsed as an email address", "err", err, "username", slackMsg.UserInfo.Username)
 
 		return nil
 	}

--- a/eventnotifier/slack/slack.go
+++ b/eventnotifier/slack/slack.go
@@ -183,7 +183,7 @@ func (n *Notifier) sendMessageToUserChannel(obj client.Object, slackMsg slackMes
 
 	emailAddr, err := mail.ParseAddress(slackMsg.UserInfo.Username)
 	if err != nil {
-		logger.Warnw("invalid user info email in %s %s: %w", objKind, obj.GetName(), err)
+		logger.Warnf("invalid user info email in %s %s: %s", objKind, obj.GetName(), err.Error())
 
 		return nil
 	}

--- a/eventnotifier/slack/slack.go
+++ b/eventnotifier/slack/slack.go
@@ -181,7 +181,7 @@ func (n *Notifier) notifyForDisruptionCron(disruptionCron *v1beta1.DisruptionCro
 func (n *Notifier) sendMessageToUserChannel(slackMsg slackMessage, logger *zap.SugaredLogger) error {
 	emailAddr, err := mail.ParseAddress(slackMsg.UserInfo.Username)
 	if err != nil {
-		logger.Warnw("username could not be parsed as an email address", "err", err, "username", slackMsg.UserInfo.Username)
+		logger.Infow("username could not be parsed as an email address", "err", err, "username", slackMsg.UserInfo.Username)
 
 		return nil
 	}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Previously the line `logger.Warnw("invalid user info email in %s %s: %w", objKind, obj.GetName(), err)` was using formatting directives, but they weren't being used. Seems that `Warnw` was used instead of `Warnf`. Given that username's aren't necessarily emails, I don't think calling it an invalid email is technically accurate. So I've changed the log message. wdyt? If you don't like the change, I could just keep the first commit?
- Would we be alright with changing this warning to an Info? It's either totally expect (if the username is a serviceaccount) or an error (if it's a human).

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
