### PR TITLE
[CHAOSPLT-579] Fix eBPF warnings + fix eBPF CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ build:make:
   script:
     - *install-make
     - export PATH="/usr/local/go/bin:${PATH}"
-    - make GOBIN=/usr/local/go/bin install-go all docker-build-ebpf
+    - make GOBIN=/usr/local/go/bin install-go all docker-build-ebpf_arm docker-build-ebpf_amd
   artifacts:
     paths:
       - bin/manager/manager_amd64

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,12 @@ else
 	docker run --rm --platform linux/$(GOARCH) -v $(shell pwd):/app ebpf-builder-$(GOARCH)
 endif
 
+docker-build-ebpf_arm:
+	$(MAKE) docker-build-ebpf GOARCH=arm64
+
+docker-build-ebpf_amd:
+	$(MAKE) docker-build-ebpf GOARCH=amd64
+
 lima-push-injector lima-push-handler lima-push-manager: FAKE_FOR=COMPLETION
 
 _injector:;

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ ifeq (true,$(USE_VOLUMES))
 	-docker cp . ebpf-volume:/app
 	-docker rm ebpf-builder
 	docker run --platform linux/$(GOARCH) --volumes-from ebpf-volume --name=ebpf-builder ebpf-builder-$(GOARCH)
+	mkdir -p bin/injector/ebpf/$(GOARCH)
 	docker cp ebpf-builder:/app/bin/injector/ebpf/$(GOARCH) bin/injector/ebpf/$(GOARCH)
 	docker rm ebpf-builder
 else

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ docker-build-manager docker-build-only-manager: CONTAINER_NAME=$(MANAGER_IMAGE)
 
 docker-build-ebpf:
 	docker buildx build --platform linux/$(GOARCH) --build-arg BUILDGOVERSION=$(BUILDGOVERSION) -t ebpf-builder-$(GOARCH) -f bin/ebpf-builder/Dockerfile .
-	-rm -r bin/injector/ebpf/
+	-rm -r bin/injector/ebpf/$(GOARCH)/
 ifeq (true,$(USE_VOLUMES))
 # create a dummy container with volume to store files
 # circleci remote docker does not allow to use volumes, locally we fallbakc to standard volume but can call this target with USE_VOLUMES=true to debug if necessary
@@ -115,7 +115,7 @@ ifeq (true,$(USE_VOLUMES))
 	-docker cp . ebpf-volume:/app
 	-docker rm ebpf-builder
 	docker run --platform linux/$(GOARCH) --volumes-from ebpf-volume --name=ebpf-builder ebpf-builder-$(GOARCH)
-	docker cp ebpf-builder:/app/bin/injector/ebpf bin/injector/ebpf
+	docker cp ebpf-builder:/app/bin/injector/ebpf/$(GOARCH) bin/injector/ebpf/$(GOARCH)
 	docker rm ebpf-builder
 else
 	docker run --rm --platform linux/$(GOARCH) -v $(shell pwd):/app ebpf-builder-$(GOARCH)

--- a/bin/injector/Dockerfile
+++ b/bin/injector/Dockerfile
@@ -45,7 +45,7 @@ COPY injector_${TARGETARCH} /usr/local/bin/chaos-injector
 COPY injector_${TARGETARCH} /usr/local/bin/injector
 
 COPY dns_disruption_resolver.py /usr/local/bin/dns_disruption_resolver.py
-COPY ebpf/ /usr/local/bin/
+COPY ebpf/${TARGETARCH}/ /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/chaos-injector"]
 

--- a/ebpf/Makefile
+++ b/ebpf/Makefile
@@ -1,5 +1,6 @@
 ARCH := x86
-BUILD_DIR := ../bin/injector/ebpf
+GOARCH := $(shell go env GOARCH)
+BUILD_DIR := ../bin/injector/ebpf/$(GOARCH)
 TARGET_PREFIX := bpf-
 UNAME_ARCH := $(shell uname -m)
 

--- a/ebpf/disk-failure/injection.bpf.c
+++ b/ebpf/disk-failure/injection.bpf.c
@@ -71,7 +71,7 @@ int injection_disk_failure(struct pt_regs *ctx)
     char cmp_path_name[62];
     bpf_probe_read(&cmp_path_name, sizeof(cmp_path_name), path);
     char cmp_expected_path[62];
-    bpf_probe_read(cmp_expected_path, sizeof(cmp_expected_path), filter_path);
+    bpf_probe_read(cmp_expected_path, sizeof(cmp_expected_path),  (const void *)filter_path);
     int filter_len = (int) (sizeof(filter_path) / sizeof(filter_path[0])) - 1;
    
     if (filter_len > 62) {

--- a/ebpf/network-tc-filter/injection.bpf.c
+++ b/ebpf/network-tc-filter/injection.bpf.c
@@ -53,7 +53,6 @@ static __always_inline bool  validate_path(char* path) {
         bpf_probe_read_kernel_str(&request_path, sizeof(request_path), path);
 
         // Check if the prefix match the method.
-        #pragma unroll
         for (int j = 0; j < MAX_PATH_LEN; ++j) {
             // Break the loop if the prefix is completed
             if (expected_path[j] == '\0')


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- `Fix eBPF compilation warnings`
- `Generate the eBPF binaries in a folder representing the build architecture to fix our internal CI.`

**Reason:**
The gitlab which release the eBPF program only build the eBPF binaries for `amd64` architecture and the `arm64` use the eBPF program with `amd64` architecture.

  


## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
