### PR TITLE
Explain feature should not require selectors

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -885,7 +885,7 @@ func (s DisruptionSpec) DisruptionCount() int {
 
 // Explain returns a string explanation of this disruption spec
 func (s DisruptionSpec) Explain() []string {
-	if err := s.Validate(); err != nil {
+	if err := s.ValidateSelectorsOptional(false); err != nil {
 		retErr := []string{"We were not able to explain this spec as it is not valid."}
 
 		if merr, ok := err.(*multierror.Error); ok {


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- The Explain feature should work for specs without selectors, just as Validate can

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
