### PR TITLE
CHAOSPLT-643: Send event directly to user if DisruptionCron lacks a target

### DIFF
--- a/api/v1beta1/disruption_cron_types.go
+++ b/api/v1beta1/disruption_cron_types.go
@@ -86,6 +86,10 @@ type TargetResourceSpec struct {
 	Name string `json:"name"`
 }
 
+func (trs TargetResourceSpec) String() string {
+	return fmt.Sprintf("%s/%s", trs.Kind, trs.Name)
+}
+
 // DisruptionCronStatus defines the observed state of DisruptionCron
 type DisruptionCronStatus struct {
 	// The last time when the disruption was last successfully scheduled.

--- a/api/v1beta1/events.go
+++ b/api/v1beta1/events.go
@@ -86,9 +86,10 @@ const (
 	EventDisrupted                 EventReason = "Disrupted"
 
 	// DisruptionCron related events
-	EventDisruptionCronCreated EventReason = "DisruptionCronCreated"
-	EventDisruptionCronUpdated EventReason = "DisruptionCronUpdated"
-	EventDisruptionCronDeleted EventReason = "DisruptionCronDeleted"
+	EventDisruptionCronCreated       EventReason = "DisruptionCronCreated"
+	EventDisruptionCronUpdated       EventReason = "DisruptionCronUpdated"
+	EventDisruptionCronDeleted       EventReason = "DisruptionCronDeleted"
+	EventDisruptionCronTargetMissing EventReason = "DisruptionCronTargetMissing"
 
 	// Injection related events
 	// Warning events
@@ -272,6 +273,12 @@ var Events = map[EventReason]Event{
 		Type:                        corev1.EventTypeNormal,
 		Reason:                      EventDisruptionCronDeleted,
 		OnDisruptionTemplateMessage: "DisruptionCron deleted",
+		Category:                    DisruptionCronEvent,
+	},
+	EventDisruptionCronTargetMissing: {
+		Type:                        corev1.EventTypeWarning,
+		Reason:                      EventDisruptionCronTargetMissing,
+		OnDisruptionTemplateMessage: "DisruptionCron target cannot be found, we are unable to launch disruptions",
 		Category:                    DisruptionCronEvent,
 	},
 	EventDisruptionCleaned: {

--- a/api/v1beta1/events.go
+++ b/api/v1beta1/events.go
@@ -278,7 +278,7 @@ var Events = map[EventReason]Event{
 	EventDisruptionCronTargetMissing: {
 		Type:                        corev1.EventTypeWarning,
 		Reason:                      EventDisruptionCronTargetMissing,
-		OnDisruptionTemplateMessage: "DisruptionCron target cannot be found, we are unable to launch disruptions",
+		OnDisruptionTemplateMessage: "DisruptionCron is unable to launch a disruption, because %s",
 		Category:                    DisruptionCronEvent,
 	},
 	EventDisruptionCleaned: {

--- a/controllers/disruption_cron_controller.go
+++ b/controllers/disruption_cron_controller.go
@@ -377,5 +377,4 @@ func (r *DisruptionCronReconciler) recordEventOnDisruptionCron(instance *chaosv1
 	}
 
 	r.Recorder.Event(instance, disEvent.Type, string(disEvent.Reason), message)
-
 }

--- a/controllers/disruption_cron_controller.go
+++ b/controllers/disruption_cron_controller.go
@@ -14,12 +14,12 @@ import (
 	cLog "github.com/DataDog/chaos-controller/log"
 	"github.com/DataDog/chaos-controller/o11y/metrics"
 	chaostypes "github.com/DataDog/chaos-controller/types"
-	"k8s.io/client-go/tools/record"
 
 	"github.com/robfig/cron"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"

--- a/main.go
+++ b/main.go
@@ -388,7 +388,8 @@ func main() {
 			Client:  mgr.GetClient(),
 			BaseLog: logger,
 			Scheme:  mgr.GetScheme(),
-			// new metrics sink for cron controller
+			// separate metrics sink and recorder for cron controller
+			Recorder:                       disruptionCronRecorder,
 			MetricsSink:                    disruptionCronMetricsSink,
 			FinalizerDeletionDelay:         cfg.Controller.FinalizerDeletionDelay,
 			TargetResourceMissingThreshold: cfg.Controller.TargetResourceMissingThreshold,


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Metrics and Logs don't help a user fix their spec

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
