### PR TITLE
Remove all deprecated network spec fields

### DIFF
--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -95,25 +95,14 @@ type NetworkDisruptionSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	// +ddmark:validation:Minimum=0
 	BandwidthLimit int `json:"bandwidthLimit,omitempty"`
-	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=65535
-	// +ddmark:validation:Minimum=0
-	// +ddmark:validation:Maximum=65535
-	// +nullable
-	DeprecatedPort *int `json:"port,omitempty"`
-	// +kubebuilder:validation:Enum=egress;ingress
-	// +ddmark:validation:Enum=egress;ingress
-	DeprecatedFlow string `json:"flow,omitempty"`
 	// +nullable
 	HTTP *NetworkHTTPFilters `json:"http,omitempty"`
 }
 
 // NetworkHTTPFilters contains http filters
 type NetworkHTTPFilters struct {
-	DeprecatedMethod string      `json:"method,omitempty"`
-	DeprecatedPath   HTTPPath    `json:"path,omitempty"`
-	Methods          HTTPMethods `json:"methods,omitempty"`
-	Paths            HTTPPaths   `json:"paths,omitempty"`
+	Methods HTTPMethods `json:"methods,omitempty"`
+	Paths   HTTPPaths   `json:"paths,omitempty"`
 }
 
 type NetworkDisruptionHostSpec struct {
@@ -202,14 +191,6 @@ func (h HTTPMethods) isNotEmpty() bool {
 
 // validate validates args for the given http filters.
 func (s *NetworkHTTPFilters) validate() (retErr error) {
-	if s.DeprecatedPath != "" {
-		retErr = multierror.Append(retErr, fmt.Errorf("the Path specification at the HTTP network disruption level is no longer supported; use Paths HTTP field instead"))
-	}
-
-	if s.DeprecatedMethod != "" {
-		retErr = multierror.Append(retErr, fmt.Errorf("the Method specification at the HTTP network disruption level is no longer supported; use Methods HTTP field instead"))
-	}
-
 	retErr = s.validatePaths(retErr)
 
 	retErr = s.validateMethods(retErr)
@@ -329,15 +310,6 @@ func (s *NetworkDisruptionSpec) Validate() (retErr error) {
 		if err := host.Validate(); err != nil {
 			retErr = multierror.Append(retErr, err)
 		}
-	}
-
-	// ensure deprecated fields are not used
-	if s.DeprecatedPort != nil {
-		retErr = multierror.Append(retErr, fmt.Errorf("the port specification at the network disruption level is deprecated; apply to network disruption hosts instead"))
-	}
-
-	if s.DeprecatedFlow != "" {
-		retErr = multierror.Append(retErr, fmt.Errorf("the flow specification at the network disruption level is deprecated; apply to network disruption hosts instead"))
 	}
 
 	if s.HTTP != nil {

--- a/api/v1beta1/network_disruption_test.go
+++ b/api/v1beta1/network_disruption_test.go
@@ -302,45 +302,6 @@ var _ = Describe("NetworkDisruptionSpec", func() {
 			})
 		})
 
-		Describe("test deprecated fields cases", func() {
-			port := 8080
-			DescribeTable("with deprecated field defined",
-				func(invalidDisruptionSpec NetworkDisruptionSpec, expectedErrorMessage string) {
-					// Action
-					err := invalidDisruptionSpec.Validate()
-
-					// Assert
-					Expect(err).Should(HaveOccurred())
-					errorMessage := err.Error()
-					Expect(strings.Count(errorMessage, expectedErrorMessage)).To(Equal(1))
-				},
-				Entry("When the DeprecatedPort is defined",
-					NetworkDisruptionSpec{DeprecatedPort: &port},
-					"the port specification at the network disruption level is deprecated; apply to network disruption hosts instead",
-				),
-				Entry("When the DeprecatedFlow is defined",
-					NetworkDisruptionSpec{DeprecatedFlow: "lorem"},
-					"the flow specification at the network disruption level is deprecated; apply to network disruption hosts instead",
-				),
-				Entry("When the DeprecatedMethod is defined",
-					NetworkDisruptionSpec{
-						HTTP: &NetworkHTTPFilters{
-							DeprecatedMethod: "ALL",
-						},
-					},
-					"the Method specification at the HTTP network disruption level is no longer supported; use Methods HTTP field instead",
-				),
-				Entry("When the DeprecatedPath is defined",
-					NetworkDisruptionSpec{
-						HTTP: &NetworkHTTPFilters{
-							DeprecatedPath: DefaultHTTPPathFilter,
-						},
-					},
-					"the Path specification at the HTTP network disruption level is no longer supported; use Paths HTTP field instead",
-				),
-			)
-		})
-
 		Describe("test Methods field cases", func() {
 			DescribeTable("with valid methods",
 				func(methods HTTPMethods) {

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -957,11 +957,6 @@ func (in *NetworkDisruptionSpec) DeepCopyInto(out *NetworkDisruptionSpec) {
 		*out = new(NetworkDisruptionCloudSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.DeprecatedPort != nil {
-		in, out := &in.DeprecatedPort, &out.DeprecatedPort
-		*out = new(int)
-		**out = **in
-	}
 	if in.HTTP != nil {
 		in, out := &in.HTTP, &out.HTTP
 		*out = new(NetworkHTTPFilters)

--- a/chart/templates/generated/chaos.datadoghq.com_disruptioncrons.yaml
+++ b/chart/templates/generated/chaos.datadoghq.com_disruptioncrons.yaml
@@ -415,11 +415,6 @@ spec:
                           maximum: 100
                           minimum: 0
                           type: integer
-                        flow:
-                          enum:
-                            - egress
-                            - ingress
-                          type: string
                         hosts:
                           items:
                             properties:
@@ -454,24 +449,15 @@ spec:
                           description: NetworkHTTPFilters contains http filters
                           nullable: true
                           properties:
-                            method:
-                              type: string
                             methods:
                               items:
                                 type: string
                               type: array
-                            path:
-                              type: string
                             paths:
                               items:
                                 type: string
                               type: array
                           type: object
-                        port:
-                          maximum: 65535
-                          minimum: 0
-                          nullable: true
-                          type: integer
                         services:
                           items:
                             properties:

--- a/chart/templates/generated/chaos.datadoghq.com_disruptionrollouts.yaml
+++ b/chart/templates/generated/chaos.datadoghq.com_disruptionrollouts.yaml
@@ -416,11 +416,6 @@ spec:
                           maximum: 100
                           minimum: 0
                           type: integer
-                        flow:
-                          enum:
-                            - egress
-                            - ingress
-                          type: string
                         hosts:
                           items:
                             properties:
@@ -455,24 +450,15 @@ spec:
                           description: NetworkHTTPFilters contains http filters
                           nullable: true
                           properties:
-                            method:
-                              type: string
                             methods:
                               items:
                                 type: string
                               type: array
-                            path:
-                              type: string
                             paths:
                               items:
                                 type: string
                               type: array
                           type: object
-                        port:
-                          maximum: 65535
-                          minimum: 0
-                          nullable: true
-                          type: integer
                         services:
                           items:
                             properties:

--- a/chart/templates/generated/chaos.datadoghq.com_disruptions.yaml
+++ b/chart/templates/generated/chaos.datadoghq.com_disruptions.yaml
@@ -406,11 +406,6 @@ spec:
                       maximum: 100
                       minimum: 0
                       type: integer
-                    flow:
-                      enum:
-                        - egress
-                        - ingress
-                      type: string
                     hosts:
                       items:
                         properties:
@@ -445,24 +440,15 @@ spec:
                       description: NetworkHTTPFilters contains http filters
                       nullable: true
                       properties:
-                        method:
-                          type: string
                         methods:
                           items:
                             type: string
                           type: array
-                        path:
-                          type: string
                         paths:
                           items:
                             type: string
                           type: array
                       type: object
-                    port:
-                      maximum: 65535
-                      minimum: 0
-                      nullable: true
-                      type: integer
                     services:
                       items:
                         properties:


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- DeprecatedPort was removed in 2021. DeprecatedFlow was removed in 2022.
- The deprecated http fields were removed in October 2023.

There's no need to carry these fields around with deprecation error messages anymore, we can remove the code and tests.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
