### PR TITLE
Use cgroup filter for network disruptions

### DIFF
--- a/network/tc.go
+++ b/network/tc.go
@@ -61,6 +61,7 @@ type TrafficController interface {
 	AddPrio(ifaces []string, parent string, handle string, bands uint32, priomap [16]uint32) error
 	AddFilter(ifaces []string, parent string, handle string, srcIP, dstIP *net.IPNet, srcPort, dstPort int, prot protocol, state connState, flowid string) (uint32, error)
 	DeleteFilter(iface string, priority uint32) error
+	AddCgroupFilter(ifaces []string, parent string, handle uint32) error
 	AddFwFilter(ifaces []string, parent string, handle string, flowid string) error
 	AddBPFFilter(ifaces []string, parent string, obj string, flowid string, section string) error
 	ConfigBPFFilter(cmd executor, args ...string) error
@@ -246,6 +247,16 @@ func (t *tc) AddBPFFilter(ifaces []string, parent string, obj string, flowid str
 func (t *tc) DeleteFilter(iface string, priority uint32) error {
 	if _, _, err := t.executer.Run([]string{"filter", "delete", "dev", iface, "priority", fmt.Sprintf("%d", priority)}); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (t *tc) AddCgroupFilter(ifaces []string, parent string, handle uint32) error {
+	for _, iface := range ifaces {
+		if _, _, err := t.executer.Run(buildCmd("filter", iface, parent, "", 0, fmt.Sprintf("%d", handle), "cgroup", "")); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/network/tc_test.go
+++ b/network/tc_test.go
@@ -212,6 +212,19 @@ var _ = Describe("Tc", func() {
 		})
 	})
 
+	Describe("AddCgroupFilter", func() {
+		JustBeforeEach(func() {
+			Expect(tcRunner.AddCgroupFilter(ifaces, parent, 12345)).Should(Succeed())
+		})
+
+		Context("add a cgroup filter", func() {
+			It("should execute", func() {
+				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"filter", "add", "dev", "lo", "root", "handle", "12345", "cgroup"})
+				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"filter", "add", "dev", "eth0", "root", "handle", "12345", "cgroup"})
+			})
+		})
+	})
+
 	Describe("AddFwFilter", func() {
 		JustBeforeEach(func() {
 			Expect(tcRunner.AddFwFilter(ifaces, parent, handle, flowid)).Should(Succeed())

--- a/network/traffic_controller_mock.go
+++ b/network/traffic_controller_mock.go
@@ -77,6 +77,54 @@ func (_c *TrafficControllerMock_AddBPFFilter_Call) RunAndReturn(run func([]strin
 	return _c
 }
 
+// AddCgroupFilter provides a mock function with given fields: ifaces, parent, handle
+func (_m *TrafficControllerMock) AddCgroupFilter(ifaces []string, parent string, handle uint32) error {
+	ret := _m.Called(ifaces, parent, handle)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddCgroupFilter")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]string, string, uint32) error); ok {
+		r0 = rf(ifaces, parent, handle)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// TrafficControllerMock_AddCgroupFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddCgroupFilter'
+type TrafficControllerMock_AddCgroupFilter_Call struct {
+	*mock.Call
+}
+
+// AddCgroupFilter is a helper method to define mock.On call
+//   - ifaces []string
+//   - parent string
+//   - handle uint32
+func (_e *TrafficControllerMock_Expecter) AddCgroupFilter(ifaces interface{}, parent interface{}, handle interface{}) *TrafficControllerMock_AddCgroupFilter_Call {
+	return &TrafficControllerMock_AddCgroupFilter_Call{Call: _e.mock.On("AddCgroupFilter", ifaces, parent, handle)}
+}
+
+func (_c *TrafficControllerMock_AddCgroupFilter_Call) Run(run func(ifaces []string, parent string, handle uint32)) *TrafficControllerMock_AddCgroupFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]string), args[1].(string), args[2].(uint32))
+	})
+	return _c
+}
+
+func (_c *TrafficControllerMock_AddCgroupFilter_Call) Return(_a0 error) *TrafficControllerMock_AddCgroupFilter_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *TrafficControllerMock_AddCgroupFilter_Call) RunAndReturn(run func([]string, string, uint32) error) *TrafficControllerMock_AddCgroupFilter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AddFilter provides a mock function with given fields: ifaces, parent, handle, srcIP, dstIP, srcPort, dstPort, prot, state, flowid
 func (_m *TrafficControllerMock) AddFilter(ifaces []string, parent string, handle string, srcIP *net.IPNet, dstIP *net.IPNet, srcPort int, dstPort int, prot protocol, state connState, flowid string) (uint32, error) {
 	ret := _m.Called(ifaces, parent, handle, srcIP, dstIP, srcPort, dstPort, prot, state, flowid)

--- a/types/types.go
+++ b/types/types.go
@@ -134,6 +134,9 @@ const (
 	// This value should NEVER be changed without changing the Network Disruption TC tree.
 	InjectorCgroupClassID = "0x00020002"
 
+	// This should be used specifically for eBPF disruptions
+	InjectorBPFCgroupClassID = "0x00040002"
+
 	// DDMarkChaoslibPrefix allows to consistently name the chaos-imported API in ddmark.
 	// It's arbitrary but needs to be consistent across multiple files.
 	DDMarkChaoslibPrefix = "chaos-api"


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- `x`

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
