### PR TITLE
feat: make the controller and injector log levels configurable

### DIFF
--- a/builderstest/chaospod.go
+++ b/builderstest/chaospod.go
@@ -176,7 +176,7 @@ func (b *ChaosPodBuilder) WithPullSecrets(imagePullSecrets []v1.LocalObjectRefer
 }
 
 // WithChaosSpec sets the chaos-specific pod spec.
-func (b *ChaosPodBuilder) WithChaosSpec(targetNodeName string, terminationGracePeriod, activeDeadlineSeconds int64, args []string, hostPathDirectory, pathFile v1.HostPathType, serviceAccountName string, image string) *ChaosPodBuilder {
+func (b *ChaosPodBuilder) WithChaosSpec(targetNodeName string, terminationGracePeriod, activeDeadlineSeconds int64, args []string, hostPathDirectory, pathFile v1.HostPathType, serviceAccountName string, image string, logLevel string) *ChaosPodBuilder {
 	b.modifiers = append(
 		b.modifiers,
 		func() {
@@ -259,6 +259,10 @@ func (b *ChaosPodBuilder) WithChaosSpec(targetNodeName string, terminationGraceP
 							{
 								Name:  env.InjectorMountCgroup,
 								Value: "/mnt/cgroup/",
+							},
+							{
+								Name:  env.InjectorLogLevel,
+								Value: logLevel,
 							},
 						},
 						VolumeMounts: []v1.VolumeMount{ // define volume mounts required for disruptions to work

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -108,6 +108,9 @@ data:
             {{- end }}
         {{- end }}
       {{- end }}
+      {{- if .Values.injector.logLevel }}
+      logLevel: {{ .Values.injector.logLevel }}
+      {{- end }}
       serviceAccount: {{ .Values.injector.serviceAccount | quote }}
       chaosNamespace: {{ .Values.chaosNamespace | quote }}
       dnsDisruption:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -90,6 +90,10 @@ spec:
               value: /tmp/go
             - name: GOCACHE
               value: /tmp/go-build
+            {{- if .Values.controller.logLevel }}
+            - name: LOG_LEVEL
+              value: {{ .Values.controller.logLevel }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.controller.webhook.port }}
               name: webhook-server

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -80,6 +80,7 @@ controller:
     clusterThreshold: 66
     allowNodeFailure: true # if set to false, will prevent the creation of any disruption that applies a nodeFailure, but only if safeMode.enable is true
     allowNodeLevel: true # if set to false, will prevent the creation of any disruption at the node level, but only if safeMode.enable is true
+  logLevel: DEBUG # sets the log level for the chaos controller
   resources: # resources assigned to the controller pod. may need to be increased when deploying to larger scale clusters
     cpu: 100m
     memory: 300Mi
@@ -106,6 +107,7 @@ injector:
     #     value: "value1"
     #     effect: "NoExecute"
   serviceAccount: chaos-injector # service account to use for the chaos injector pods
+  logLevel: DEBUG # sets the log level for the chaos injector pods
   dnsDisruption: # dns disruption configuration
     dnsServer: "" # IP address of the upstream dns server
     kubeDns:

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,7 @@ type injectorConfig struct {
 	NetworkDisruption injectorNetworkDisruptionConfig `json:"networkDisruption"`
 	ImagePullSecrets  string                          `json:"imagePullSecrets"`
 	Tolerations       []Toleration                    `json:"tolerations"`
+	LogLevel          string                          `json:"logLevel"`
 }
 
 type Toleration struct {
@@ -288,6 +289,12 @@ func New(logger *zap.SugaredLogger, osArgs []string) (config, error) {
 	mainFS.StringVar(&cfg.Injector.ImagePullSecrets, "image-pull-secrets", "", "Secrets used for pulling the Docker image from a private registry")
 
 	if err := viper.BindPFlag("controller.imagePullSecrets", mainFS.Lookup("image-pull-secrets")); err != nil {
+		return cfg, err
+	}
+
+	mainFS.StringVar(&cfg.Injector.LogLevel, "injector-log-level", "DEBUG", "The LOG_LEVEL used for the injector pods")
+
+	if err := viper.BindPFlag("injector.logLevel", mainFS.Lookup("injector-log-level")); err != nil {
 		return cfg, err
 	}
 

--- a/env/env.go
+++ b/env/env.go
@@ -15,4 +15,5 @@ const (
 	InjectorTargetPodHostIP   = "TARGET_POD_HOST_IP"
 	InjectorChaosPodIP        = "CHAOS_POD_IP"
 	InjectorPodName           = "INJECTOR_POD_NAME"
+	InjectorLogLevel          = "LOG_LEVEL"
 )

--- a/log/log.go
+++ b/log/log.go
@@ -6,6 +6,8 @@
 package log
 
 import (
+	"os"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -17,6 +19,17 @@ func NewZapLogger() (*zap.SugaredLogger, error) {
 	loggerConfig.Level.SetLevel(zapcore.DebugLevel)
 	loggerConfig.EncoderConfig.MessageKey = "message"
 	loggerConfig.EncoderConfig.EncodeTime = zapcore.EpochMillisTimeEncoder
+
+	// optionally override the log level from the default based on the LOG_LEVEL env var
+	lvl, exists := os.LookupEnv("LOG_LEVEL")
+	if exists {
+		// parse string, this is built-in feature of zap
+		ll, err := zapcore.ParseLevel(lvl)
+		// if the log level can be parsed, set the logger to this level
+		if err == nil {
+			loggerConfig.Level.SetLevel(ll)
+		}
+	}
 
 	// generate logger
 	logger, err := loggerConfig.Build()

--- a/log/log_suite_test.go
+++ b/log/log_suite_test.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package log_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Log Suite")
+}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package log_test
+
+import (
+	"os"
+
+	. "github.com/DataDog/chaos-controller/log"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
+)
+
+var _ = Describe("Zap Logger", func() {
+	Describe("NewZapLogger", func() {
+		Context("with the LOG_LEVEL env var unset", func() {
+			It("should use the default (DEBUG) log level", func() {
+				// Arrange
+				os.Unsetenv("LOG_LEVEL")
+				logger, err := NewZapLogger()
+
+				// Assert
+				By("not return an error")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("use the default DEBUG log level")
+				Expect(logger.Level()).Should(Equal(zapcore.DebugLevel))
+			})
+		})
+
+		Context("with the LOG_LEVEL env var set to DEBUG", func() {
+			It("should use the DEBUG log level", func() {
+				// Arrange
+				os.Setenv("LOG_LEVEL", "DEBUG")
+				logger, err := NewZapLogger()
+
+				// Assert
+				By("not return an error")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("use the DEBUG log level")
+				Expect(logger.Level()).Should(Equal(zapcore.DebugLevel))
+			})
+		})
+
+		Context("with the LOG_LEVEL env var set to INFO", func() {
+			It("should use the INFO log level", func() {
+				// Arrange
+				os.Setenv("LOG_LEVEL", "INFO")
+				logger, err := NewZapLogger()
+
+				// Assert
+				By("not return an error")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("use the INFO log level")
+				Expect(logger.Level()).Should(Equal(zapcore.InfoLevel))
+			})
+		})
+
+		Context("with the LOG_LEVEL env var set to ERROR", func() {
+			It("should use the ERROR log level", func() {
+				// Arrange
+				os.Setenv("LOG_LEVEL", "ERROR")
+				logger, err := NewZapLogger()
+
+				// Assert
+				By("not return an error")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("use the ERROR log level")
+				Expect(logger.Level()).Should(Equal(zapcore.ErrorLevel))
+			})
+		})
+
+		Context("with the LOG_LEVEL env var set to warn (lowercase)", func() {
+			It("should use the ERROR log level", func() {
+				// Arrange
+				os.Setenv("LOG_LEVEL", "warn")
+				logger, err := NewZapLogger()
+
+				// Assert
+				By("not return an error")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("use the WARN log level")
+				Expect(logger.Level()).Should(Equal(zapcore.WarnLevel))
+			})
+		})
+
+		Context("with the LOG_LEVEL env var set to an invalid log level", func() {
+			It("should use the default (DEBUG) log level", func() {
+				// Arrange
+				os.Setenv("LOG_LEVEL", "Invalid")
+				logger, err := NewZapLogger()
+
+				// Assert
+				By("not return an error")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("use the default DEBUG log level")
+				Expect(logger.Level()).Should(Equal(zapcore.DebugLevel))
+			})
+		})
+
+		Context("with the LOG_LEVEL env var set to an empty string", func() {
+			It("should use the INFO log level", func() {
+				// Arrange
+				os.Setenv("LOG_LEVEL", "")
+				logger, err := NewZapLogger()
+
+				// Assert
+				By("not return an error")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("use the INFO log level")
+				Expect(logger.Level()).Should(Equal(zapcore.InfoLevel))
+			})
+		})
+
+	})
+
+})

--- a/main.go
+++ b/main.go
@@ -189,6 +189,7 @@ func main() {
 			DNSDisruptionDNSServer:        cfg.Injector.DNSDisruption.DNSServer,
 			DNSDisruptionKubeDNS:          cfg.Injector.DNSDisruption.KubeDNS,
 			ImagePullSecrets:              cfg.Injector.ImagePullSecrets,
+			LogLevel:                      cfg.Injector.LogLevel,
 		},
 		ImagePullSecrets: cfg.Injector.ImagePullSecrets,
 		MetricsSink:      metricsSink,

--- a/services/chaospod.go
+++ b/services/chaospod.go
@@ -72,6 +72,7 @@ type ChaosPodServiceInjectorConfig struct {
 	DNSDisruptionKubeDNS          string              // KubeDNS server to be used for DNS disruption.
 	ImagePullSecrets              string              // Image pull secrets for the injector.
 	Tolerations                   []config.Toleration // Tolerations to be applied to injected pods.
+	LogLevel                      string
 }
 
 // ChaosPodServiceConfig contains configuration options for the chaosPodService.
@@ -516,6 +517,10 @@ func (m *chaosPodService) generateChaosPodSpec(targetNodeName string, terminatio
 					{
 						Name:  env.InjectorMountCgroup,
 						Value: "/mnt/cgroup/",
+					},
+					{
+						Name:  env.InjectorLogLevel,
+						Value: m.config.Injector.LogLevel,
 					},
 				},
 				VolumeMounts: []corev1.VolumeMount{ // define volume mounts required for disruptions to work

--- a/services/chaospod_test.go
+++ b/services/chaospod_test.go
@@ -48,6 +48,7 @@ const (
 	DefaultInjectorImage                  = "image"
 	DefaultInjectorDNSDisruptionDNSServer = "8.8.8.8"
 	DefaultInjectorDNSDisruptionKubeDNS   = "9.9.9.9"
+	DefaultInjectorLogLevel               = "DEBUG"
 	DefaultMetricsSinkName                = "name"
 )
 
@@ -878,6 +879,7 @@ var _ = Describe("Chaos Pod Service", func() {
 				DefaultPathFile,
 				DefaultInjectorServiceAccount,
 				DefaultInjectorImage,
+				DefaultInjectorLogLevel,
 			).Build()
 
 			imagePullSecrets := ""
@@ -891,6 +893,7 @@ var _ = Describe("Chaos Pod Service", func() {
 				Annotations:      DefaultInjectorAnnotation,
 				Labels:           DefaultInjectorLabels,
 				ImagePullSecrets: imagePullSecrets,
+				LogLevel:         DefaultInjectorLogLevel,
 			}
 
 			chaosPodService, err := services.NewChaosPodService(chaosPodServiceConfig)
@@ -980,6 +983,7 @@ var _ = Describe("Chaos Pod Service", func() {
 							DefaultPathFile,
 							DefaultInjectorServiceAccount,
 							DefaultInjectorImage,
+							DefaultInjectorLogLevel,
 						).Build()
 					})
 


### PR DESCRIPTION
## What does this PR do?

- [x] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- `Allows the log level of the controller and injector to be configurable. Currently the log level is set to debug within the code and cannot be changed at runtime`

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [x] as a canary deployment to a cluster.
