### PR TITLE
Safely remove injector pods that never started

### DIFF
--- a/services/chaospod.go
+++ b/services/chaospod.go
@@ -188,7 +188,7 @@ func (m *chaosPodService) HandleChaosPodTermination(ctx context.Context, disrupt
 			}
 
 			// if the injector container definitively did not start, we can remove the finalizer
-			if !(*cs.Started) {
+			if cs.Started != nil && !(*cs.Started) {
 				shouldRemoveFinalizer = true
 			}
 

--- a/services/chaospod.go
+++ b/services/chaospod.go
@@ -187,6 +187,12 @@ func (m *chaosPodService) HandleChaosPodTermination(ctx context.Context, disrupt
 				continue
 			}
 
+			// if the injector container definitively did not start, we can remove the finalizer
+			if !(*cs.Started) {
+				shouldRemoveFinalizer = true
+			}
+
+			// if the injector container was terminated due to a start error, it can't have injected, we can remove the finalizer
 			if cs.State.Terminated != nil && cs.State.Terminated.Reason == "StartError" {
 				shouldRemoveFinalizer = true
 			}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- There's a container status field, `started`, that we can check to get a better idea if injector pods are safe to remove or not.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
