### PR TITLE
Reduce severity of http warning log for non-email usernames

### DIFF
--- a/eventnotifier/http/http.go
+++ b/eventnotifier/http/http.go
@@ -214,7 +214,7 @@ func (n *Notifier) getUserDetails(uInfo authv1.UserInfo, logger *zap.SugaredLogg
 	emailAddr, err := n.extractEmail(username)
 
 	if err != nil {
-		logger.Warnw("http notifier: user info username is not a valid email address", "error", err, "username", username)
+		logger.Infow("http notifier: user info username is not a valid email address", "error", err, "username", username)
 	}
 
 	userGroups, err = n.marshalUserGroups(uInfo.Groups)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- We already made this change for the slack notifier. It's expected that many usernames might not be email addresses

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
