### PR TITLE
Make spec.count docs more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ metadata:
 spec:
   selector: # a label selector used to target resources
     app: demo-curl
-  count: 1 # the number of resources to target, can be a percentage
+  count: 1 # the number of resources to target, can be a percentage if you suffix with "%", e.g. `count: 50%`
   duration: 1h # the amount of time before your disruption automatically terminates itself, for safety
   nodeFailure: # trigger a kernel panic on the target node
     shutdown: false # do not force the node to be kept down

--- a/cli/chaosli/README.md
+++ b/cli/chaosli/README.md
@@ -50,7 +50,7 @@ This Disruption...
 	ℹ️  will be run on the Pod level, so everything in this disruption is scoped at this level.
 	ℹ️  has the following selectors which will be used to target pods
 		🎯  app=demo-curl
-	ℹ️  is going to target 1 pod(s) (either described as a percentage of total pods or actual number of them).
+	ℹ️  is going to target 1 pod(s) (described as a discrete number of pods).
 =======================================================================================================================================
 💉 injects a network disruption ...
 	💥 applies network failures on outgoing traffic.

--- a/cli/chaosli/cmd/explain.go
+++ b/cli/chaosli/cmd/explain.go
@@ -15,6 +15,7 @@ import (
 	grpccalc "github.com/DataDog/chaos-controller/grpc/calculations"
 	chaostypes "github.com/DataDog/chaos-controller/types"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func explainMetaSpec(spec v1beta1.DisruptionSpec) {
@@ -65,7 +66,13 @@ func explainMetaSpec(spec v1beta1.DisruptionSpec) {
 		fmt.Printf("\tℹ️  has the onInit mode activated meaning the disruptions will be launched at the initialization of the targeted pods.\n")
 	}
 
-	fmt.Printf("\tℹ️  is going to target %s %s(s) (either described as a percentage of total %ss or actual number of them).\n", spec.Count, spec.Level, spec.Level)
+	countSuffix := ""
+	if spec.Count.Type == intstr.Int {
+		countSuffix = fmt.Sprintf("(described as a discrete number of %ss)", spec.Level)
+	} else {
+		countSuffix = fmt.Sprintf("(described as a percentage of total %ss)", spec.Level)
+	}
+	fmt.Printf("\tℹ️  is going to target %s %s(s) (%s).\n", spec.Count, spec.Level, countSuffix)
 
 	if spec.StaticTargeting {
 		fmt.Printf("\tℹ️  has StaticTargeting activated, so new pods/nodes will be NOT be targeted \n")

--- a/cli/chaosli/cmd/explain.go
+++ b/cli/chaosli/cmd/explain.go
@@ -72,6 +72,7 @@ func explainMetaSpec(spec v1beta1.DisruptionSpec) {
 	} else {
 		countSuffix = fmt.Sprintf("(described as a percentage of total %ss)", spec.Level)
 	}
+
 	fmt.Printf("\tℹ️  is going to target %s %s(s) (%s).\n", spec.Count, spec.Level, countSuffix)
 
 	if spec.StaticTargeting {

--- a/docs/design.md
+++ b/docs/design.md
@@ -36,7 +36,7 @@ A hash of the disruption resource spec is computed and stored in the resource st
 
 #### Step 3: select targets
 
-A list of targets is created from the given selector and level. It first lists the targets (pods if the given level is `pod`, nodes if it is `node`) matching the given label selector. Then, it randomly selects a certain amount of targets in the list depending on the given count. If the count is a percentage, it rounds up the amount.
+A list of targets is created from the given selector and level. It first lists the targets (pods if the given level is `pod`, nodes if it is `node`) matching the given label selector. Then, it randomly selects a certain amount of targets in the list depending on the given count. If the count is a percentage, e.g. `count: 25%`, it rounds up the amount.
 
 Some targets can be ignored and removed from the list depending on if they were:
 * already targeted by the same disruption but the associated chaos pod was terminated

--- a/docs/disruption_cron.md
+++ b/docs/disruption_cron.md
@@ -23,7 +23,7 @@ spec:
     kind: deployment # a resource name to target
     name: demo-curl # can be either deployment or statefulset
   disruptionTemplate:
-    count: 1 # the number of resources to target, can be a percentage
+    count: 1 # the number of resources to target, can be a percentage if you suffix with "%", e.g. `count: 100%`
     duration: 1h # the amount of time before your disruption automatically terminates itself, for safety
     nodeFailure: # trigger a kernel panic on the target node
       shutdown: false # do not force the node to be kept down


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Updates `chaosli explain` and the docs to be more clear about how to specify a % count vs an integer count

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
