### PR TITLE
Add generic cluster name to datadog agent configuration

### DIFF
--- a/examples/datadog-agent.yaml
+++ b/examples/datadog-agent.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: datadog-agent
 spec:
   global:
+    clusterName: operator-lima-cluster
     logLevel: debug
     site: datadoghq.com
     credentials:


### PR DESCRIPTION
## What does this PR do?

- Add a generic cluster name to the Datadog Agent config so that the orchestrator check would be working fine

Without cluster name set: 
<img width="1195" alt="image" src="https://github.com/user-attachments/assets/64426fd8-7811-4459-923f-98576bd79aaa" />

With cluster name set:
<img width="1030" alt="image" src="https://github.com/user-attachments/assets/8dadf56b-398f-4189-b8d4-ae18f14fcc46" />

## Code Quality Checklist

## Testing

