### PR TITLE
Remove unused selector cache from old dynamic targeting implementation

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -70,19 +70,12 @@ type DisruptionReconciler struct {
 	log                        *zap.SugaredLogger
 	SafetyNets                 []safemode.Safemode
 	ExpiredDisruptionGCDelay   *time.Duration
-	CacheContextStore          map[string]CtxTuple
 	DisruptionsWatchersManager watchers.DisruptionsWatchersManager
 	ChaosPodService            services.ChaosPodService
 	CloudService               cloudservice.CloudServicesProvidersManager
 	DisruptionsDeletionTimeout time.Duration
 	DeleteOnly                 bool
 	FinalizerDeletionDelay     time.Duration
-}
-
-type CtxTuple struct {
-	Ctx                      context.Context
-	CancelFunc               context.CancelFunc
-	DisruptionNamespacedName types.NamespacedName
 }
 
 const TargetsCountLogLimit = 50
@@ -1094,10 +1087,6 @@ func (r *DisruptionReconciler) ReportMetrics(ctx context.Context) {
 
 		if err := r.MetricsSink.MetricPodsGauge(float64(chaosPodsCount)); err != nil {
 			r.BaseLog.Errorw("error sending pods.gauge metric", "error", err)
-		}
-
-		if err := r.MetricsSink.MetricSelectorCacheGauge(float64(len(r.CacheContextStore))); err != nil {
-			r.BaseLog.Errorw("error sending selector.cache.gauge metric", "error", err)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -225,7 +225,6 @@ func main() {
 		TracerSink:                 tracerSink,
 		TargetSelector:             targetSelector,
 		ExpiredDisruptionGCDelay:   gcPtr,
-		CacheContextStore:          make(map[string]controllers.CtxTuple),
 		ChaosPodService:            chaosPodService,
 		CloudService:               cloudProviderManager,
 		DisruptionsDeletionTimeout: cfg.Controller.DisruptionDeletionTimeout,
@@ -457,13 +456,6 @@ func main() {
 	// for safety purposes: as long as no event is emitted and mgr.Start(ctx.Context) isn't
 	// called, the broadcaster isn't actually initiated
 	defer broadcaster.Shutdown()
-
-	// erase/close caches contexts
-	defer func() {
-		for _, contextTuple := range disruptionReconciler.CacheContextStore {
-			contextTuple.CancelFunc()
-		}
-	}()
 
 	// +kubebuilder:scaffold:builder
 

--- a/o11y/metrics/datadog/datadog.go
+++ b/o11y/metrics/datadog/datadog.go
@@ -219,11 +219,6 @@ func (d Sink) MetricWatcherCalls(tags []string) error {
 	return d.metricWithStatus(d.prefix+"watcher.calls_total", tags)
 }
 
-// MetricSelectorCacheGauge reports how many caches are still in the cache array to prevent leaks
-func (d Sink) MetricSelectorCacheGauge(gauge float64) error {
-	return d.client.Gauge(d.prefix+"selector.cache.gauge", gauge, []string{}, 1)
-}
-
 // MetricTooLate reports when a scheduled disruption misses its aloted time to be scheduled
 // specific to cron and rollout controllers
 func (d Sink) MetricTooLate(tags []string) error {

--- a/o11y/metrics/metrics.go
+++ b/o11y/metrics/metrics.go
@@ -36,7 +36,6 @@ type Sink interface {
 	MetricStuckOnRemovalGauge(gauge float64) error
 	MetricDisruptionsGauge(gauge float64, tags []string) error
 	MetricDisruptionsCount(kind chaostypes.DisruptionKindName, tags []string) error
-	MetricSelectorCacheGauge(gauge float64) error
 	MetricWatcherCalls(tags []string) error
 	MetricPodsGauge(gauge float64) error
 	MetricRestart() error

--- a/o11y/metrics/noop/noop.go
+++ b/o11y/metrics/noop/noop.go
@@ -203,13 +203,6 @@ func (n Sink) MetricWatcherCalls(tags []string) error {
 	return nil
 }
 
-// MetricSelectorCacheGauge reports how many caches are still in the cache array to prevent leaks
-func (n Sink) MetricSelectorCacheGauge(gauge float64) error {
-	n.log.Debugf("NOOP: MetricSelectorCacheGauge %f\n", gauge)
-
-	return nil
-}
-
 // MetricTooLate reports when a scheduled disruption misses its aloted time to be scheduled
 // specific to cron and rollout controllers
 func (n Sink) MetricTooLate(tags []string) error {

--- a/o11y/metrics/sink_mock.go
+++ b/o11y/metrics/sink_mock.go
@@ -1191,52 +1191,6 @@ func (_c *SinkMock_MetricRestart_Call) RunAndReturn(run func() error) *SinkMock_
 	return _c
 }
 
-// MetricSelectorCacheGauge provides a mock function with given fields: gauge
-func (_m *SinkMock) MetricSelectorCacheGauge(gauge float64) error {
-	ret := _m.Called(gauge)
-
-	if len(ret) == 0 {
-		panic("no return value specified for MetricSelectorCacheGauge")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(float64) error); ok {
-		r0 = rf(gauge)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// SinkMock_MetricSelectorCacheGauge_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MetricSelectorCacheGauge'
-type SinkMock_MetricSelectorCacheGauge_Call struct {
-	*mock.Call
-}
-
-// MetricSelectorCacheGauge is a helper method to define mock.On call
-//   - gauge float64
-func (_e *SinkMock_Expecter) MetricSelectorCacheGauge(gauge interface{}) *SinkMock_MetricSelectorCacheGauge_Call {
-	return &SinkMock_MetricSelectorCacheGauge_Call{Call: _e.mock.On("MetricSelectorCacheGauge", gauge)}
-}
-
-func (_c *SinkMock_MetricSelectorCacheGauge_Call) Run(run func(gauge float64)) *SinkMock_MetricSelectorCacheGauge_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(float64))
-	})
-	return _c
-}
-
-func (_c *SinkMock_MetricSelectorCacheGauge_Call) Return(_a0 error) *SinkMock_MetricSelectorCacheGauge_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *SinkMock_MetricSelectorCacheGauge_Call) RunAndReturn(run func(float64) error) *SinkMock_MetricSelectorCacheGauge_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // MetricStuckOnRemoval provides a mock function with given fields: tags
 func (_m *SinkMock) MetricStuckOnRemoval(tags []string) error {
 	ret := _m.Called(tags)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- While looking at our metrics, I went to see what the selector cache metric was for. I found that this cache and metric was added in #523. The functionality is now handled differently, thanks to the watchers from #681. However, this map and metric remain. We don't ever fill this map. We don't ever read from this map. I've checked our use of this metric, and it's consistently zero, which matches the expectation that we aren't using this map. I've removed all this code

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [x] as a canary deployment to a cluster.
