### PR TITLE
Fix bug of registering all notifier sinks twice

### DIFF
--- a/main.go
+++ b/main.go
@@ -356,8 +356,6 @@ func main() {
 	}
 
 	if cfg.Controller.DisruptionCronEnabled {
-		eventbroadcaster.RegisterNotifierSinks(mgr, broadcaster, notifiers, logger)
-
 		disruptionCronRecorder := broadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: chaosv1beta1.SourceDisruptionCronComponent})
 
 		// create disruption cron reconciler


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- We were registering notifier sinks twice, using all the same arguments, which led to us double-sending every event. We don't need to call this twice to have a recorder for Disruptions and a separate recorder for DisruptionCrons

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
