### PR TITLE
Explain shouldn't panic on invalid specs

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -887,11 +887,13 @@ func (s DisruptionSpec) DisruptionCount() int {
 func (s DisruptionSpec) Explain() []string {
 	if err := s.Validate(); err != nil {
 		retErr := []string{"We were not able to explain this spec as it is not valid."}
+
 		if merr, ok := err.(*multierror.Error); ok {
 			for _, e := range merr.Errors {
 				retErr = append(retErr, e.Error())
 			}
 		}
+
 		return retErr
 	}
 

--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -885,6 +885,16 @@ func (s DisruptionSpec) DisruptionCount() int {
 
 // Explain returns a string explanation of this disruption spec
 func (s DisruptionSpec) Explain() []string {
+	if err := s.Validate(); err != nil {
+		retErr := []string{"We were not able to explain this spec as it is not valid."}
+		if merr, ok := err.(*multierror.Error); ok {
+			for _, e := range merr.Errors {
+				retErr = append(retErr, e.Error())
+			}
+		}
+		return retErr
+	}
+
 	var explanation []string
 	explanation = append(explanation, "Here's our best explanation of what this spec will do when run:")
 


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- We assume that Explain is taking a valid spec, but it will panic if the spec is invalid. Rather than making checks all over the Explain code, we just start by validating

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
