### PR TITLE
Fix typo in configmap preventing multiple disabled disruptions

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -79,7 +79,7 @@ data:
       disruptionDeletionTimeout: {{ .Values.controller.disruptionDeletionTimeout }}
       disabledDisruptions:
       {{- range $index, $kind := .Values.controller.disabledDisruptions }}
-        {{ $kind }}
+        - {{ $kind }}
       {{- end }}
     injector:
       image: {{ template "chaos-controller.format-image" deepCopy .Values.global.chaos.defaultImage | merge .Values.global.oci | merge .Values.injector.image }}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Seems that we forgot the `-` character in the configmap under disabledDisruptions, which is needed for this field to be read as a yaml list. As a result, we can only read in a single disabledDisruption.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
