### PR TITLE
Remove kube-rbac-proxy sidecar

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -40,27 +40,6 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
       containers:
-        - name: kube-rbac-proxy
-          image: {{ template "chaos-controller.format-image" .Values.proxy.image }}
-          imagePullPolicy: IfNotPresent
-          args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
-            - --v=10
-          ports:
-            - containerPort: 8443
-              name: https
-          resources:
-            limits:
-              cpu: 50m
-              memory: 64Mi
-            requests:
-              cpu: 50m
-              memory: 64Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
         - name: manager
           image: {{ template "chaos-controller.format-image" deepCopy .Values.global.chaos.defaultImage | merge .Values.global.oci | merge .Values.controller.image }}
           imagePullPolicy: IfNotPresent

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -150,9 +150,3 @@ handler:
   resources:
     cpu: 10m
     memory: 5Mi
-
-proxy:
-  image:
-    registry: gcr.io
-    repo: kubebuilder/kube-rbac-proxy
-    tag: v0.4.1


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Closes #950.
- This sidecar is optional, and not core to the chaos-controller's functionality. Rather than relocate the container registry we point to, it's better to remove it entirely, and let users handle NetworkPolicies or SubjectAccessReview on their own

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
