### PR TITLE
Replace stuck on removal metrics with new stuck_on_removal_current

### DIFF
--- a/o11y/metrics/datadog/datadog.go
+++ b/o11y/metrics/datadog/datadog.go
@@ -10,9 +10,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
+
 	"github.com/DataDog/chaos-controller/o11y/metrics/types"
 	chaostypes "github.com/DataDog/chaos-controller/types"
-	"github.com/DataDog/datadog-go/statsd"
 )
 
 const (
@@ -163,17 +164,11 @@ func (d Sink) MetricPodsCreated(target, instanceName, namespace string, succeed 
 	return d.metricWithStatus(d.prefix+"pods.created", tags)
 }
 
-// MetricStuckOnRemoval is emitted once per minute per disruption, if that disruption is "stuck on removal", i.e.,
+// MetricStuckOnRemovalCurrent is emitted once per minute counting the number of disruptions _per namespace_
+// that are "stuck on removal", i.e.,
 // we have attempted to clean and delete the disruption, but that has not worked, and a human needs to intervene.
-func (d Sink) MetricStuckOnRemoval(tags []string) error {
-	return d.metricWithStatus(d.prefix+"disruptions.stuck_on_removal", tags)
-}
-
-// MetricStuckOnRemovalGauge is emitted once per minute counting the total number of disruptions that are
-// "stuck on removal", i.e., we have attempted to clean and delete the disruption, but that has not worked,
-// and a human needs to intervene.
-func (d Sink) MetricStuckOnRemovalGauge(gauge float64) error {
-	return d.client.Gauge(d.prefix+"disruptions.stuck_on_removal_total", gauge, []string{}, 1)
+func (d Sink) MetricStuckOnRemovalCurrent(gauge float64, tags []string) error {
+	return d.client.Gauge(d.prefix+"disruptions.stuck_on_removal_current", gauge, tags, 1)
 }
 
 // MetricDisruptionsGauge is emitted once per minute counting the total number of ongoing disruptions per namespace,

--- a/o11y/metrics/metrics.go
+++ b/o11y/metrics/metrics.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/DataDog/chaos-controller/o11y/metrics/datadog"
 	"github.com/DataDog/chaos-controller/o11y/metrics/noop"
 	"github.com/DataDog/chaos-controller/o11y/metrics/types"
 	chaostypes "github.com/DataDog/chaos-controller/types"
-	"go.uber.org/zap"
 )
 
 // Sink describes a metric sink
@@ -56,13 +57,10 @@ type Sink interface {
 	// MetricDisruptionOngoingDuration indicates the duration between a Disruption's creation timestamp, and the current time.
 	// This is emitted approximately every one minute
 	MetricDisruptionOngoingDuration(duration time.Duration, tags []string) error
-	// MetricStuckOnRemoval is emitted once per minute per disruption, if that disruption is "stuck on removal", i.e.,
+	// MetricStuckOnRemovalCurrent is emitted once per minute counting the number of disruptions _per namespace_
+	// that are "stuck on removal", i.e.,
 	// we have attempted to clean and delete the disruption, but that has not worked, and a human needs to intervene.
-	MetricStuckOnRemoval(tags []string) error
-	// MetricStuckOnRemovalGauge is emitted once per minute counting the total number of disruptions that are
-	// "stuck on removal", i.e., we have attempted to clean and delete the disruption, but that has not worked,
-	// and a human needs to intervene.
-	MetricStuckOnRemovalGauge(gauge float64) error
+	MetricStuckOnRemovalCurrent(gauge float64, tags []string) error
 	// MetricDisruptionsGauge is emitted once per minute counting the total number of ongoing disruptions per namespace,
 	// or if we fail to determine the namespaced metrics, simply the total number of disruptions found
 	MetricDisruptionsGauge(gauge float64, tags []string) error

--- a/o11y/metrics/noop/noop.go
+++ b/o11y/metrics/noop/noop.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/DataDog/chaos-controller/o11y/metrics/types"
 	chaostypes "github.com/DataDog/chaos-controller/types"
-	"go.uber.org/zap"
 )
 
 // Sink describes a no-op sink
@@ -128,19 +129,11 @@ func (n Sink) MetricPodsCreated(target, instanceName, namespace string, succeed 
 	return nil
 }
 
-// MetricStuckOnRemoval is emitted once per minute per disruption, if that disruption is "stuck on removal", i.e.,
+// MetricStuckOnRemovalCurrent is emitted once per minute counting the number of disruptions _per namespace_
+// that are "stuck on removal", i.e.,
 // we have attempted to clean and delete the disruption, but that has not worked, and a human needs to intervene.
-func (n Sink) MetricStuckOnRemoval(tags []string) error {
-	fmt.Println("NOOP: MetricStuckOnRemoval +1")
-
-	return nil
-}
-
-// MetricStuckOnRemovalGauge is emitted once per minute counting the total number of disruptions that are
-// "stuck on removal", i.e., we have attempted to clean and delete the disruption, but that has not worked,
-// and a human needs to intervene.
-func (n Sink) MetricStuckOnRemovalGauge(gauge float64) error {
-	n.log.Debugf("NOOP: MetricStuckOnRemovalGauge %f\n", gauge)
+func (n Sink) MetricStuckOnRemovalCurrent(gauge float64, tags []string) error {
+	fmt.Println("NOOP: MetricStuckOnRemovalCurrent +1")
 
 	return nil
 }

--- a/o11y/metrics/noop/noop.go
+++ b/o11y/metrics/noop/noop.go
@@ -133,7 +133,7 @@ func (n Sink) MetricPodsCreated(target, instanceName, namespace string, succeed 
 // that are "stuck on removal", i.e.,
 // we have attempted to clean and delete the disruption, but that has not worked, and a human needs to intervene.
 func (n Sink) MetricStuckOnRemovalCurrent(gauge float64, tags []string) error {
-	fmt.Println("NOOP: MetricStuckOnRemovalCurrent +1")
+	n.log.Debugf("NOOP: MetricStuckOnRemovalCurrent %f %s\n", gauge, tags)
 
 	return nil
 }

--- a/o11y/metrics/sink_mock.go
+++ b/o11y/metrics/sink_mock.go
@@ -1192,17 +1192,17 @@ func (_c *SinkMock_MetricRestart_Call) RunAndReturn(run func() error) *SinkMock_
 	return _c
 }
 
-// MetricStuckOnRemoval provides a mock function with given fields: tags
-func (_m *SinkMock) MetricStuckOnRemoval(tags []string) error {
-	ret := _m.Called(tags)
+// MetricStuckOnRemovalCurrent provides a mock function with given fields: gauge, tags
+func (_m *SinkMock) MetricStuckOnRemovalCurrent(gauge float64, tags []string) error {
+	ret := _m.Called(gauge, tags)
 
 	if len(ret) == 0 {
-		panic("no return value specified for MetricStuckOnRemoval")
+		panic("no return value specified for MetricStuckOnRemovalCurrent")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func([]string) error); ok {
-		r0 = rf(tags)
+	if rf, ok := ret.Get(0).(func(float64, []string) error); ok {
+		r0 = rf(gauge, tags)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1210,76 +1210,31 @@ func (_m *SinkMock) MetricStuckOnRemoval(tags []string) error {
 	return r0
 }
 
-// SinkMock_MetricStuckOnRemoval_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MetricStuckOnRemoval'
-type SinkMock_MetricStuckOnRemoval_Call struct {
+// SinkMock_MetricStuckOnRemovalCurrent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MetricStuckOnRemovalCurrent'
+type SinkMock_MetricStuckOnRemovalCurrent_Call struct {
 	*mock.Call
 }
 
-// MetricStuckOnRemoval is a helper method to define mock.On call
-//   - tags []string
-func (_e *SinkMock_Expecter) MetricStuckOnRemoval(tags interface{}) *SinkMock_MetricStuckOnRemoval_Call {
-	return &SinkMock_MetricStuckOnRemoval_Call{Call: _e.mock.On("MetricStuckOnRemoval", tags)}
-}
-
-func (_c *SinkMock_MetricStuckOnRemoval_Call) Run(run func(tags []string)) *SinkMock_MetricStuckOnRemoval_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]string))
-	})
-	return _c
-}
-
-func (_c *SinkMock_MetricStuckOnRemoval_Call) Return(_a0 error) *SinkMock_MetricStuckOnRemoval_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *SinkMock_MetricStuckOnRemoval_Call) RunAndReturn(run func([]string) error) *SinkMock_MetricStuckOnRemoval_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// MetricStuckOnRemovalGauge provides a mock function with given fields: gauge
-func (_m *SinkMock) MetricStuckOnRemovalGauge(gauge float64) error {
-	ret := _m.Called(gauge)
-
-	if len(ret) == 0 {
-		panic("no return value specified for MetricStuckOnRemovalGauge")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(float64) error); ok {
-		r0 = rf(gauge)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// SinkMock_MetricStuckOnRemovalGauge_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MetricStuckOnRemovalGauge'
-type SinkMock_MetricStuckOnRemovalGauge_Call struct {
-	*mock.Call
-}
-
-// MetricStuckOnRemovalGauge is a helper method to define mock.On call
+// MetricStuckOnRemovalCurrent is a helper method to define mock.On call
 //   - gauge float64
-func (_e *SinkMock_Expecter) MetricStuckOnRemovalGauge(gauge interface{}) *SinkMock_MetricStuckOnRemovalGauge_Call {
-	return &SinkMock_MetricStuckOnRemovalGauge_Call{Call: _e.mock.On("MetricStuckOnRemovalGauge", gauge)}
+//   - tags []string
+func (_e *SinkMock_Expecter) MetricStuckOnRemovalCurrent(gauge interface{}, tags interface{}) *SinkMock_MetricStuckOnRemovalCurrent_Call {
+	return &SinkMock_MetricStuckOnRemovalCurrent_Call{Call: _e.mock.On("MetricStuckOnRemovalCurrent", gauge, tags)}
 }
 
-func (_c *SinkMock_MetricStuckOnRemovalGauge_Call) Run(run func(gauge float64)) *SinkMock_MetricStuckOnRemovalGauge_Call {
+func (_c *SinkMock_MetricStuckOnRemovalCurrent_Call) Run(run func(gauge float64, tags []string)) *SinkMock_MetricStuckOnRemovalCurrent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(float64))
+		run(args[0].(float64), args[1].([]string))
 	})
 	return _c
 }
 
-func (_c *SinkMock_MetricStuckOnRemovalGauge_Call) Return(_a0 error) *SinkMock_MetricStuckOnRemovalGauge_Call {
+func (_c *SinkMock_MetricStuckOnRemovalCurrent_Call) Return(_a0 error) *SinkMock_MetricStuckOnRemovalCurrent_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *SinkMock_MetricStuckOnRemovalGauge_Call) RunAndReturn(run func(float64) error) *SinkMock_MetricStuckOnRemovalGauge_Call {
+func (_c *SinkMock_MetricStuckOnRemovalCurrent_Call) RunAndReturn(run func(float64, []string) error) *SinkMock_MetricStuckOnRemovalCurrent_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- We currently emit two different metrics for stuck disruptions, both of which have problems.
- The first, `disruptions.stuck_on_removal` is a count metric that is _not_ counting discrete stuck disruptions, but is emitted once per minute per stuck disruption, and so it cannot be aggregated appropriately
- The second, `disruptions.stuck_on_removal_total` is a gauge metric that is [apparently, confusingly named for a gauge](https://www.robustperception.io/on-the-naming-of-things/), and has no tags, making it impossible to measure or filter stuck disruptions per namespace
- The new PR will replace these both with a new gauge metrics, `disruptions.stuck_on_removal_current`, that we intend to be appropriately aggregatable and tagged.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [ ] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [x] as a canary deployment to a cluster.
