### PR TITLE
[CHAOSPLT-463] Set user info annotation on disruption creation from parent resource

### DIFF
--- a/api/disruption_types_test.go
+++ b/api/disruption_types_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/chaos-controller/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("DisruptionStatus.RemoveDeadTargets Test", func() {
@@ -289,130 +288,6 @@ var _ = Describe("DisruptionStatus.RemoveTargets Test", func() {
 		It("expects to remove all the targets", func() {
 			status.RemoveTargets(toRemoveTargetsCount)
 			Expect(status.TargetInjections).To(BeEmpty())
-		})
-	})
-})
-
-var _ = Describe("Disruption Annotations Tests", func() {
-	var disruption *v1beta1.Disruption
-	var owner metav1.Object
-
-	BeforeEach(func() {
-		disruption = &v1beta1.Disruption{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: make(map[string]string),
-			},
-		}
-		owner = &metav1.ObjectMeta{
-			Annotations: map[string]string{
-				"key1": "value1",
-				"key2": "value2",
-			},
-		}
-	})
-
-	Describe("CopyOwnerAnnotations", func() {
-		It("copies annotations from the owner to the disruption", func() {
-			disruption.CopyOwnerAnnotations(owner)
-			Expect(disruption.Annotations).To(HaveKeyWithValue("key1", "value1"))
-			Expect(disruption.Annotations).To(HaveKeyWithValue("key2", "value2"))
-		})
-
-		It("creates a new annotations map if it's nil", func() {
-			disruption.Annotations = nil
-			disruption.CopyOwnerAnnotations(owner)
-			Expect(disruption.Annotations).NotTo(BeNil())
-			Expect(disruption.Annotations).To(HaveKeyWithValue("key1", "value1"))
-		})
-	})
-
-	Describe("SetScheduledAtAnnotation", func() {
-		It("sets the scheduled time annotation", func() {
-			scheduledTime := time.Now()
-			disruption.SetScheduledAtAnnotation(scheduledTime)
-
-			Expect(disruption.Annotations).To(HaveKey(types.ScheduledAtAnnotation))
-
-			parsedTime, err := time.Parse(time.RFC3339, disruption.Annotations[types.ScheduledAtAnnotation])
-			Expect(err).NotTo(HaveOccurred())
-			Expect(parsedTime).To(BeTemporally("~", scheduledTime, time.Second))
-		})
-
-		It("creates a new annotations map if it's nil", func() {
-			disruption.Annotations = nil
-			scheduledTime := time.Now()
-			disruption.SetScheduledAtAnnotation(scheduledTime)
-
-			Expect(disruption.Annotations).NotTo(BeNil())
-			Expect(disruption.Annotations).To(HaveKey(types.ScheduledAtAnnotation))
-		})
-	})
-
-	Describe("GetScheduledAtAnnotation", func() {
-		Describe("success cases", func() {
-			It("retrieves the scheduled time annotation", func() {
-				scheduledTime := time.Now().Format(time.RFC3339)
-				disruption.Annotations[types.ScheduledAtAnnotation] = scheduledTime
-
-				retrievedTime, err := disruption.GetScheduledAtAnnotation()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(retrievedTime.Format(time.RFC3339)).To(Equal(scheduledTime))
-			})
-		})
-
-		Describe("error cases", func() {
-			It("returns and error when the annotation is missing", func() {
-				_, err := disruption.GetScheduledAtAnnotation()
-				Expect(err).To(MatchError("scheduledAt annotation not found"))
-			})
-
-			It("return and error when the annotation cannot be parsed", func() {
-				disruption.Annotations[types.ScheduledAtAnnotation] = "invalid-time"
-				_, err := disruption.GetScheduledAtAnnotation()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("unable to parse scheduledAt annotation"))
-			})
-		})
-	})
-
-	Describe("CopyUserInfoToAnnotations", func() {
-		var userInfoJSON string
-
-		BeforeEach(func() {
-			userInfoJSON = `{
-				"username": "test-user",
-				"groups": ["group1", "group2"]
-			}`
-			owner.SetAnnotations(map[string]string{
-				"UserInfo": userInfoJSON,
-			})
-		})
-
-		Describe("success cases", func() {
-			It("copies user-related annotations from the owner", func() {
-				err := disruption.CopyUserInfoToAnnotations(owner)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(disruption.Annotations).To(HaveKeyWithValue(types.UserAnnotation, "test-user"))
-				Expect(disruption.Annotations).To(HaveKeyWithValue(types.UserGroupsAnnotation, "group1,group2"))
-			})
-		})
-
-		Describe("error cases", func() {
-			It("returns an error if the UserInfo annotation is invalid JSON", func() {
-				owner.SetAnnotations(map[string]string{
-					"UserInfo": "invalid-json",
-				})
-				err := disruption.CopyUserInfoToAnnotations(owner)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("unable to parse UserInfo annotation"))
-			})
-
-			It("does nothing if the UserInfo annotation does not exist", func() {
-				owner.SetAnnotations(map[string]string{})
-				err := disruption.CopyUserInfoToAnnotations(owner)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(disruption.Annotations).To(BeEmpty())
-			})
 		})
 	})
 })

--- a/builderstest/disruption.go
+++ b/builderstest/disruption.go
@@ -234,3 +234,20 @@ func (b *DisruptionBuilder) WithInjectionStatus(status types.DisruptionInjection
 
 	return b
 }
+
+// WithAnnotations sets the specified annotations.
+func (b *DisruptionBuilder) WithAnnotations(annotations map[string]string) *DisruptionBuilder {
+	b.modifiers = append(
+		b.modifiers,
+		func() {
+			if b.ObjectMeta.Annotations == nil {
+				b.ObjectMeta.Annotations = make(map[string]string)
+			}
+
+			for k, v := range annotations {
+				b.ObjectMeta.Annotations[k] = v
+			}
+		})
+
+	return b
+}

--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -126,11 +126,7 @@ func setDisruptionAnnotations(disruption *chaosv1beta1.Disruption, owner metav1.
 
 	disruption.SetScheduledAtAnnotation(scheduledTime)
 
-	if err := disruption.CopyUserInfoToAnnotations(owner); err != nil {
-		return err
-	}
-
-	return nil
+	return disruption.CopyUserInfoToAnnotations(owner)
 }
 
 // overwriteDisruptionSelectors updates the selectors of a given Disruption object based on the provided targetResource.

--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -163,7 +163,7 @@ func CreateDisruptionFromTemplate(ctx context.Context, cl client.Client, scheme 
 	disruption.Labels[ownerNameLabel] = owner.GetName()
 
 	if err := setDisruptionAnnotations(disruption, owner, scheduledTime); err != nil {
-		log.Warnw("unable to set annotations for child disruption", "err", err, "disruptionName", disruption.Name)
+		log.Errorw("unable to set annotations for child disruption", "err", err, "disruptionName", disruption.Name)
 	}
 
 	if err := overwriteDisruptionSelectors(ctx, cl, disruption, targetResource, owner.GetNamespace()); err != nil {

--- a/controllers/disruption_cron_controller.go
+++ b/controllers/disruption_cron_controller.go
@@ -170,7 +170,7 @@ func (r *DisruptionCronReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	r.log.Infow("processing current run", "currentRun", missedRun.Format(time.UnixDate))
 
 	// Create disruption for current run
-	disruption, err := CreateDisruptionFromTemplate(ctx, r.Client, r.Scheme, instance, &instance.Spec.TargetResource, &instance.Spec.DisruptionTemplate, missedRun)
+	disruption, err := CreateDisruptionFromTemplate(ctx, r.Client, r.Scheme, instance, &instance.Spec.TargetResource, &instance.Spec.DisruptionTemplate, missedRun, r.log)
 
 	if err != nil {
 		r.log.Warnw("unable to construct disruption from template", "err", err)

--- a/controllers/disruption_rollout_controller.go
+++ b/controllers/disruption_rollout_controller.go
@@ -136,7 +136,7 @@ func (r *DisruptionRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Create disruption
 	scheduledTime := time.Now()
-	disruption, err := CreateDisruptionFromTemplate(ctx, r.Client, r.Scheme, instance, &instance.Spec.TargetResource, &instance.Spec.DisruptionTemplate, scheduledTime)
+	disruption, err := CreateDisruptionFromTemplate(ctx, r.Client, r.Scheme, instance, &instance.Spec.TargetResource, &instance.Spec.DisruptionTemplate, scheduledTime, r.log)
 
 	if err != nil {
 		r.log.Warnw("unable to construct disruption from template", "err", err)

--- a/types/types.go
+++ b/types/types.go
@@ -120,6 +120,14 @@ const (
 	// DisruptionNamespaceLabel is the label used to identify the disruption namespace for a chaos pod. This is used to determine pod ownership.
 	DisruptionNamespaceLabel = GroupName + "/disruption-namespace"
 
+	// ScheduledAtAnnotation is the annotation key for the scheduled time of the disruption when it is created from DisruptionCron or DisruptionRollout.
+	ScheduledAtAnnotation = GroupName + "/scheduled-at"
+
+	// UserAnnotation is the annotation key that stores the username of the user who created the parent resource (DisruptionCron or DisruptionRollout).
+	UserAnnotation = GroupName + "/user"
+	// UserGroupsAnnotation is the annotation key that stores the user groups of the individual who created the parent resource (DisruptionCron or DisruptionRollout).
+	UserGroupsAnnotation = GroupName + "/user-groups"
+
 	finalizerPrefix         = "finalizer." + GroupName
 	DisruptionFinalizer     = finalizerPrefix
 	DisruptionCronFinalizer = finalizerPrefix


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

When a disruption is created by the parent resource, `DisruptionCron` or `DisruptionRollout`, the user information is incorrectly set to the `chaos-controller` service account. This overwrites the actual user who initially created the cron job, making it impossible to track the real user behind the disruption.

To preserve the real user information, custom annotations will be added to store the actual user alongside the existing `UserInfo` annotation. This ensures that both the service account responsible for executing the disruption and the human user who created `DisruptionCron` or `DisruptionRollout` are properly recorded.

```
Annotations:
  UserInfo:
      {"username":"system:serviceaccount:chaos-engineering:chaos-controller","uid":"6d993b12-616a-44ed-9fc8-f18f308fad92","groups":["system:serv...
  chaos.datadoghq.com/scheduled-at: 2024-10-08T03:49:00Z
  chaos.datadoghq.com/user: system:admin
  chaos.datadoghq.com/user-groups: system:masters,system:authenticated
```

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
