### PR TITLE
Reduce disruption lifecycle in lima for easier dev testing

### DIFF
--- a/chart/values/dev.yaml
+++ b/chart/values/dev.yaml
@@ -6,6 +6,8 @@
 controller:
   enableSafeguards: false
   leaderElection: false
+  minimumCronFrequency: 30s
+  expiredDisruptionGCDelay: 1m
   resources: # resources assigned to the controller pod. may need to be increased when deploying to larger scale clusters
     cpu: 1
     memory: 2Gi

--- a/examples/disruption_crons/network_drop.yaml
+++ b/examples/disruption_crons/network_drop.yaml
@@ -9,7 +9,7 @@ metadata:
   name: network-drop
   namespace: chaos-demo
 spec:
-  schedule: "*/15 * * * *"
+  schedule: "*/2 * * * *"
   targetResource:
     kind: deployment
     name: demo-curl

--- a/examples/disruption_crons/reporting_network_drop.yaml
+++ b/examples/disruption_crons/reporting_network_drop.yaml
@@ -15,7 +15,7 @@ spec:
       | # required, purpose/contextual informations to explain reasons of the disruption launch, can contain markdown formatting
       *full network drop*: _aims to validate retry capabilities of demo-curl_. Contact #team-test for more informations.
     minNotificationType: Info # optional, minimal notification type to be notified, default is Success, available options are Info, Success, Warning, Error
-  schedule: "*/15 * * * *"
+  schedule: "*/5 * * * *"
   targetResource:
     kind: deployment
     name: demo-curl


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [x] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- When I want to test disruption crons in lima, it is inconvenient, because they only run every 15 minutes, and the cron frequency & disruption gc delay are too high. I've reduced these for lima only

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
