### PR TITLE
CHAOSPLT-447: Add a spec field for pausing DisruptionCrons

### DIFF
--- a/api/v1beta1/disruption_cron_types.go
+++ b/api/v1beta1/disruption_cron_types.go
@@ -47,6 +47,11 @@ type DisruptionCronSpec struct {
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	Schedule string `json:"schedule"`
 
+	// If set to true, no disruptions will be created from this DisruptionCron
+	// useful if there's a reason to temporarily stop injecting, but without
+	// deleting this DisruptionCron
+	Paused bool `json:"paused,omitempty"`
+
 	// Optional deadline for starting the disruption if it misses scheduled time
 	// for any reason.  Missed disruption executions will be counted as failed ones.
 	// +nullable

--- a/chart/templates/generated/chaos.datadoghq.com_disruptioncrons.yaml
+++ b/chart/templates/generated/chaos.datadoghq.com_disruptioncrons.yaml
@@ -630,6 +630,12 @@ spec:
                   required:
                     - count
                   type: object
+                paused:
+                  description: |-
+                    If set to true, no disruptions will be created from this DisruptionCron
+                    useful if there's a reason to temporarily stop injecting, but without
+                    deleting this DisruptionCron
+                  type: boolean
                 reporting:
                   description: |-
                     Reporting provides additional reporting options in order to send a message to a custom slack channel

--- a/controllers/disruption_cron_controller.go
+++ b/controllers/disruption_cron_controller.go
@@ -121,7 +121,9 @@ func (r *DisruptionCronReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	if instance.Spec.Paused {
+		r.handleMetricSinkError(r.MetricsSink.MetricPausedCron(DisruptionCronTags))
 		r.log.Debugw("disruptioncron has been paused, will not resume until spec.paused is false")
+
 		return ctrl.Result{}, nil
 	}
 
@@ -336,7 +338,6 @@ func (r *DisruptionCronReconciler) getNextSchedule(instance *chaosv1beta1.Disrup
 		lastMissed = t
 	}
 
-	// TODO do we want to emit this metric when suspended?
 	r.handleMetricSinkError(r.MetricsSink.MetricNextScheduledTime(time.Until(sched.Next(now)), DisruptionCronTags))
 
 	return lastMissed, sched.Next(now), nil

--- a/docs/disruption_cron.md
+++ b/docs/disruption_cron.md
@@ -19,6 +19,7 @@ metadata:
   namespace: chaos-demo # it must be in the same namespace as targeted resources
 spec:
   schedule: "*/15 * * * *" # cron syntax specifying that disruption occurs every 15 minutes
+  paused: false # set to true if you want to disable disruption creation temporarily (until set to false again)
   targetResource: # a resource to target
     kind: deployment # a resource name to target
     name: demo-curl # can be either deployment or statefulset

--- a/o11y/metrics/datadog/datadog.go
+++ b/o11y/metrics/datadog/datadog.go
@@ -252,6 +252,11 @@ func (d Sink) MetricDisruptionScheduled(tags []string) error {
 	return d.metricWithStatus(d.prefix+"schedule.disruption_scheduled", tags)
 }
 
+// MetricPausedCron reports when a disruption cron has reconciled in a paused state
+func (d Sink) MetricPausedCron(tags []string) error {
+	return d.metricWithStatus(d.prefix+"schedule.paused", tags)
+}
+
 func boolToStatus(succeed bool) string {
 	var status string
 	if succeed {

--- a/o11y/metrics/metrics.go
+++ b/o11y/metrics/metrics.go
@@ -51,6 +51,7 @@ type Sink interface {
 	MetricMissingTargetFound(tags []string) error
 	MetricNextScheduledTime(time time.Duration, tags []string) error
 	MetricDisruptionScheduled(tags []string) error
+	MetricPausedCron(tags []string) error
 }
 
 // GetSink returns an initiated sink

--- a/o11y/metrics/noop/noop.go
+++ b/o11y/metrics/noop/noop.go
@@ -247,3 +247,10 @@ func (n Sink) MetricDisruptionScheduled(tags []string) error {
 
 	return nil
 }
+
+// MetricPausedCron reports when a disruption cron has reconciled in a paused state
+func (n Sink) MetricPausedCron(tags []string) error {
+	n.log.Debugf("NOOP: MetricPausedCron %s\n", tags)
+
+	return nil
+}

--- a/o11y/metrics/sink_mock.go
+++ b/o11y/metrics/sink_mock.go
@@ -819,6 +819,52 @@ func (_c *SinkMock_MetricOrphanFound_Call) RunAndReturn(run func([]string) error
 	return _c
 }
 
+// MetricPausedCron provides a mock function with given fields: tags
+func (_m *SinkMock) MetricPausedCron(tags []string) error {
+	ret := _m.Called(tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricPausedCron")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]string) error); ok {
+		r0 = rf(tags)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SinkMock_MetricPausedCron_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MetricPausedCron'
+type SinkMock_MetricPausedCron_Call struct {
+	*mock.Call
+}
+
+// MetricPausedCron is a helper method to define mock.On call
+//   - tags []string
+func (_e *SinkMock_Expecter) MetricPausedCron(tags interface{}) *SinkMock_MetricPausedCron_Call {
+	return &SinkMock_MetricPausedCron_Call{Call: _e.mock.On("MetricPausedCron", tags)}
+}
+
+func (_c *SinkMock_MetricPausedCron_Call) Run(run func(tags []string)) *SinkMock_MetricPausedCron_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]string))
+	})
+	return _c
+}
+
+func (_c *SinkMock_MetricPausedCron_Call) Return(_a0 error) *SinkMock_MetricPausedCron_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SinkMock_MetricPausedCron_Call) RunAndReturn(run func([]string) error) *SinkMock_MetricPausedCron_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MetricPodsCreated provides a mock function with given fields: target, instanceName, namespace, succeed
 func (_m *SinkMock) MetricPodsCreated(target string, instanceName string, namespace string, succeed bool) error {
 	ret := _m.Called(target, instanceName, namespace, succeed)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- DisruptionCrons are permanent resources. Sometimes we want them to stop creating Disruptions temporarily, but we don't want to delete them or update their schedule. To support that, we add a new spec field, `paused`, that will still allow for Crons to be updated or deleted, but they won't ever try to create new Disruptions
- We add a new metric to count crons that are paused

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
