### PR TITLE
CHAOSPLT-367: When in DeleteOnly mode, the chaos-controller should attempt to remove all disruptions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -132,7 +132,7 @@ func New(logger *zap.SugaredLogger, osArgs []string) (config, error) {
 	}
 
 	mainFS.BoolVar(&cfg.Controller.DeleteOnly, "delete-only", false,
-		"Enable delete only mode which will not allow new disruption to start and will only continue to clean up and remove existing disruptions.")
+		"Enable delete only mode which will not allow new disruption to start and will clean up and remove existing disruptions.")
 
 	if err := viper.BindPFlag("controller.deleteOnly", mainFS.Lookup("delete-only")); err != nil {
 		return cfg, err

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -241,10 +241,6 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 	} else {
-		if err := r.validateDisruptionSpec(instance); err != nil {
-			return ctrl.Result{Requeue: false}, err
-		}
-
 		// initialize all safety nets for future use
 		if instance.Spec.Unsafemode == nil || !instance.Spec.Unsafemode.DisableAll {
 			// initialize all relevant safety nets for the first time
@@ -906,17 +902,6 @@ func (r *DisruptionReconciler) emitKindCountMetrics(instance *chaosv1beta1.Disru
 	for _, kind := range instance.Spec.KindNames() {
 		r.handleMetricSinkError(r.MetricsSink.MetricDisruptionsCount(kind, []string{"disruptionName:" + instance.Name, "namespace:" + instance.Namespace}))
 	}
-}
-
-func (r *DisruptionReconciler) validateDisruptionSpec(instance *chaosv1beta1.Disruption) error {
-	err := instance.Spec.Validate()
-	if err != nil {
-		r.recordEventOnDisruption(instance, chaosv1beta1.EventInvalidSpecDisruption, err.Error(), "")
-
-		return err
-	}
-
-	return nil
 }
 
 // recordEventOnTarget records an event on the given target which can be either a pod or a node depending on the given disruption level

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -74,6 +74,7 @@ type DisruptionReconciler struct {
 	ChaosPodService            services.ChaosPodService
 	CloudService               cloudservice.CloudServicesProvidersManager
 	DisruptionsDeletionTimeout time.Duration
+	DeleteOnly                 bool
 }
 
 type CtxTuple struct {

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -242,6 +242,16 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 	} else {
+		if r.DeleteOnly {
+			r.log.Info("the chaos-controller is in deleteOnly mode, we're halting this disruption asap")
+
+			if err = r.Client.Delete(ctx, instance); err != nil {
+				r.log.Errorw("error deleting disruption while in deleteOnly", "error", err)
+			}
+
+			return ctrl.Result{Requeue: true}, nil
+		}
+
 		// initialize all safety nets for future use
 		if instance.Spec.Unsafemode == nil || !instance.Spec.Unsafemode.DisableAll {
 			// initialize all relevant safety nets for the first time

--- a/main.go
+++ b/main.go
@@ -213,6 +213,7 @@ func main() {
 		ChaosPodService:            chaosPodService,
 		CloudService:               cloudProviderManager,
 		DisruptionsDeletionTimeout: cfg.Controller.DisruptionDeletionTimeout,
+		DeleteOnly:                 cfg.Controller.DeleteOnly,
 	}
 
 	informerClient := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Sometimes we need an emergency procedure to remove all existing disruptions. It's not enough to simply refuse to start new ones. The DeleteOnly flag will now do both

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
