### PR TITLE
CHAOSPLT-571: Allow for extra ip ranges for GCP cloud disruption

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -50,6 +50,12 @@ data:
         gcp:
           enabled: {{ .Values.controller.cloudProviders.gcp.enabled }}
           ipRangesURL: {{ .Values.controller.cloudProviders.gcp.ipRangesURL }}
+        {{- if .Values.controller.cloudProviders.gcp.extraIpRanges }}
+          extraIpRanges:
+          {{- range $index, $val := .Values.controller.cloudProviders.gcp.extraIpRanges }}
+            - {{ $val | quote }}
+          {{- end }}
+        {{- end}}
         datadog:
           enabled: {{ .Values.controller.cloudProviders.datadog.enabled }}
           ipRangesURL: {{ .Values.controller.cloudProviders.datadog.ipRangesURL }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -61,6 +61,8 @@ controller:
     gcp: # gcp cloud provider config
       enabled: true # enable the provider
       ipRangesURL: "https://www.gstatic.com/ipranges/goog.json" # URL to the IP ranges file (format must be the expected one, defaults is the public file provided by the cloud provider)
+      extraIpRanges:
+        - "Google;199.36.153.8/30;199.36.153.4/30" # private.googleapis.com;restricted.googleapis.com
     datadog: # datadog cloud provider config
       enabled: true # enable the provider
       ipRangesURL: "https://ip-ranges.datadoghq.com/" # URL to the IP ranges file (format must be the expected one, defaults is the public file provided by the cloud provider)

--- a/cloudservice/manager.go
+++ b/cloudservice/manager.go
@@ -263,9 +263,7 @@ func (s *cloudServicesProvidersManager) pullIPRangesPerCloudProvider(cloudProvid
 		serviceAndSplitIPRange := strings.SplitN(ipRangeList, ";", 2)
 		service := serviceAndSplitIPRange[0]
 		splitIPRange := strings.Split(serviceAndSplitIPRange[1], ";")
-		for _, ipRange := range splitIPRange {
-			provider.IPRangeInfo.IPRanges[service] = append(provider.IPRangeInfo.IPRanges[service], ipRange)
-		}
+		provider.IPRangeInfo.IPRanges[service] = append(provider.IPRangeInfo.IPRanges[service], splitIPRange...)
 	}
 
 	return err

--- a/cloudservice/manager.go
+++ b/cloudservice/manager.go
@@ -109,6 +109,7 @@ func New(log *zap.SugaredLogger, config types.CloudProviderConfigs, httpClientMo
 			provider.CloudProviderIPRangeManager = gcp.New()
 			provider.Conf.Enabled = config.GCP.Enabled
 			provider.Conf.IPRangesURL = config.GCP.IPRangesURL
+			provider.Conf.ExtraIPRanges = config.GCP.ExtraIPRanges
 		case types.CloudProviderDatadog:
 			provider.CloudProviderIPRangeManager = datadog.New()
 			provider.Conf.Enabled = config.Datadog.Enabled
@@ -252,6 +253,20 @@ func (s *cloudServicesProvidersManager) pullIPRangesPerCloudProvider(cloudProvid
 	}
 
 	provider.IPRangeInfo, err = provider.CloudProviderIPRangeManager.ConvertToGenericIPRanges(unparsedIPRange)
+
+	for _, ipRangeList := range provider.Conf.ExtraIPRanges {
+		// Viper "normalizes" all map keys by casting them all to lower case: https://github.com/spf13/viper/issues/373
+		// Because the services for each cloud provider use different case methods, e.g., "Google" vs "S3" vs "synthetics",
+		// there's no easy way to undo this lowercasing. So we've stored the extra ranges in the following syntax:
+		// "service;iprange;iprange;...;iprange". We split by ';' once to find the service, then split by ';' again to find
+		// all extra ranges
+		serviceAndSplitIPRange := strings.SplitN(ipRangeList, ";", 2)
+		service := serviceAndSplitIPRange[0]
+		splitIPRange := strings.Split(serviceAndSplitIPRange[1], ";")
+		for _, ipRange := range splitIPRange {
+			provider.IPRangeInfo.IPRanges[service] = append(provider.IPRangeInfo.IPRanges[service], ipRange)
+		}
+	}
 
 	return err
 }

--- a/cloudservice/types/types.go
+++ b/cloudservice/types/types.go
@@ -28,8 +28,9 @@ type CloudProviderIPRangeInfo struct {
 
 // CloudProviderConfig Single configuration for any cloud provider
 type CloudProviderConfig struct {
-	Enabled     bool   `json:"enabled" yaml:"enabled"`
-	IPRangesURL string `json:"ipRangesURL" yaml:"ipRangesURL"`
+	Enabled       bool     `json:"enabled" yaml:"enabled"`
+	IPRangesURL   string   `json:"ipRangesURL" yaml:"ipRangesURL"`
+	ExtraIPRanges []string `json:"extraIpRanges" yaml:"extraIpRanges"`
 }
 
 // CloudProviderConfigs all cloud provider configurations for the manager

--- a/config/config.go
+++ b/config/config.go
@@ -509,6 +509,12 @@ func New(client corev1client.ConfigMapInterface, logger *zap.SugaredLogger, osAr
 		return cfg, err
 	}
 
+	mainFS.StringSliceVar(&cfg.Controller.CloudProviders.GCP.ExtraIPRanges, "cloud-providers-gcp-extraipranges", []string{}, "Any additional ranges for GCP")
+
+	if err := viper.BindPFlag("controller.cloudProviders.gcp.ipRanges", mainFS.Lookup("cloud-providers-gcp-extraipranges")); err != nil {
+		return cfg, err
+	}
+
 	mainFS.BoolVar(&cfg.Controller.CloudProviders.Datadog.Enabled, "cloud-providers-datadog-enabled", true, "Enable Datadog cloud provider disruptions (defaults to true, is overridden by --cloud-providers-disable-all)")
 
 	if err := viper.BindPFlag("controller.cloudProviders.datadog.enabled", mainFS.Lookup("cloud-providers-datadog-enabled")); err != nil {

--- a/docs/network_disruption/cloud-managed-services.md
+++ b/docs/network_disruption/cloud-managed-services.md
@@ -79,9 +79,16 @@ We are using the URL **https://ip-ranges.amazonaws.com/ip-ranges.json** to pull 
 
 Available service is `Google`.
 
-Google does not indicates which ip ranges correspond to which service in its ip ranges files.
+Google does not indicate which ip ranges correspond to which service in its ip ranges files.
 
 We are using the URL **https://www.gstatic.com/ipranges/goog.json**. This file is the generic Google ip ranges file. We could not use the Google Cloud specific file due to some ip ranges from the apis being in the first file (goog.json). ([More info here](https://support.google.com/a/answer/10026322?hl=en))
+
+We'd like to include the private ranges alongside the public ranges. The private ranges don't appear to be published in a static json file, but are listed in documentation in various places:
+https://cloud.google.com/vpc/docs/configure-private-google-access#config-options
+https://cloud.google.com/vpc/docs/subnets#restricted-ranges
+
+So we configure this directly in the configmap under `controller.cloudProviders.gcp.extraIpRanges`, which takes a list of strings,
+of the form `"service;iprange;iprange;...;iprange`. We aren't able to use a map because of how viper normalizes map keys.
 
 ### Datadog
 

--- a/examples/network_cloud.yaml
+++ b/examples/network_cloud.yaml
@@ -15,19 +15,6 @@ spec:
   count: 100%
   network:
     cloud:
-      aws:
-        - service: "S3" # service name as declared in the provider file (see doc for details)
-          protocol: tcp # optional, protocol to drop packets on (can be tcp or udp, defaults to both)
-          flow: ingress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
-          connState: new # optional, connection state (new: new connections, est: established connections, defaults to all states)
       gcp:
         - service: "Google" # service name as declared in the provider file (see doc for details)
-          protocol: tcp # optional, protocol to drop packets on (can be tcp or udp, defaults to both)
-          flow: ingress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
-          connState: new # optional, connection state (new: new connections, est: established connections, defaults to all states)
-      datadog:
-        - service: "synthetics" # service name as declared in the provider file (see doc for details)
-          protocol: tcp # optional, protocol to drop packets on (can be tcp or udp, defaults to both)
-          flow: ingress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
-          connState: new # optional, connection state (new: new connections, est: established connections, defaults to all states)
     drop: 100 # percentage of outgoing packets to drop

--- a/examples/network_cloud.yaml
+++ b/examples/network_cloud.yaml
@@ -15,6 +15,19 @@ spec:
   count: 100%
   network:
     cloud:
+      aws:
+        - service: "S3" # service name as declared in the provider file (see doc for details)
+          protocol: tcp # optional, protocol to drop packets on (can be tcp or udp, defaults to both)
+          flow: ingress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
+          connState: new # optional, connection state (new: new connections, est: established connections, defaults to all states)
       gcp:
         - service: "Google" # service name as declared in the provider file (see doc for details)
+          protocol: tcp # optional, protocol to drop packets on (can be tcp or udp, defaults to both)
+          flow: ingress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
+          connState: new # optional, connection state (new: new connections, est: established connections, defaults to all states)
+      datadog:
+        - service: "synthetics" # service name as declared in the provider file (see doc for details)
+          protocol: tcp # optional, protocol to drop packets on (can be tcp or udp, defaults to both)
+          flow: ingress # optional, flow direction (egress: outgoing traffic, ingress: incoming traffic, defaults to egress)
+          connState: new # optional, connection state (new: new connections, est: established connections, defaults to all states)
     drop: 100 # percentage of outgoing packets to drop


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- We'd like to include the private ranges alongside the public ranges. The private ranges don't appear to be published in a static json file, but are listed in documentation in various places:
https://cloud.google.com/vpc/docs/configure-private-google-access#config-options
https://cloud.google.com/vpc/docs/subnets#restricted-ranges
These appear to not change often, so putting them in configuration should be safe.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
