### PR TITLE
CHAOSPLT-580: Send metric when cron or rollout self-deletes

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -59,6 +59,7 @@ data:
       minimumCronFrequency: {{ .Values.controller.minimumCronFrequency }}
       maxDuration: {{ .Values.controller.maxDuration }}
       finalizerDeletionDelay: {{ .Values.controller.finalizerDeletionDelay }}
+      targetResourceMissingThreshold: {{ .Values.controller.targetResourceMissingThreshold }}
       expiredDisruptionGCDelay: {{ .Values.controller.expiredDisruptionGCDelay }}
       userInfoHook: {{ .Values.controller.userInfoHook }}
       webhook:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -69,6 +69,7 @@ controller:
   defaultCronDelayedStartTolerance: 15m
   minimumCronFrequency: 15m # a disruption cron with a spec.schedule that runs more often than this will be rejected.
   finalizerDeletionDelay: 20s
+  targetResourceMissingThreshold: 24h # duration after a cron or rollout self-delete if target is missing for this long
   expiredDisruptionGCDelay: 10m # time after a disruption expires before deleting it
   userInfoHook: true
   webhook: # admission webhook configuration

--- a/chart/values/local.yaml
+++ b/chart/values/local.yaml
@@ -43,6 +43,7 @@ controller:
   defaultDuration: 3m
   finalizerDeletionDelay: 2s
   expiredDisruptionGCDelay: 15s
+  targetResourceMissingThreshold: 1m
   webhook:
     certDir: chart/certs
     host: ""

--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,7 @@ type controllerConfig struct {
 	DisruptionRolloutEnabled         bool                            `json:"disruptionRolloutEnabled" yaml:"disruptionRolloutEnabled"`
 	DisruptionDeletionTimeout        time.Duration                   `json:"disruptionDeletionTimeout" yaml:"disruptionDeletionTimeout"`
 	FinalizerDeletionDelay           time.Duration                   `json:"finalizerDeletionDelay" yaml:"finalizerDeletionDelay"`
+	TargetResourceMissingThreshold   time.Duration                   `json:"targetResourceMissingThreshold" yaml:"targetResourceMissingThreshold"`
 	DisabledDisruptions              []string                        `json:"disabledDisruptions" yaml:"disabledDisruptions"`
 }
 
@@ -560,6 +561,12 @@ func New(client corev1client.ConfigMapInterface, logger *zap.SugaredLogger, osAr
 	mainFS.DurationVar(&cfg.Controller.FinalizerDeletionDelay, "finalizer-deletion-delay", DefaultFinalizerDeletionDelay, "Define a delay before we attempt at removing the finalizers (on disruption and disruptioncron only)")
 
 	if err := viper.BindPFlag("controller.finalizerDeletionDelay", mainFS.Lookup("finalizer-deletion-delay")); err != nil {
+		return cfg, err
+	}
+
+	mainFS.DurationVar(&cfg.Controller.TargetResourceMissingThreshold, "target-resource-missing-threshold", time.Hour*24, "Define the amount of time a cron or rollout will tolerate its target missing before self-deleting")
+
+	if err := viper.BindPFlag("controller.targetResourceMissingThreshold", mainFS.Lookup("target-resource-missing-threshold")); err != nil {
 		return cfg, err
 	}
 

--- a/controllers/cron_rollout_helpers.go
+++ b/controllers/cron_rollout_helpers.go
@@ -25,9 +25,8 @@ import (
 )
 
 const (
-	DisruptionCronNameLabel        = chaosv1beta1.GroupName + "/disruption-cron-name"
-	DisruptionRolloutNameLabel     = chaosv1beta1.GroupName + "/disruption-rollout-name"
-	TargetResourceMissingThreshold = time.Hour * 24
+	DisruptionCronNameLabel    = chaosv1beta1.GroupName + "/disruption-cron-name"
+	DisruptionRolloutNameLabel = chaosv1beta1.GroupName + "/disruption-rollout-name"
 )
 
 // GetChildDisruptions retrieves disruptions associated with a resource by its label.

--- a/controllers/disruption_cron_controller.go
+++ b/controllers/disruption_cron_controller.go
@@ -298,6 +298,8 @@ func (r *DisruptionCronReconciler) handleTargetResourceMissingPastExpiration(ctx
 		return fmt.Errorf("failed to delete instance: %w", err)
 	}
 
+	r.handleMetricSinkError(r.MetricsSink.MetricMissingTargetDeleted(DisruptionCronTags))
+
 	return nil
 }
 

--- a/controllers/disruption_cron_controller.go
+++ b/controllers/disruption_cron_controller.go
@@ -27,12 +27,13 @@ import (
 var DisruptionCronTags = []string{}
 
 type DisruptionCronReconciler struct {
-	Client                 client.Client
-	Scheme                 *runtime.Scheme
-	BaseLog                *zap.SugaredLogger
-	log                    *zap.SugaredLogger
-	MetricsSink            metrics.Sink
-	FinalizerDeletionDelay time.Duration
+	Client                         client.Client
+	Scheme                         *runtime.Scheme
+	BaseLog                        *zap.SugaredLogger
+	log                            *zap.SugaredLogger
+	MetricsSink                    metrics.Sink
+	FinalizerDeletionDelay         time.Duration
+	TargetResourceMissingThreshold time.Duration
 }
 
 func (r *DisruptionCronReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
@@ -260,7 +261,7 @@ func (r *DisruptionCronReconciler) updateTargetResourcePreviouslyMissing(ctx con
 			return targetResourceExists, disruptionCronDeleted, r.handleTargetResourceFirstMissing(ctx, instance)
 		}
 
-		if time.Since(instance.Status.TargetResourcePreviouslyMissing.Time) > TargetResourceMissingThreshold {
+		if time.Since(instance.Status.TargetResourcePreviouslyMissing.Time) > r.TargetResourceMissingThreshold {
 			r.log.Warnw("target has been missing for over one day, deleting this schedule",
 				"timeMissing", time.Since(instance.Status.TargetResourcePreviouslyMissing.Time))
 

--- a/controllers/disruption_rollout_controller.go
+++ b/controllers/disruption_rollout_controller.go
@@ -242,6 +242,8 @@ func (r *DisruptionRolloutReconciler) handleTargetResourceMissingPastExpiration(
 		return fmt.Errorf("failed to delete instance: %w", err)
 	}
 
+	r.handleMetricSinkError(r.MetricsSink.MetricMissingTargetDeleted(DisruptionRolloutTags))
+
 	return nil
 }
 

--- a/controllers/disruption_rollout_controller.go
+++ b/controllers/disruption_rollout_controller.go
@@ -24,11 +24,12 @@ import (
 var DisruptionRolloutTags = []string{}
 
 type DisruptionRolloutReconciler struct {
-	Client      client.Client
-	Scheme      *runtime.Scheme
-	BaseLog     *zap.SugaredLogger
-	log         *zap.SugaredLogger
-	MetricsSink metrics.Sink
+	Client                         client.Client
+	Scheme                         *runtime.Scheme
+	BaseLog                        *zap.SugaredLogger
+	log                            *zap.SugaredLogger
+	MetricsSink                    metrics.Sink
+	TargetResourceMissingThreshold time.Duration
 }
 
 func (r *DisruptionRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
@@ -203,7 +204,7 @@ func (r *DisruptionRolloutReconciler) updateTargetResourcePreviouslyMissing(ctx 
 			return targetResourceExists, disruptionRolloutDeleted, r.handleTargetResourceFirstMissing(ctx, instance)
 		}
 
-		if time.Since(instance.Status.TargetResourcePreviouslyMissing.Time) > TargetResourceMissingThreshold {
+		if time.Since(instance.Status.TargetResourcePreviouslyMissing.Time) > r.TargetResourceMissingThreshold {
 			r.log.Errorw("target has been missing for over one day, deleting this schedule",
 				"timeMissing", time.Since(instance.Status.TargetResourcePreviouslyMissing.Time))
 

--- a/main.go
+++ b/main.go
@@ -322,7 +322,8 @@ func main() {
 			BaseLog: logger,
 			Scheme:  mgr.GetScheme(),
 			// new metrics sink for rollout controller
-			MetricsSink: initMetricsSink(cfg.Controller.MetricsSink, logger, metricstypes.SinkAppRolloutController),
+			MetricsSink:                    initMetricsSink(cfg.Controller.MetricsSink, logger, metricstypes.SinkAppRolloutController),
+			TargetResourceMissingThreshold: cfg.Controller.TargetResourceMissingThreshold,
 		}
 
 		defer closeMetricsSink(logger, disruptionRolloutReconciler.MetricsSink)
@@ -386,8 +387,9 @@ func main() {
 			BaseLog: logger,
 			Scheme:  mgr.GetScheme(),
 			// new metrics sink for cron controller
-			MetricsSink:            initMetricsSink(cfg.Controller.MetricsSink, logger, metricstypes.SinkAppCronController),
-			FinalizerDeletionDelay: cfg.Controller.FinalizerDeletionDelay,
+			MetricsSink:                    initMetricsSink(cfg.Controller.MetricsSink, logger, metricstypes.SinkAppCronController),
+			FinalizerDeletionDelay:         cfg.Controller.FinalizerDeletionDelay,
+			TargetResourceMissingThreshold: cfg.Controller.TargetResourceMissingThreshold,
 		}
 
 		defer closeMetricsSink(logger, disruptionCronReconciler.MetricsSink)

--- a/o11y/metrics/datadog/datadog.go
+++ b/o11y/metrics/datadog/datadog.go
@@ -242,6 +242,12 @@ func (d Sink) MetricMissingTargetFound(tags []string) error {
 	return d.metricWithStatus(d.prefix+"schedule.missing_target_found", tags)
 }
 
+// MetricMissingTargetDeleted reports when a scheduled Disruption has been deleted by the chaos-controller,
+// because its target has been missing for too long
+func (d Sink) MetricMissingTargetDeleted(tags []string) error {
+	return d.metricWithStatus(d.prefix+"schedule.missing_target_deleted", tags)
+}
+
 // MetricNextScheduledTime reports the duration until the next scheduled disruption will run
 func (d Sink) MetricNextScheduledTime(duration time.Duration, tags []string) error {
 	return d.timing(d.prefix+"schedule.next_scheduled", duration, tags)

--- a/o11y/metrics/metrics.go
+++ b/o11y/metrics/metrics.go
@@ -49,6 +49,7 @@ type Sink interface {
 	MetricTooLate(tags []string) error
 	MetricTargetMissing(duration time.Duration, tags []string) error
 	MetricMissingTargetFound(tags []string) error
+	MetricMissingTargetDeleted(tags []string) error
 	MetricNextScheduledTime(time time.Duration, tags []string) error
 	MetricDisruptionScheduled(tags []string) error
 	MetricPausedCron(tags []string) error

--- a/o11y/metrics/noop/noop.go
+++ b/o11y/metrics/noop/noop.go
@@ -234,6 +234,14 @@ func (n Sink) MetricMissingTargetFound(tags []string) error {
 	return nil
 }
 
+// MetricMissingTargetDeleted reports when a scheduled Disruption has been deleted by the chaos-controller,
+// because its target has been missing for too long
+func (n Sink) MetricMissingTargetDeleted(tags []string) error {
+	n.log.Debugf("NOOP: MetricMissingTargetDeleted %s\n", tags)
+
+	return nil
+}
+
 // MetricNextScheduledTime reports the duration until the next scheduled disruption will run
 func (n Sink) MetricNextScheduledTime(duration time.Duration, tags []string) error {
 	n.log.Debugf("NOOP: MetricNextScheduledRun %v, s%s\n", duration, tags)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Allows for configuring the 24h "target missing" threshold for crons or rollouts
- Sends a metric when a cron or rollout is deleted because its target has been missing for too long

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
