### PR TITLE
Make the network.services field more clear

### DIFF
--- a/docs/network_disruption/hosts-and-services.md
+++ b/docs/network_disruption/hosts-and-services.md
@@ -16,12 +16,14 @@ The `hosts` field takes a list of `host`/`port`/`protocol`/`connState` tuples. A
 
 ## Q: When should I specify services instead?
 
+Are you attempting to disrupt traffic to a service in the same kubernetes cluster?
+
 While the `network.hosts` field is meant for specifying only disrupting packets interacting with a particular IP, hostname, or CIDR range,
 a very common use case of network disruptions is to disrupt packets interacting with a particular kubernetes service. This can be tricky for users,
 as NAT rules are applied before `tc` rules, and thus the port that a pod uses to send packets to a service is not necessarily the same port used by the node in the root network namespace.
 It is not simple to detect that a hostname passed to `network.hosts` is a kubernetes service, and thus we include the `network.services` field.
 
-Whenever you want to disrupt traffic interacting with a kubernetes service[s], for correctness's sake, you _must_ specify the service under `network.services`, rather than `network.hosts`.
+Whenever you want to disrupt traffic interacting with a kubernetes service[s] in the same cluster as your target, for correctness's sake, you _must_ specify the service under `network.services`, rather than `network.hosts`.
 `network.services` takes a list of services, which are defined with each service's `name` and `namespace`, as well as a list of `ports` to be affected. 
 In this `ports` list, you can specify the `name` of the port and/or the `port` itself ([see kubernetes service definition for context](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)). Those fields (`name`, `port`) are **exclusively used to find the right service port to affect**. 
 

--- a/examples/complete.yaml
+++ b/examples/complete.yaml
@@ -63,7 +63,7 @@ spec:
         protocol: tcp # optional, protocol to filter on (can be tcp or udp, defaults to both)
         flow: ingress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
         connState: new # optional, connection state (new: new connections, est: established connections, defaults to all states)
-    services: # optional, list of destination Kubernetes services to filter on. these must be in the same kubernetes cluster
+    services: # optional, list of destination Kubernetes services to filter on. These must be in the same kubernetes cluster
       - name: foo # service name
         namespace: bar # service namespace
       - name: fooo # service name

--- a/examples/complete.yaml
+++ b/examples/complete.yaml
@@ -63,7 +63,7 @@ spec:
         protocol: tcp # optional, protocol to filter on (can be tcp or udp, defaults to both)
         flow: ingress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
         connState: new # optional, connection state (new: new connections, est: established connections, defaults to all states)
-    services: # optional, list of destination Kubernetes services to filter on
+    services: # optional, list of destination Kubernetes services to filter on. these must be in the same kubernetes cluster
       - name: foo # service name
         namespace: bar # service namespace
       - name: fooo # service name

--- a/examples/network_filter_service.yaml
+++ b/examples/network_filter_service.yaml
@@ -15,7 +15,7 @@ spec:
   count: 1
   network:
     drop: 100
-    services: # filter on Kubernetes services; this will correctly handle the port differences in node vs. pod-level disruptions
+    services: # filter on same cluster Kubernetes services; this will correctly handle the port differences in node vs. pod-level disruptions. this cannot resolve services from other k8s clusters
       - name: demo # service name
         namespace: chaos-demo # service namespace
         ports: # optional. List of affected ports. No list means all ports are affected

--- a/examples/network_filter_service.yaml
+++ b/examples/network_filter_service.yaml
@@ -15,7 +15,7 @@ spec:
   count: 1
   network:
     drop: 100
-    services: # filter on same cluster Kubernetes services; this will correctly handle the port differences in node vs. pod-level disruptions. this cannot resolve services from other k8s clusters
+    services: # filter on same cluster Kubernetes services; this will correctly handle the port differences in node vs. pod-level disruptions. This cannot resolve services from other k8s clusters
       - name: demo # service name
         namespace: chaos-demo # service namespace
         ports: # optional. List of affected ports. No list means all ports are affected


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Update all docs and examples to explain that network.services is only for the same cluster

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
