### PR TITLE
Replace FW Filters with Flower filters

### DIFF
--- a/injector/network_disruption.go
+++ b/injector/network_disruption.go
@@ -490,8 +490,8 @@ func (i *networkDisruptionInjector) applyOperations() error {
 				return fmt.Errorf("could not update the configuration of the bpf-network-tc-filter filter: %w", err)
 			}
 
-			// create fw filter to classify packets based on their mark
-			if err := i.config.TrafficController.AddFwFilter(interfaces, "4:0", types.InjectorCgroupClassID, "4:2"); err != nil {
+			// create flower filter to classify packets based on their mark
+			if err := i.config.TrafficController.AddFlowerFilter(interfaces, "4:0", types.InjectorCgroupClassID, "4:2"); err != nil {
 				return fmt.Errorf("can't create the fw filter: %w", err)
 			}
 
@@ -505,8 +505,8 @@ func (i *networkDisruptionInjector) applyOperations() error {
 				return fmt.Errorf("can't create a new qdisc: %w", err)
 			}
 
-			// create fw filter to classify packets based on their mark
-			if err := i.config.TrafficController.AddFwFilter(interfaces, "2:0", types.InjectorCgroupClassID, "2:2"); err != nil {
+			// create flower filter to classify packets based on their mark
+			if err := i.config.TrafficController.AddFlowerFilter(interfaces, "2:0", types.InjectorCgroupClassID, "2:2"); err != nil {
 				return fmt.Errorf("can't create the fw filter: %w", err)
 			}
 			// parent 2:2 refers to the 2nd band of the 2nd prio qdisc

--- a/injector/network_disruption_test.go
+++ b/injector/network_disruption_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Failure", func() {
 		tc.EXPECT().AddNetem(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tc.EXPECT().AddPrio(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tc.EXPECT().AddFilter(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil).Maybe()
-		tc.EXPECT().AddFwFilter(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		tc.EXPECT().AddFlowerFilter(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tc.EXPECT().AddOutputLimit(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tc.EXPECT().DeleteFilter(mock.Anything, mock.Anything).Return(nil).Maybe()
 		tc.EXPECT().ClearQdisc(mock.Anything).Return(nil).Maybe()
@@ -294,7 +294,7 @@ var _ = Describe("Failure", func() {
 		})
 
 		It("should add an fw filter to classify packets according to their classid set by iptables mark", func() {
-			tc.AssertCalled(GinkgoT(), "AddFwFilter", []string{"lo", "eth0", "eth1"}, "2:0", "0x00020002", "2:2")
+			tc.AssertCalled(GinkgoT(), "AddFlowerFilter", []string{"lo", "eth0", "eth1"}, "2:0", "0x00020002", "2:2")
 		})
 
 		It("should apply disruptions to main interfaces 2nd band", func() {
@@ -720,7 +720,7 @@ var _ = Describe("Failure", func() {
 					tc.AssertCalled(GinkgoT(), "AddPrio", interfaces, "3:2", "4:", uint32(2), mock.Anything)
 
 					By("adding an fw filter to classify packets according to their classid set by iptables mark")
-					tc.AssertCalled(GinkgoT(), "AddFwFilter", interfaces, "4:0", "0x00020002", "4:2")
+					tc.AssertCalled(GinkgoT(), "AddFlowerFilter", interfaces, "4:0", "0x00020002", "4:2")
 
 					By("adding an BPF filter to classify packets according to their method")
 					tc.AssertCalled(GinkgoT(), "AddBPFFilter", interfaces, "2:0", "/usr/local/bin/bpf-network-tc-filter.bpf.o", "2:2", "classifier_methods")

--- a/network/tc.go
+++ b/network/tc.go
@@ -62,7 +62,6 @@ type TrafficController interface {
 	AddFilter(ifaces []string, parent string, handle string, srcIP, dstIP *net.IPNet, srcPort, dstPort int, prot protocol, state connState, flowid string) (uint32, error)
 	DeleteFilter(iface string, priority uint32) error
 	AddFlowerFilter(ifaces []string, parent string, handle string, flowid string) error
-	AddFwFilter(ifaces []string, parent string, handle string, flowid string) error
 	AddBPFFilter(ifaces []string, parent string, obj string, flowid string, section string) error
 	ConfigBPFFilter(cmd executor, args ...string) error
 	AddOutputLimit(ifaces []string, parent string, handle string, bytesPerSec uint) error
@@ -247,17 +246,6 @@ func (t *tc) AddBPFFilter(ifaces []string, parent string, obj string, flowid str
 func (t *tc) DeleteFilter(iface string, priority uint32) error {
 	if _, _, err := t.executer.Run([]string{"filter", "delete", "dev", iface, "priority", fmt.Sprintf("%d", priority)}); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-// AddFwFilter generates a tc filter of kind "fw"
-func (t *tc) AddFwFilter(ifaces []string, parent string, handle string, flowid string) error {
-	for _, iface := range ifaces {
-		if _, _, err := t.executer.Run(buildCmd("filter", iface, parent, "ip", 0, handle, "fw", "flowid "+flowid)); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/network/tc.go
+++ b/network/tc.go
@@ -61,6 +61,7 @@ type TrafficController interface {
 	AddPrio(ifaces []string, parent string, handle string, bands uint32, priomap [16]uint32) error
 	AddFilter(ifaces []string, parent string, handle string, srcIP, dstIP *net.IPNet, srcPort, dstPort int, prot protocol, state connState, flowid string) (uint32, error)
 	DeleteFilter(iface string, priority uint32) error
+	AddFlowerFilter(ifaces []string, parent string, handle string, flowid string) error
 	AddFwFilter(ifaces []string, parent string, handle string, flowid string) error
 	AddBPFFilter(ifaces []string, parent string, obj string, flowid string, section string) error
 	ConfigBPFFilter(cmd executor, args ...string) error
@@ -251,10 +252,21 @@ func (t *tc) DeleteFilter(iface string, priority uint32) error {
 	return nil
 }
 
-// AddFwFilter generates a cgroup filter
+// AddFwFilter generates a tc filter of kind "fw"
 func (t *tc) AddFwFilter(ifaces []string, parent string, handle string, flowid string) error {
 	for _, iface := range ifaces {
 		if _, _, err := t.executer.Run(buildCmd("filter", iface, parent, "ip", 0, handle, "fw", "flowid "+flowid)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// AddFlowerFilter generates a tc filter of kind "flower"
+func (t *tc) AddFlowerFilter(ifaces []string, parent string, handle string, flowid string) error {
+	for _, iface := range ifaces {
+		if _, _, err := t.executer.Run(buildCmd("filter", iface, parent, "ip", 0, handle, "flower", "flowid "+flowid)); err != nil {
 			return err
 		}
 	}

--- a/network/tc_test.go
+++ b/network/tc_test.go
@@ -212,18 +212,6 @@ var _ = Describe("Tc", func() {
 		})
 	})
 
-	Describe("AddFwFilter", func() {
-		JustBeforeEach(func() {
-			Expect(tcRunner.AddFwFilter(ifaces, parent, handle, flowid)).Should(Succeed())
-		})
-
-		Context("add a cgroup filter", func() {
-			It("should execute", func() {
-				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"filter", "add", "dev", "lo", "protocol", "ip", "root", "fw", "flowid", "1:2"})
-			})
-		})
-	})
-
 	Describe("AddFlowerFilter", func() {
 		JustBeforeEach(func() {
 			Expect(tcRunner.AddFlowerFilter(ifaces, parent, handle, flowid)).Should(Succeed())

--- a/network/tc_test.go
+++ b/network/tc_test.go
@@ -224,6 +224,18 @@ var _ = Describe("Tc", func() {
 		})
 	})
 
+	Describe("AddFlowerFilter", func() {
+		JustBeforeEach(func() {
+			Expect(tcRunner.AddFlowerFilter(ifaces, parent, handle, flowid)).Should(Succeed())
+		})
+
+		Context("add a cgroup filter", func() {
+			It("should execute", func() {
+				tcExecuter.AssertCalled(GinkgoT(), "Run", []string{"filter", "add", "dev", "lo", "protocol", "ip", "root", "flower", "flowid", "1:2"})
+			})
+		})
+	})
+
 	Describe("AddOutputLimit", func() {
 		JustBeforeEach(func() {
 			Expect(tcRunner.AddOutputLimit(ifaces, parent, handle, 12345)).Should(Succeed())

--- a/network/traffic_controller_mock.go
+++ b/network/traffic_controller_mock.go
@@ -142,6 +142,55 @@ func (_c *TrafficControllerMock_AddFilter_Call) RunAndReturn(run func([]string, 
 	return _c
 }
 
+// AddFlowerFilter provides a mock function with given fields: ifaces, parent, handle, flowid
+func (_m *TrafficControllerMock) AddFlowerFilter(ifaces []string, parent string, handle string, flowid string) error {
+	ret := _m.Called(ifaces, parent, handle, flowid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddFlowerFilter")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]string, string, string, string) error); ok {
+		r0 = rf(ifaces, parent, handle, flowid)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// TrafficControllerMock_AddFlowerFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddFlowerFilter'
+type TrafficControllerMock_AddFlowerFilter_Call struct {
+	*mock.Call
+}
+
+// AddFlowerFilter is a helper method to define mock.On call
+//   - ifaces []string
+//   - parent string
+//   - handle string
+//   - flowid string
+func (_e *TrafficControllerMock_Expecter) AddFlowerFilter(ifaces interface{}, parent interface{}, handle interface{}, flowid interface{}) *TrafficControllerMock_AddFlowerFilter_Call {
+	return &TrafficControllerMock_AddFlowerFilter_Call{Call: _e.mock.On("AddFlowerFilter", ifaces, parent, handle, flowid)}
+}
+
+func (_c *TrafficControllerMock_AddFlowerFilter_Call) Run(run func(ifaces []string, parent string, handle string, flowid string)) *TrafficControllerMock_AddFlowerFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]string), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *TrafficControllerMock_AddFlowerFilter_Call) Return(_a0 error) *TrafficControllerMock_AddFlowerFilter_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *TrafficControllerMock_AddFlowerFilter_Call) RunAndReturn(run func([]string, string, string, string) error) *TrafficControllerMock_AddFlowerFilter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AddFwFilter provides a mock function with given fields: ifaces, parent, handle, flowid
 func (_m *TrafficControllerMock) AddFwFilter(ifaces []string, parent string, handle string, flowid string) error {
 	ret := _m.Called(ifaces, parent, handle, flowid)

--- a/network/traffic_controller_mock.go
+++ b/network/traffic_controller_mock.go
@@ -191,55 +191,6 @@ func (_c *TrafficControllerMock_AddFlowerFilter_Call) RunAndReturn(run func([]st
 	return _c
 }
 
-// AddFwFilter provides a mock function with given fields: ifaces, parent, handle, flowid
-func (_m *TrafficControllerMock) AddFwFilter(ifaces []string, parent string, handle string, flowid string) error {
-	ret := _m.Called(ifaces, parent, handle, flowid)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AddFwFilter")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func([]string, string, string, string) error); ok {
-		r0 = rf(ifaces, parent, handle, flowid)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// TrafficControllerMock_AddFwFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddFwFilter'
-type TrafficControllerMock_AddFwFilter_Call struct {
-	*mock.Call
-}
-
-// AddFwFilter is a helper method to define mock.On call
-//   - ifaces []string
-//   - parent string
-//   - handle string
-//   - flowid string
-func (_e *TrafficControllerMock_Expecter) AddFwFilter(ifaces interface{}, parent interface{}, handle interface{}, flowid interface{}) *TrafficControllerMock_AddFwFilter_Call {
-	return &TrafficControllerMock_AddFwFilter_Call{Call: _e.mock.On("AddFwFilter", ifaces, parent, handle, flowid)}
-}
-
-func (_c *TrafficControllerMock_AddFwFilter_Call) Run(run func(ifaces []string, parent string, handle string, flowid string)) *TrafficControllerMock_AddFwFilter_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]string), args[1].(string), args[2].(string), args[3].(string))
-	})
-	return _c
-}
-
-func (_c *TrafficControllerMock_AddFwFilter_Call) Return(_a0 error) *TrafficControllerMock_AddFwFilter_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *TrafficControllerMock_AddFwFilter_Call) RunAndReturn(run func([]string, string, string, string) error) *TrafficControllerMock_AddFwFilter_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // AddNetem provides a mock function with given fields: ifaces, parent, handle, delay, delayJitter, drop, corrupt, duplicate
 func (_m *TrafficControllerMock) AddNetem(ifaces []string, parent string, handle string, delay time.Duration, delayJitter time.Duration, drop int, corrupt int, duplicate int) error {
 	ret := _m.Called(ifaces, parent, handle, delay, delayJitter, drop, corrupt, duplicate)


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Replaces our `fw` tc filters with `flower` tc filters, as we're seeing more consistent behavior from them

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
