### PR TITLE
Fix: HTTP network filters

### DIFF
--- a/docs/network_disruption/prio.md
+++ b/docs/network_disruption/prio.md
@@ -47,11 +47,14 @@ spec:
   count: 1
   network:
     hosts:
-      - 10.0.1.26/32
-      - 10.0.1.25/32
-    port: 80
-    protocol: tcp
-    flow: egress
+      - host: 10.0.1.26/32
+        port: 80
+        protocol: tcp
+        flow: egress
+      - host: 10.0.1.25/32
+        port: 80
+        protocol: tcp
+        flow: egress
     delay: 1000
     delayJitter: 5
     bandwidthLimit: 5000
@@ -106,10 +109,10 @@ spec:
   count: 1
   network:
     hosts:
-      - 10.0.1.254/31
-    port: 80
-    protocol: tcp
-    flow: egress
+      - host: 10.0.1.254/32
+        port: 80
+        protocol: tcp
+        flow: egress
     delay: 1000
     delayJitter: 5
 ```
@@ -206,15 +209,15 @@ spec:
   count: 1
   network:
     hosts:
-      - 10.0.1.254/31
-    port: 80
-    protocol: tcp
+      - host: 10.0.1.254/32
+        port: 80
+        protocol: tcp
+        flow: egress
     http:
         methods:
-          - get <-- eBPF filter
+          - GET # <-- eBPF filter
         paths:
-          - /test <-- eBPF filter
-    flow: egress
+          - /test # <-- eBPF filter
     delay: 1000
     delayJitter: 5
 ```
@@ -246,15 +249,15 @@ spec:
   count: 1
   network:
     hosts:
-      - 10.0.1.254/31
-    port: 80
-    protocol: tcp
+      - host: 10.0.1.254/32
+        port: 80
+        protocol: tcp
+        flow: egress
     http:
       methods: 
-        - get <-- eBPF filter
+        - GET # <-- eBPF filter
       paths: 
-        - /test <-- eBPF filter
-    flow: egress
+        - /test # <-- eBPF filter
     delay: 1000
     delayJitter: 5
 ```

--- a/ebpf/network-tc-filter/injection.bpf.c
+++ b/ebpf/network-tc-filter/injection.bpf.c
@@ -54,13 +54,13 @@ static __always_inline bool  validate_path(char* path) {
 
         // Check if the prefix match the method.
         #pragma unroll
-        for (int ii = 0; ii < MAX_PATH_LEN; ++ii) {
+        for (int jj = 0; jj < MAX_PATH_LEN; ++jj) {
             // Break the loop if the prefix is completed
-            if (expected_path[ii] == '\0')
+            if (expected_path[jj] == '\0')
                 return true;
 
             // If the prefix does not match the str return false
-            if (expected_path[ii] != request_path[ii])
+            if (expected_path[jj] != request_path[jj])
                 break;
         }
      }
@@ -92,14 +92,14 @@ static __always_inline bool  validate_method(char* method) {
 
         // Check if the prefix match the method.
         #pragma unroll
-        for (int ii = 0; ii < MAX_METHOD_LEN; ++ii) {
+        for (int jj = 0; jj < MAX_METHOD_LEN; ++jj) {
             // Break the loop if the prefix is completed
-            if (expected_method[ii] == '\0')
+            if (expected_method[jj] == '\0')
                 return true;
 
 
             // If the prefix does not match the str return false
-            if (expected_method[ii] != method[ii])
+            if (expected_method[jj] != method[jj])
                 break;
         }
      }

--- a/ebpf/network-tc-filter/injection.bpf.c
+++ b/ebpf/network-tc-filter/injection.bpf.c
@@ -161,7 +161,7 @@ int cls_classifier_paths(struct __sk_buff *skb)
         p[i] = load_byte(skb, skb_info.data_off + i);
     }
 
-    char path[MAX_PATH_LEN] = {0};
+    char path[MAX_PATH_LEN] = "";
     int path_length = 0;
 
     // Extract the path from the response

--- a/ebpf/network-tc-filter/injection.bpf.c
+++ b/ebpf/network-tc-filter/injection.bpf.c
@@ -54,13 +54,13 @@ static __always_inline bool  validate_path(char* path) {
 
         // Check if the prefix match the method.
         #pragma unroll
-        for (int jj = 0; jj < MAX_PATH_LEN; ++jj) {
+        for (int j = 0; j < MAX_PATH_LEN; ++j) {
             // Break the loop if the prefix is completed
-            if (expected_path[jj] == '\0')
+            if (expected_path[j] == '\0')
                 return true;
 
             // If the prefix does not match the str return false
-            if (expected_path[jj] != request_path[jj])
+            if (expected_path[j] != request_path[j])
                 break;
         }
      }

--- a/ebpf/network-tc-filter/injection.bpf.c
+++ b/ebpf/network-tc-filter/injection.bpf.c
@@ -92,14 +92,14 @@ static __always_inline bool  validate_method(char* method) {
 
         // Check if the prefix match the method.
         #pragma unroll
-        for (int jj = 0; jj < MAX_METHOD_LEN; ++jj) {
+        for (int j = 0; j < MAX_METHOD_LEN; ++j) {
             // Break the loop if the prefix is completed
-            if (expected_method[jj] == '\0')
+            if (expected_method[j] == '\0')
                 return true;
 
 
             // If the prefix does not match the str return false
-            if (expected_method[jj] != method[jj])
+            if (expected_method[j] != method[j])
                 break;
         }
      }


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The http filters are not interpreted and disrupt all the requests. This fix updates the eBPF map correctly to ensure the custom paths and methods are taken into account.
- Update the documentation
- Improve performance by adding the directive `#pragma unroll` to instruct the compiler to unroll loops.  Loop unrolling is an optimization technique that can improve performance by reducing the overhead of loop control instruction-level  parallelism.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
