### PR TITLE
validateUserInfoGroup log should not reference global variable

### DIFF
--- a/api/v1beta1/userinfo.go
+++ b/api/v1beta1/userinfo.go
@@ -124,8 +124,8 @@ func validateUserInfoImmutable(oldObject, newObject client.Object) error {
 	return nil
 }
 
-// validateUserInfoGroup checks that if permittedUserGroups is set, which is controlled in controller.safeMode.permittedUserGroups in the configmap,
-// then we will return an error if the user in r.UserInfo does not belong to any of the permitted. If permittedUserGroups is unset, or if the user belongs to one of those
+// validateUserInfoGroup checks that if permittedGroups is set, which is controlled in controller.safeMode.permittedUserGroups in the configmap,
+// then we will return an error if the user in r.UserInfo does not belong to any of the permitted. If permittedGroups is unset, or if the user belongs to one of those
 // groups, then we will return nil
 func validateUserInfoGroup(object client.Object, permittedGroups map[string]struct{}, permittedGroupsString string) error {
 	if len(permittedGroups) == 0 {
@@ -145,7 +145,7 @@ func validateUserInfoGroup(object client.Object, permittedGroups map[string]stru
 		return nil
 	}
 
-	logger.Warnw(fmt.Sprintf("rejecting user from creating this %s", objectKind), "permittedUserGroups", permittedUserGroups, "userGroups", userInfo.Groups)
+	logger.Warnw(fmt.Sprintf("rejecting user from creating this %s", objectKind), "permittedUserGroups", permittedGroups, "userGroups", userInfo.Groups)
 
 	return fmt.Errorf(
 		"lacking sufficient authorization to create %s. your user groups are %s, but you must be in one of the following groups: %s",

--- a/api/v1beta1/userinfo.go
+++ b/api/v1beta1/userinfo.go
@@ -145,7 +145,7 @@ func validateUserInfoGroup(object client.Object, permittedGroups map[string]stru
 		return nil
 	}
 
-	logger.Warnw(fmt.Sprintf("rejecting user from creating this %s", objectKind), "permittedUserGroups", permittedGroups, "userGroups", userInfo.Groups)
+	logger.Warnw(fmt.Sprintf("rejecting user from creating this %s", objectKind), "permittedUserGroups", permittedGroupsString, "userGroups", userInfo.Groups)
 
 	return fmt.Errorf(
 		"lacking sufficient authorization to create %s. your user groups are %s, but you must be in one of the following groups: %s",


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- validateUserInfo was taking in `permittedGroups` as an argument, checking against that, but then was logging `permittedUserGroups`. It should instead be logging `permittedGroups`. No behavioral change, just a logging fix.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
