### PR TITLE
defer validationFailed so that we always send it correctly

### DIFF
--- a/api/v1beta1/disruption_cron_types.go
+++ b/api/v1beta1/disruption_cron_types.go
@@ -6,7 +6,10 @@
 package v1beta1
 
 import (
+	"fmt"
 	"time"
+
+	"github.com/DataDog/chaos-controller/log"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -107,4 +110,14 @@ type DisruptionCronTrigger struct {
 // IsReadyToRemoveFinalizer checks if adisruptioncron has been deleting for > finalizerDelay
 func (d *DisruptionCron) IsReadyToRemoveFinalizer(finalizerDelay time.Duration) bool {
 	return d.DeletionTimestamp != nil && time.Now().After(d.DeletionTimestamp.Add(finalizerDelay))
+}
+
+// getMetricsTags parses the disruptioncron to generate metrics tags
+func (d *DisruptionCron) getMetricsTags() []string {
+	tags := []string{
+		fmt.Sprintf("%s:%s", log.DisruptionCronNameKey, d.Name),
+		fmt.Sprintf("%s:%s", log.DisruptionCronNamespaceKey, d.Namespace),
+	}
+
+	return tags
 }

--- a/api/v1beta1/disruption_cron_webhook_test.go
+++ b/api/v1beta1/disruption_cron_webhook_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DataDog/chaos-controller/mocks"
+	metricsnoop "github.com/DataDog/chaos-controller/o11y/metrics/noop"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap/zaptest"
 	authV1 "k8s.io/api/authentication/v1"
@@ -29,6 +30,7 @@ var _ = Describe("DisruptionCron Webhook", func() {
 
 	BeforeEach(func() {
 		disruptionCronWebhookLogger = zaptest.NewLogger(GinkgoT()).Sugar()
+		disruptionCronMetricsSink = metricsnoop.New(disruptionCronWebhookLogger)
 		defaultUserGroups = map[string]struct{}{
 			"group1": {},
 			"group2": {},

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -116,6 +116,7 @@ func (r *Disruption) ValidateCreate() (_ admission.Warnings, err error) {
 	log := logger.With(cLog.DisruptionNameKey, r.Name, cLog.DisruptionNamespaceKey, r.Namespace)
 
 	metricTags := r.getMetricsTags()
+
 	defer func() {
 		if err != nil {
 			if mErr := metricsSink.MetricValidationFailed(metricTags); mErr != nil {
@@ -270,6 +271,7 @@ func (r *Disruption) ValidateUpdate(old runtime.Object) (_ admission.Warnings, e
 	log.Debugw("validating updated disruption", "spec", r.Spec)
 
 	metricTags := r.getMetricsTags()
+
 	defer func() {
 		if err != nil {
 			if mErr := metricsSink.MetricValidationFailed(metricTags); mErr != nil {

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -372,8 +372,8 @@ func (r *Disruption) ValidateDelete() (admission.Warnings, error) {
 // getMetricsTags parses the disruption to generate metrics tags
 func (r *Disruption) getMetricsTags() []string {
 	tags := []string{
-		"disruptionName:" + r.Name,
-		"namespace:" + r.Namespace,
+		fmt.Sprintf("%s:%s", cLog.DisruptionNameKey, r.Name),
+		fmt.Sprintf("%s:%s", cLog.DisruptionNamespaceKey, r.Namespace),
 	}
 
 	if userInfo, err := r.UserInfo(); !errors.Is(err, ErrNoUserInfo) {

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -112,8 +112,17 @@ func (r *Disruption) Default() {
 var _ webhook.Validator = &Disruption{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *Disruption) ValidateCreate() (admission.Warnings, error) {
+func (r *Disruption) ValidateCreate() (_ admission.Warnings, err error) {
 	log := logger.With(cLog.DisruptionNameKey, r.Name, cLog.DisruptionNamespaceKey, r.Namespace)
+
+	metricTags := r.getMetricsTags()
+	defer func() {
+		if err != nil {
+			if mErr := metricsSink.MetricValidationFailed(metricTags); mErr != nil {
+				log.Errorw("error sending a metric", "error", mErr)
+			}
+		}
+	}()
 
 	ctx, err := r.SpanContext(context.Background())
 	if err != nil {
@@ -196,11 +205,7 @@ func (r *Disruption) ValidateCreate() (admission.Warnings, error) {
 		}
 	}
 
-	if err := r.Spec.Validate(); err != nil {
-		if mErr := metricsSink.MetricValidationFailed(r.getMetricsTags()); mErr != nil {
-			log.Errorw("error sending a metric", "error", mErr)
-		}
-
+	if err = r.Spec.Validate(); err != nil {
 		return nil, err
 	}
 
@@ -260,15 +265,22 @@ func (r *Disruption) ValidateCreate() (admission.Warnings, error) {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *Disruption) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+func (r *Disruption) ValidateUpdate(old runtime.Object) (_ admission.Warnings, err error) {
 	log := logger.With(cLog.DisruptionNameKey, r.Name, cLog.DisruptionNamespaceKey, r.Namespace)
 	log.Debugw("validating updated disruption", "spec", r.Spec)
 
-	var err error
+	metricTags := r.getMetricsTags()
+	defer func() {
+		if err != nil {
+			if mErr := metricsSink.MetricValidationFailed(metricTags); mErr != nil {
+				log.Errorw("error sending a metric", "error", mErr)
+			}
+		}
+	}()
 
 	oldDisruption := old.(*Disruption)
 
-	if err := validateUserInfoImmutable(oldDisruption, r); err != nil {
+	if err = validateUserInfoImmutable(oldDisruption, r); err != nil {
 		return nil, err
 	}
 
@@ -287,10 +299,7 @@ func (r *Disruption) ValidateUpdate(old runtime.Object) (admission.Warnings, err
 				oldPodsInfos = append(oldPodsInfos, fmt.Sprintf("%s/%s", oldPod.Namespace, oldPod.Name))
 			}
 
-			metricTags := append(r.getMetricsTags(), "prevent_finalizer_removal:true")
-			if mErr := metricsSink.MetricValidationFailed(metricTags); mErr != nil {
-				log.Errorw("error sending a metric", "error", mErr)
-			}
+			metricTags = append(metricTags, "prevent_finalizer_removal:true")
 
 			return nil, fmt.Errorf(`unable to remove disruption finalizer, disruption '%s/%s' still has associated pods:
 - %s
@@ -337,10 +346,6 @@ You first need to remove those chaos pods (and potentially their finalizers) to 
 	}
 
 	if err := r.Spec.Validate(); err != nil {
-		if mErr := metricsSink.MetricValidationFailed(r.getMetricsTags()); mErr != nil {
-			log.Errorw("error sending a metric", "error", mErr)
-		}
-
 		return nil, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -382,6 +382,8 @@ func main() {
 		disruptionCronRecorder := broadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: chaosv1beta1.SourceDisruptionCronComponent})
 		disruptionCronMetricsSink := initMetricsSink(cfg.Controller.MetricsSink, logger, metricstypes.SinkAppCronController)
 
+		defer closeMetricsSink(logger, disruptionCronMetricsSink)
+
 		// create disruption cron reconciler
 		disruptionCronReconciler := &controllers.DisruptionCronReconciler{
 			Client:  mgr.GetClient(),

--- a/main.go
+++ b/main.go
@@ -380,6 +380,7 @@ func main() {
 
 	if cfg.Controller.DisruptionCronEnabled {
 		disruptionCronRecorder := broadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: chaosv1beta1.SourceDisruptionCronComponent})
+		disruptionCronMetricsSink := initMetricsSink(cfg.Controller.MetricsSink, logger, metricstypes.SinkAppCronController)
 
 		// create disruption cron reconciler
 		disruptionCronReconciler := &controllers.DisruptionCronReconciler{
@@ -387,7 +388,7 @@ func main() {
 			BaseLog: logger,
 			Scheme:  mgr.GetScheme(),
 			// new metrics sink for cron controller
-			MetricsSink:                    initMetricsSink(cfg.Controller.MetricsSink, logger, metricstypes.SinkAppCronController),
+			MetricsSink:                    disruptionCronMetricsSink,
 			FinalizerDeletionDelay:         cfg.Controller.FinalizerDeletionDelay,
 			TargetResourceMissingThreshold: cfg.Controller.TargetResourceMissingThreshold,
 		}
@@ -408,6 +409,7 @@ func main() {
 			DefaultCronDelayedStartTolerance: cfg.Controller.DefaultCronDelayedStartTolerance,
 			MinimumCronFrequency:             cfg.Controller.MinimumCronFrequency,
 			DefaultDurationFlag:              cfg.Controller.DefaultDuration,
+			MetricsSink:                      disruptionCronMetricsSink,
 		}
 
 		if err = (&chaosv1beta1.DisruptionCron{}).SetupWebhookWithManager(disruptionCronSetupWebhookConfig); err != nil {


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- As noticed in #955, we don't consistently emit this metric on a failed validation, only in specific cases. I'm changing that here, so that anytime validations fails, i.e., returns an error, we try to send this metric

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [x] as a canary deployment to a cluster.
