### PR TITLE
handleChaosPodTermination shouldnt log at Error on stale deletes

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -736,6 +736,7 @@ func (r *DisruptionReconciler) handleChaosPodTermination(ctx context.Context, in
 		} else {
 			r.log.Errorw("could not handle the chaos pod termination", "error", err, "chaosPod", chaosPod.Name)
 		}
+
 		return
 	}
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -731,8 +731,11 @@ func (r *DisruptionReconciler) handleChaosPodTermination(ctx context.Context, in
 
 	isStuckOnRemoval, err := r.ChaosPodService.HandleChaosPodTermination(ctx, instance, &chaosPod)
 	if err != nil {
-		r.log.Errorw("could not handle the chaos pod termination", "error", err, "chaosPod", chaosPod.Name)
-
+		if chaosv1beta1.IsUpdateConflictError(err) {
+			r.log.Infow("need to retry the chaos pod termination", "error", err, "chaosPod", chaosPod.Name)
+		} else {
+			r.log.Errorw("could not handle the chaos pod termination", "error", err, "chaosPod", chaosPod.Name)
+		}
 		return
 	}
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- We're logging at Error even when the returned error from the k8s api is to safely retry, e.g. `the object has been modified; please apply your changes to the latest version and try again`

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
