### PR TITLE
Replace all printf-like functions that lack format strings

### DIFF
--- a/api/v1beta1/disruption_types.go
+++ b/api/v1beta1/disruption_types.go
@@ -957,7 +957,7 @@ func (s DisruptionSpec) Explain() []string {
 	}
 
 	if s.OnInit {
-		explanation = append(explanation, fmt.Sprintf("spec.onInit is true. "+
+		explanation = append(explanation, fmt.Sprint("spec.onInit is true. "+
 			"The disruptions will be launched during the initialization of the targeted pods."+
 			"This requires some extra setup on your end, please [read the full documentation](https://github.com/DataDog/chaos-controller/blob/main/docs/features.md#applying-a-disruption-on-pod-initialization)"))
 	}
@@ -990,7 +990,7 @@ func (s DisruptionSpec) Explain() []string {
 	))
 
 	if s.StaticTargeting {
-		explanation = append(explanation, fmt.Sprintf("spec.staticTargeting is true, so after we pick an initial set of targets and inject, "+
+		explanation = append(explanation, fmt.Sprint("spec.staticTargeting is true, so after we pick an initial set of targets and inject, "+
 			"we will not attempt to inject into any new targets that appear while the disruption is ongoing."))
 	} else {
 		explanation = append(explanation, "By default we will continually compare the injected target count "+

--- a/api/v1beta1/network_disruption.go
+++ b/api/v1beta1/network_disruption.go
@@ -251,7 +251,7 @@ func (s *NetworkHTTPFilters) validatePaths(retErr error) error {
 		visitedPaths[path] = visitedPath
 
 		if isMultiplePath && path == DefaultHTTPPathFilter {
-			retErr = multierror.Append(retErr, fmt.Errorf(HTTPPathsFilterErrorPrefix+"no needs to define other paths if the / path is defined because it already catches all paths"))
+			retErr = multierror.Append(retErr, errors.New(HTTPPathsFilterErrorPrefix+"no needs to define other paths if the / path is defined because it already catches all paths"))
 		}
 
 		if err := path.validate(); err != nil {


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [ ] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- In preparation for go 1.24 compliance, which does not allow for printf type functions that don't include format strings

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.
