### PR TITLE
Dont overwrite returned error with metric error in webhooks

### DIFF
--- a/api/v1beta1/disruption_cron_webhook.go
+++ b/api/v1beta1/disruption_cron_webhook.go
@@ -15,6 +15,7 @@ import (
 	cLog "github.com/DataDog/chaos-controller/log"
 	"github.com/DataDog/chaos-controller/o11y/metrics"
 	"github.com/DataDog/chaos-controller/utils"
+
 	"github.com/robfig/cron"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,8 +122,8 @@ func (d *DisruptionCron) ValidateCreate() (_ admission.Warnings, err error) {
 		return nil, err
 	}
 
-	if err := metricsSink.MetricValidationCreated(metricTags); err != nil {
-		log.Errorw("error sending a metric", "error", err)
+	if mErr := metricsSink.MetricValidationCreated(metricTags); mErr != nil {
+		log.Errorw("error sending a metric", "error", mErr)
 	}
 
 	// send informative event to disruption cron to broadcast
@@ -167,8 +168,8 @@ func (d *DisruptionCron) ValidateUpdate(oldObject runtime.Object) (_ admission.W
 		}
 	}
 
-	if err := metricsSink.MetricValidationUpdated(metricTags); err != nil {
-		log.Errorw("error sending a metric", "error", err)
+	if mErr := metricsSink.MetricValidationUpdated(metricTags); mErr != nil {
+		log.Errorw("error sending a metric", "error", mErr)
 	}
 
 	// send informative event to disruption cron to broadcast
@@ -185,8 +186,8 @@ func (d *DisruptionCron) ValidateDelete() (warnings admission.Warnings, err erro
 	// During the validation of the deletion the timestamp does not exist so we need to set it before emitting the event
 	d.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 
-	if err := metricsSink.MetricValidationDeleted(d.getMetricsTags()); err != nil {
-		log.Errorw("error sending a metric", "error", err)
+	if mErr := metricsSink.MetricValidationDeleted(d.getMetricsTags()); mErr != nil {
+		log.Errorw("error sending a metric", "error", mErr)
 	}
 
 	// send informative event to disruption cron to broadcast

--- a/api/v1beta1/disruption_webhook.go
+++ b/api/v1beta1/disruption_webhook.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/chaos-controller/o11y/tracer"
 	chaostypes "github.com/DataDog/chaos-controller/types"
 	"github.com/DataDog/chaos-controller/utils"
+
 	"github.com/hashicorp/go-multierror"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -244,9 +245,8 @@ func (r *Disruption) ValidateCreate() (_ admission.Warnings, err error) {
 		}
 	}
 
-	// send validation metric
-	if err := metricsSink.MetricValidationCreated(r.getMetricsTags()); err != nil {
-		log.Errorw("error sending a metric", "error", err)
+	if mErr := metricsSink.MetricValidationCreated(r.getMetricsTags()); mErr != nil {
+		log.Errorw("error sending a metric", "error", mErr)
 	}
 
 	// send informative event to disruption to broadcast
@@ -351,9 +351,8 @@ You first need to remove those chaos pods (and potentially their finalizers) to 
 		return nil, err
 	}
 
-	// send validation metric
-	if err := metricsSink.MetricValidationUpdated(r.getMetricsTags()); err != nil {
-		log.Errorw("error sending a metric", "error", err)
+	if mErr := metricsSink.MetricValidationUpdated(r.getMetricsTags()); mErr != nil {
+		log.Errorw("error sending a metric", "error", mErr)
 	}
 
 	return nil, nil
@@ -361,9 +360,8 @@ You first need to remove those chaos pods (and potentially their finalizers) to 
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *Disruption) ValidateDelete() (admission.Warnings, error) {
-	// send validation metric
-	if err := metricsSink.MetricValidationDeleted(r.getMetricsTags()); err != nil {
-		logger.Errorw("error sending a metric", "error", err)
+	if mErr := metricsSink.MetricValidationDeleted(r.getMetricsTags()); mErr != nil {
+		logger.Errorw("error sending a metric", "error", mErr)
 	}
 
 	return nil, nil


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- I made a mistake in #967 that might lead to failing validations if metrics fail
- Realized this also happens for disruptions, so i fixed it there

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
