### PR TITLE
Allow for overlapping disruptions when the first disruption is complete

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -1150,9 +1150,9 @@ func (r *DisruptionReconciler) getEligibleTargets(ctx context.Context, instance 
 		}
 
 		// skip targets already targeted by a chaos pod from another disruption with the same kind if any
-		if len(chaosPods) != 0 {
-			anyChaosPodsRunning := false
 
+		anyChaosPodsRunning := false
+		if len(chaosPods) != 0 {
 			// chaosPods might all be in a Completed state. If any of these injectors aren't terminated, or terminated in an unready state, we set alreadyDisrupted
 			// because if all chaosPods for this target _are_ Completed, then this target is not already injected, and the current instance can proceed
 			for _, chaosPod := range chaosPods {
@@ -1162,12 +1162,9 @@ func (r *DisruptionReconciler) getEligibleTargets(ctx context.Context, instance 
 					}
 				}
 			}
+		}
 
-			allChaosPodsCompleted := !anyChaosPodsRunning
-			if allChaosPodsCompleted {
-				continue
-			}
-
+		if anyChaosPodsRunning {
 			if !instance.Spec.AllowDisruptedTargets {
 				r.log.Infow(`disruption spec does not allow to use already disrupted targets with ANY kind of existing disruption, skipping...
 NB: you can specify "spec.allowDisruptedTargets: true" to allow a new disruption without any disruption kind intersection to target the same pod`, "target", target, "targetLabels", targetLabels)

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -1159,6 +1159,7 @@ func (r *DisruptionReconciler) getEligibleTargets(ctx context.Context, instance 
 				for _, containerStatuses := range chaosPod.Status.ContainerStatuses {
 					if containerStatuses.State.Terminated == nil || containerStatuses.State.Terminated.ExitCode != 0 {
 						anyChaosPodsRunning = true
+						break
 					}
 				}
 			}

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -1151,25 +1151,28 @@ func (r *DisruptionReconciler) getEligibleTargets(ctx context.Context, instance 
 
 		// skip targets already targeted by a chaos pod from another disruption with the same kind if any
 		if len(chaosPods) != 0 {
-			if !instance.Spec.AllowDisruptedTargets {
-				alreadyDisrupted := false
+			anyChaosPodsRunning := false
 
-				// chaosPods might all be in a Completed state. If any of these injectors aren't terminated, or terminated in an unready state, we set alreadyDisrupted
-				// because if all chaosPods for this target _are_ Completed, then this target is not already injected, and the current instance can proceed
-				for _, chaosPod := range chaosPods {
-					for _, containerStatuses := range chaosPod.Status.ContainerStatuses {
-						if containerStatuses.State.Terminated == nil || containerStatuses.State.Terminated.ExitCode != 0 {
-							alreadyDisrupted = true
-						}
+			// chaosPods might all be in a Completed state. If any of these injectors aren't terminated, or terminated in an unready state, we set alreadyDisrupted
+			// because if all chaosPods for this target _are_ Completed, then this target is not already injected, and the current instance can proceed
+			for _, chaosPod := range chaosPods {
+				for _, containerStatuses := range chaosPod.Status.ContainerStatuses {
+					if containerStatuses.State.Terminated == nil || containerStatuses.State.Terminated.ExitCode != 0 {
+						anyChaosPodsRunning = true
 					}
 				}
+			}
 
-				if alreadyDisrupted {
-					r.log.Infow(`disruption spec does not allow to use already disrupted targets with ANY kind of existing disruption, skipping...
+			allChaosPodsCompleted := !anyChaosPodsRunning
+			if allChaosPodsCompleted {
+				continue
+			}
+
+			if !instance.Spec.AllowDisruptedTargets {
+				r.log.Infow(`disruption spec does not allow to use already disrupted targets with ANY kind of existing disruption, skipping...
 NB: you can specify "spec.allowDisruptedTargets: true" to allow a new disruption without any disruption kind intersection to target the same pod`, "target", target, "targetLabels", targetLabels)
 
-					continue
-				}
+				continue
 			}
 
 			targetDisruptedByKinds := map[chaostypes.DisruptionKindName]string{}

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -1150,8 +1150,8 @@ func (r *DisruptionReconciler) getEligibleTargets(ctx context.Context, instance 
 		}
 
 		// skip targets already targeted by a chaos pod from another disruption with the same kind if any
-
 		anyChaosPodsRunning := false
+
 		if len(chaosPods) != 0 {
 			// chaosPods might all be in a Completed state. If any of these injectors aren't terminated, or terminated in an unready state, we set alreadyDisrupted
 			// because if all chaosPods for this target _are_ Completed, then this target is not already injected, and the current instance can proceed

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -1152,10 +1152,24 @@ func (r *DisruptionReconciler) getEligibleTargets(ctx context.Context, instance 
 		// skip targets already targeted by a chaos pod from another disruption with the same kind if any
 		if len(chaosPods) != 0 {
 			if !instance.Spec.AllowDisruptedTargets {
-				r.log.Infow(`disruption spec does not allow to use already disrupted targets with ANY kind of existing disruption, skipping...
+				alreadyDisrupted := false
+
+				// chaosPods might all be in a Completed state. If any of these injectors aren't terminated, or terminated in an unready state, we set alreadyDisrupted
+				// because if all chaosPods for this target _are_ Completed, then this target is not already injected, and the current instance can proceed
+				for _, chaosPod := range chaosPods {
+					for _, containerStatuses := range chaosPod.Status.ContainerStatuses {
+						if containerStatuses.State.Terminated == nil || containerStatuses.State.Terminated.ExitCode != 0 {
+							alreadyDisrupted = true
+						}
+					}
+				}
+
+				if alreadyDisrupted {
+					r.log.Infow(`disruption spec does not allow to use already disrupted targets with ANY kind of existing disruption, skipping...
 NB: you can specify "spec.allowDisruptedTargets: true" to allow a new disruption without any disruption kind intersection to target the same pod`, "target", target, "targetLabels", targetLabels)
 
-				continue
+					continue
+				}
 			}
 
 			targetDisruptedByKinds := map[chaostypes.DisruptionKindName]string{}

--- a/controllers/disruption_controller_test.go
+++ b/controllers/disruption_controller_test.go
@@ -247,6 +247,23 @@ var _ = Describe("Disruption Controller", func() {
 		})
 	})
 
+	Context("dont duplicate targets across disruptions", func() {
+		BeforeEach(func() {
+			disruption.Spec.Count = &intstr.IntOrString{Type: intstr.String, StrVal: "100%"}
+		})
+
+		It("should target all the selected pods", func(ctx SpecContext) {
+			disruptionTwo := disruption.DeepCopy()
+			InjectPodsAndDisruption(ctx, *disruptionTwo, skipSecondPod)
+
+			By("Ensuring that no extra chaos pods have been created")
+			ExpectChaosPods(ctx, disruption, 8)
+
+			By("Ensuring that the chaos pods have correct number of targeted containers")
+			ExpectChaosInjectors(ctx, disruption, 8)
+		})
+	})
+
 	Context("target 30% of pods (1 pod out of 2) and one container", func() {
 		BeforeEach(func() {
 			disruption.Spec.Count = &intstr.IntOrString{Type: intstr.String, StrVal: "30%"}


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- we have no unit tests for this feature, and i think doing so in CI would be tricky with the current setup. What I could do, is test that if we create a second disruption, we still only have the expected number of chaos pods? So rather than testing the change, we test we didn't regress?
- If a disruption has completed, and all of its injectors exited in a healthy state, then it should be 100% safe for a new disruption to overlap the same targets. We don't need to wait for the injector pods to be removed, as long as they're cleaned and in a Completed state.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
