### PR TITLE
CHAOSPLT-64: Add a Spec.SetDefaults method

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -567,6 +567,14 @@ func (s DisruptionSpec) HashNoCount() (string, error) {
 	return s.Hash()
 }
 
+// SetDefaults finds any unset spec options, and sets the default values. Only operates on values that lack
+// kubebuilder struct default tags, which typically only includes complex types, such as spec.duration
+func (s *DisruptionSpec) SetDefaults() {
+	if s.Duration.Duration() == 0 {
+		s.Duration = DisruptionDuration(defaultDuration.String())
+	}
+}
+
 // Validate applies rules for disruption global scope and all subsequent disruption specifications, requiring selectors
 // intended to be called when DisruptionSpec belongs directly to a Disruption
 // also exists for backwards compatibility

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -114,8 +114,9 @@ var _ webhook.Defaulter = &Disruption{}
 func (r *Disruption) Default() {
 	if r.Spec.Duration.Duration() == 0 {
 		logger.Infow(fmt.Sprintf("setting default duration of %s in disruption", defaultDuration), "instance", r.Name, "namespace", r.Namespace)
-		r.Spec.Duration = DisruptionDuration(defaultDuration.String())
 	}
+
+	r.Spec.SetDefaults()
 }
 
 //+kubebuilder:webhook:webhookVersions={v1},path=/validate-chaos-datadoghq-com-v1beta1-disruption,mutating=false,failurePolicy=fail,sideEffects=None,groups=chaos.datadoghq.com,resources=disruptions,verbs=create;update;delete,versions=v1beta1,name=vdisruption.kb.io,admissionReviewVersions={v1,v1beta1}

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -112,10 +112,6 @@ var _ webhook.Defaulter = &Disruption{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Disruption) Default() {
-	if r.Spec.Duration.Duration() == 0 {
-		logger.Infow(fmt.Sprintf("setting default duration of %s in disruption", defaultDuration), "instance", r.Name, "namespace", r.Namespace)
-	}
-
 	r.Spec.SetDefaults()
 }
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -63,7 +63,7 @@ controller:
     datadog: # datadog cloud provider config
       enabled: true # enable the provider
       ipRangesURL: "https://ip-ranges.datadoghq.com/" # URL to the IP ranges file (format must be the expected one, defaults is the public file provided by the cloud provider)
-  defaultDuration: 1h # default spec.duration for a disruption with none specified
+  defaultDuration: 5m # default spec.duration for a disruption with none specified
   maxDuration: 2h # maximum spec.duration for a disruption
   defaultCronDelayedStartTolerance: 15m
   finalizerDeletionDelay: 20s


### PR DESCRIPTION
We have a desire to set the defaults directly on a DisruptionSpec. So I've extracted a SetDefaults function that is called by the webhook's Default function, leading to no change the chaos-controller's functionality.

Unfortunately, this makes the logging a bit trickier? Do we want to stop logging when we set defaults? I don't want to pass a logger, along with the disruption name and namespace into the SetDefaults function. Any ideas?