### PR TITLE
Closes #925. Copy multi-arch images to docker hub

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,7 @@ build:make:
         CONTAINER_REGISTRY=registry.ddbuild.io \
         CONTAINER_TAG=${TAG} \
         CONTAINER_VERSION=${CI_COMMIT_SHA} \
-        CONTAINER_BUILD_EXTRA_ARGS="--platform=linux/amd64,linux/arm64 --label target=${TARGET_LABEL} --push" \
+        CONTAINER_BUILD_EXTRA_ARGS='-t $$(CONTAINER_NAME):$(CONTAINER_VERSION)'" --platform=linux/amd64,linux/arm64 --label target=${TARGET_LABEL} --push" \
         SIGN_IMAGE=true
   dependencies:
     - build:make
@@ -131,17 +131,18 @@ release-prod-tag:
   <<: *docker-hub-login
   stage: release-public
   tags: ["runner:docker"]
-  image: registry.ddbuild.io/docker-notary:0.6.1
   script:
-    - docker pull registry.ddbuild.io/${CONTROLLER_IMAGE_NAME}:${TAG}
-    - docker tag registry.ddbuild.io/${CONTROLLER_IMAGE_NAME}:${TAG} datadog/${CONTROLLER_IMAGE_NAME}:${TAG}
-    - docker push datadog/${CONTROLLER_IMAGE_NAME}:${TAG}
-    - docker pull registry.ddbuild.io/${INJECTOR_IMAGE_NAME}:${TAG}
-    - docker tag registry.ddbuild.io/${INJECTOR_IMAGE_NAME}:${TAG} datadog/${INJECTOR_IMAGE_NAME}:${TAG}
-    - docker push datadog/${INJECTOR_IMAGE_NAME}:${TAG}
-    - docker pull registry.ddbuild.io/${HANDLER_IMAGE_NAME}:${TAG}
-    - docker tag registry.ddbuild.io/${HANDLER_IMAGE_NAME}:${TAG} datadog/${HANDLER_IMAGE_NAME}:${TAG}
-    - docker push datadog/${HANDLER_IMAGE_NAME}:${TAG}
+    - docker buildx create --use
+    - *install-make
+    - >
+      make docker-build-only-all \
+        CONTAINER_REGISTRY=docker.io/datadog \
+        CONTAINER_TAG=${TAG} \
+        CONTAINER_VERSION=${CI_COMMIT_SHA} \
+        CONTAINER_BUILD_EXTRA_ARGS="--platform=linux/amd64,linux/arm64 --label target=${TARGET_LABEL} --push" \
+        SIGN_IMAGE=false
+  dependencies:
+    - build:make
 
 release-docker-hub-ref:
   <<: *release-docker-hub
@@ -149,6 +150,7 @@ release-docker-hub-ref:
   except:
     - tags
   variables:
+    TARGET_LABEL: "prod"
     TAG: "${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}"
 
 release-docker-hub-tag:

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,6 @@ docker-build-only-$(1):
 		--build-arg BUILDGOVERSION=$(BUILDGOVERSION) \
 		--build-arg BUILDSTAMP=$(NOW_ISO8601) \
 		-t $$(CONTAINER_NAME):$(CONTAINER_TAG) \
-		-t $$(CONTAINER_NAME):$(CONTAINER_VERSION) \
 		--metadata-file ./bin/$(1)/docker-metadata.json \
 		$(CONTAINER_BUILD_EXTRA_ARGS) \
 		-f bin/$(1)/Dockerfile ./bin/$(1)/


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- `docker pull` will only ever copy a single arch version of an image, so our old approach could never push the multi-arch images to docker hub. The new approach [resolves this. see this multi-arch image?](https://hub.docker.com/layers/datadog/chaos-controller/test-multi-arch/images/sha256-c9d08394a496870bacfe425d729f4df3df515445bd3d7fadd2836eee68a6e85c?context=repo)

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
