### PR TITLE
Add validation metrics

### DIFF
--- a/api/v1beta1/disruption_cron_webhook.go
+++ b/api/v1beta1/disruption_cron_webhook.go
@@ -121,6 +121,11 @@ func (d *DisruptionCron) ValidateCreate() (_ admission.Warnings, err error) {
 		return nil, err
 	}
 
+	// send validation metric
+	if err := metricsSink.MetricValidationCreated(metricTags); err != nil {
+		log.Errorw("error sending a metric", "error", err)
+	}
+
 	// send informative event to disruption cron to broadcast
 	d.emitEvent(EventDisruptionCronCreated)
 
@@ -163,6 +168,11 @@ func (d *DisruptionCron) ValidateUpdate(oldObject runtime.Object) (_ admission.W
 		}
 	}
 
+	// send validation metric
+	if err := metricsSink.MetricValidationUpdated(metricTags); err != nil {
+		log.Errorw("error sending a metric", "error", err)
+	}
+
 	// send informative event to disruption cron to broadcast
 	d.emitEvent(EventDisruptionCronUpdated)
 
@@ -176,6 +186,11 @@ func (d *DisruptionCron) ValidateDelete() (warnings admission.Warnings, err erro
 
 	// During the validation of the deletion the timestamp does not exist so we need to set it before emitting the event
 	d.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+	// send validation metric
+	if err := metricsSink.MetricValidationDeleted(d.getMetricsTags()); err != nil {
+		log.Errorw("error sending a metric", "error", err)
+	}
 
 	// send informative event to disruption cron to broadcast
 	d.emitEvent(EventDisruptionCronDeleted)

--- a/api/v1beta1/disruption_cron_webhook.go
+++ b/api/v1beta1/disruption_cron_webhook.go
@@ -121,7 +121,6 @@ func (d *DisruptionCron) ValidateCreate() (_ admission.Warnings, err error) {
 		return nil, err
 	}
 
-	// send validation metric
 	if err := metricsSink.MetricValidationCreated(metricTags); err != nil {
 		log.Errorw("error sending a metric", "error", err)
 	}
@@ -168,7 +167,6 @@ func (d *DisruptionCron) ValidateUpdate(oldObject runtime.Object) (_ admission.W
 		}
 	}
 
-	// send validation metric
 	if err := metricsSink.MetricValidationUpdated(metricTags); err != nil {
 		log.Errorw("error sending a metric", "error", err)
 	}
@@ -187,7 +185,6 @@ func (d *DisruptionCron) ValidateDelete() (warnings admission.Warnings, err erro
 	// During the validation of the deletion the timestamp does not exist so we need to set it before emitting the event
 	d.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 
-	// send validation metric
 	if err := metricsSink.MetricValidationDeleted(d.getMetricsTags()); err != nil {
 		log.Errorw("error sending a metric", "error", err)
 	}


### PR DESCRIPTION
## What does this PR do?

Adds the three validation metrics to disruptioncrons.

- [x] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Adds metrics when disruption crons validate

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.
