### PR TITLE
fix(pulse): possible cgroups race condition.

### DIFF
--- a/cli/injector/main.go
+++ b/cli/injector/main.go
@@ -602,7 +602,7 @@ func injectAndWait(cmd *cobra.Command, args []string) {
 		break
 	// those disruptions should not watch target to re-inject on container restart
 	case v1beta1.DisruptionIsNotReinjectable((chaostypes.DisruptionKindName)(cmd.Name())):
-	case disruptionArgs.Level == chaostypes.DisruptionLevelNode:
+	case parentPID == 0 && disruptionArgs.Level == chaostypes.DisruptionLevelNode:
 		if disruptionArgs.PulseActiveDuration > 0 && disruptionArgs.PulseDormantDuration > 0 {
 			var (
 				err error

--- a/command/background_cmd_mock.go
+++ b/command/background_cmd_mock.go
@@ -22,6 +22,53 @@ func (_m *BackgroundCmdMock) EXPECT() *BackgroundCmdMock_Expecter {
 	return &BackgroundCmdMock_Expecter{mock: &_m.Mock}
 }
 
+// Done provides a mock function with no fields
+func (_m *BackgroundCmdMock) Done() <-chan struct{} {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Done")
+	}
+
+	var r0 <-chan struct{}
+	if rf, ok := ret.Get(0).(func() <-chan struct{}); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(<-chan struct{})
+		}
+	}
+
+	return r0
+}
+
+// BackgroundCmdMock_Done_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Done'
+type BackgroundCmdMock_Done_Call struct {
+	*mock.Call
+}
+
+// Done is a helper method to define mock.On call
+func (_e *BackgroundCmdMock_Expecter) Done() *BackgroundCmdMock_Done_Call {
+	return &BackgroundCmdMock_Done_Call{Call: _e.mock.On("Done")}
+}
+
+func (_c *BackgroundCmdMock_Done_Call) Run(run func()) *BackgroundCmdMock_Done_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *BackgroundCmdMock_Done_Call) Return(_a0 <-chan struct{}) *BackgroundCmdMock_Done_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *BackgroundCmdMock_Done_Call) RunAndReturn(run func() <-chan struct{}) *BackgroundCmdMock_Done_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DryRun provides a mock function with no fields
 func (_m *BackgroundCmdMock) DryRun() bool {
 	ret := _m.Called()
@@ -185,53 +232,6 @@ func (_c *BackgroundCmdMock_Stop_Call) Return(_a0 error) *BackgroundCmdMock_Stop
 }
 
 func (_c *BackgroundCmdMock_Stop_Call) RunAndReturn(run func() error) *BackgroundCmdMock_Stop_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// Done provides a mock function with no fields
-func (_m *BackgroundCmdMock) Done() <-chan struct{} {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for Done")
-	}
-
-	var r0 <-chan struct{}
-	if rf, ok := ret.Get(0).(func() <-chan struct{}); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(<-chan struct{})
-		}
-	}
-
-	return r0
-}
-
-// BackgroundCmdMock_Done_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Done'
-type BackgroundCmdMock_Done_Call struct {
-	*mock.Call
-}
-
-// Done is a helper method to define mock.On call
-func (_e *BackgroundCmdMock_Expecter) Done() *BackgroundCmdMock_Done_Call {
-	return &BackgroundCmdMock_Done_Call{Call: _e.mock.On("Done")}
-}
-
-func (_c *BackgroundCmdMock_Done_Call) Run(run func()) *BackgroundCmdMock_Done_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *BackgroundCmdMock_Done_Call) Return(_a0 <-chan struct{}) *BackgroundCmdMock_Done_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *BackgroundCmdMock_Done_Call) RunAndReturn(run func() <-chan struct{}) *BackgroundCmdMock_Done_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/command/background_cmd_mock.go
+++ b/command/background_cmd_mock.go
@@ -189,6 +189,53 @@ func (_c *BackgroundCmdMock_Stop_Call) RunAndReturn(run func() error) *Backgroun
 	return _c
 }
 
+// Done provides a mock function with no fields
+func (_m *BackgroundCmdMock) Done() <-chan struct{} {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Done")
+	}
+
+	var r0 <-chan struct{}
+	if rf, ok := ret.Get(0).(func() <-chan struct{}); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(<-chan struct{})
+		}
+	}
+
+	return r0
+}
+
+// BackgroundCmdMock_Done_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Done'
+type BackgroundCmdMock_Done_Call struct {
+	*mock.Call
+}
+
+// Done is a helper method to define mock.On call
+func (_e *BackgroundCmdMock_Expecter) Done() *BackgroundCmdMock_Done_Call {
+	return &BackgroundCmdMock_Done_Call{Call: _e.mock.On("Done")}
+}
+
+func (_c *BackgroundCmdMock_Done_Call) Run(run func()) *BackgroundCmdMock_Done_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *BackgroundCmdMock_Done_Call) Return(_a0 <-chan struct{}) *BackgroundCmdMock_Done_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *BackgroundCmdMock_Done_Call) RunAndReturn(run func() <-chan struct{}) *BackgroundCmdMock_Done_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewBackgroundCmdMock creates a new instance of BackgroundCmdMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewBackgroundCmdMock(t interface {

--- a/command/command.go
+++ b/command/command.go
@@ -51,6 +51,8 @@ type BackgroundCmd interface {
 	KeepAlive()
 	Stop() error
 	DryRun() bool
+	// Done returns a channel that is closed when the background process exits.
+	Done() <-chan struct{}
 }
 
 type cmd struct {
@@ -88,6 +90,7 @@ type backgroundCmd struct {
 	err            chan error      // Used to monitor the exit of the command
 	keepAliveQuit  chan int        // Used to kill the keepAlive goroutine
 	pid            int             // PID of the process
+	done           chan struct{}   // Closed when the process exits
 }
 
 type factory struct {
@@ -114,15 +117,17 @@ func (f factory) NewCmd(ctx context.Context, name string, args []string) Cmd {
 
 func NewBackgroundCmd(cmd Cmd, log *zap.SugaredLogger, processManager process.Manager) BackgroundCmd {
 	return &backgroundCmd{
-		cmd,
-		sync.Mutex{},
-		log,
-		processManager,
-		nil,
-		nil,
-		nil,
-		process.NotFoundProcessPID,
+		Cmd:            cmd,
+		log:            log,
+		processManager: processManager,
+		pid:            process.NotFoundProcessPID,
+		done:           make(chan struct{}),
 	}
+}
+
+// Done returns a channel that is closed when the background process exits.
+func (w *backgroundCmd) Done() <-chan struct{} {
+	return w.done
 }
 
 func (w *backgroundCmd) DryRun() bool {
@@ -131,6 +136,7 @@ func (w *backgroundCmd) DryRun() bool {
 
 func (w *backgroundCmd) Start() error {
 	if w.DryRun() {
+		close(w.done)
 		return nil
 	}
 
@@ -171,6 +177,8 @@ func (w *backgroundCmd) Start() error {
 		} else {
 			w.log.Info("background command exited successfully")
 		}
+
+		close(w.done)
 	}()
 
 	return nil

--- a/command/command.go
+++ b/command/command.go
@@ -141,6 +141,7 @@ func (w *backgroundCmd) Start() error {
 	}
 
 	if err := w.Cmd.Start(); err != nil {
+		close(w.done)
 		return fmt.Errorf("unable to exec command '%s': %w", w.String(), err)
 	}
 
@@ -156,12 +157,14 @@ func (w *backgroundCmd) Start() error {
 	case <-time.After(cmdBootstrapAllowedDuration):
 	case err := <-chErr:
 		if err != nil {
+			close(w.done)
 			return fmt.Errorf("an error occurred during startup of exec command: %w", err)
 		}
 	}
 
 	w.pid = w.PID()
 	if w.pid == process.NotFoundProcessPID {
+		close(w.done)
 		return fmt.Errorf("no process created, processState exit code is %v", w.ExitCode())
 	}
 

--- a/controllers/cpu_pressure_test.go
+++ b/controllers/cpu_pressure_test.go
@@ -6,6 +6,8 @@
 package controllers
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -44,6 +46,61 @@ var _ = Describe("CPU Pressure", func() {
 
 	JustBeforeEach(func(ctx SpecContext) {
 		cpuStress, targetPod, _ = InjectPodsAndDisruption(ctx, cpuStress, true)
+	})
+
+	Context("pulse mode", func() {
+		BeforeEach(func() {
+			cpuStress.Spec.Duration = "2m"
+			cpuStress.Spec.Pulse = &chaosv1beta1.DisruptionPulse{
+				ActiveDuration:  chaosv1beta1.DisruptionDuration("15s"),
+				DormantDuration: chaosv1beta1.DisruptionDuration("10s"),
+			}
+		})
+
+		It("should inject with pulse arguments and cycle through active/dormant phases", func(ctx SpecContext) {
+			ExpectDisruptionStatus(ctx, cpuStress, chaostypes.DisruptionInjectionStatusInjected)
+
+			By("Ensuring chaos pod is created")
+			ExpectChaosPods(ctx, cpuStress, 1)
+
+			By("Verifying chaos pod has pulse arguments")
+			Eventually(func(g Gomega, ctx SpecContext) {
+				chaosPods, err := listChaosPods(ctx, cpuStress)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(chaosPods.Items).To(HaveLen(1))
+
+				args := strings.Join(chaosPods.Items[0].Spec.Containers[0].Args, " ")
+				g.Expect(args).To(ContainSubstring("cpu-pressure"))
+				g.Expect(args).To(ContainSubstring("--pulse-active-duration"))
+				g.Expect(args).To(ContainSubstring("--pulse-dormant-duration"))
+			}).WithContext(ctx).Within(calcDisruptionGoneTimeout(cpuStress)).ProbeEvery(disruptionPotentialChangesEvery).Should(Succeed())
+
+			By("Ensuring disruption stays healthy throughout pulse cycle")
+			ExpectDisruptionStatusUntilExpired(ctx, cpuStress, chaostypes.DisruptionInjectionStatusInjected)
+		})
+
+		When("initial delay is configured", func() {
+			BeforeEach(func() {
+				cpuStress.Spec.Pulse.InitialDelay = chaosv1beta1.DisruptionDuration("5s")
+			})
+
+			It("should inject with initial delay argument and remain healthy", func(ctx SpecContext) {
+				ExpectDisruptionStatus(ctx, cpuStress, chaostypes.DisruptionInjectionStatusInjected)
+
+				By("Verifying chaos pod has initial delay argument")
+				Eventually(func(g Gomega, ctx SpecContext) {
+					chaosPods, err := listChaosPods(ctx, cpuStress)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(chaosPods.Items).To(HaveLen(1))
+
+					args := strings.Join(chaosPods.Items[0].Spec.Containers[0].Args, " ")
+					g.Expect(args).To(ContainSubstring("--pulse-initial-delay"))
+				}).WithContext(ctx).Within(calcDisruptionGoneTimeout(cpuStress)).ProbeEvery(disruptionPotentialChangesEvery).Should(Succeed())
+
+				By("Ensuring disruption stays healthy throughout pulse cycle with initial delay")
+				ExpectDisruptionStatusUntilExpired(ctx, cpuStress, chaostypes.DisruptionInjectionStatusInjected)
+			})
+		})
 	})
 
 	DescribeTable("targeted container is stopped", func(ctx SpecContext, forced bool) {

--- a/controllers/memory_pressure_test.go
+++ b/controllers/memory_pressure_test.go
@@ -181,6 +181,29 @@ var _ = Describe("Memory Pressure", func() {
 			By("Ensuring disruption stays healthy throughout pulse cycle")
 			ExpectDisruptionStatusUntilExpired(ctx, memoryStress, chaostypes.DisruptionInjectionStatusInjected)
 		})
+
+		When("initial delay is configured", func() {
+			BeforeEach(func() {
+				memoryStress.Spec.Pulse.InitialDelay = chaosv1beta1.DisruptionDuration("5s")
+			})
+
+			It("should inject with initial delay argument and remain healthy", func(ctx SpecContext) {
+				ExpectDisruptionStatus(ctx, memoryStress, chaostypes.DisruptionInjectionStatusInjected)
+
+				By("Verifying chaos pod has initial delay argument")
+				Eventually(func(g Gomega, ctx SpecContext) {
+					chaosPods, err := listChaosPods(ctx, memoryStress)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(chaosPods.Items).To(HaveLen(1))
+
+					args := strings.Join(chaosPods.Items[0].Spec.Containers[0].Args, " ")
+					g.Expect(args).To(ContainSubstring("--pulse-initial-delay"))
+				}).WithContext(ctx).Within(calcDisruptionGoneTimeout(memoryStress)).ProbeEvery(disruptionPotentialChangesEvery).Should(Succeed())
+
+				By("Ensuring disruption stays healthy throughout pulse cycle with initial delay")
+				ExpectDisruptionStatusUntilExpired(ctx, memoryStress, chaostypes.DisruptionInjectionStatusInjected)
+			})
+		})
 	})
 
 	DescribeTable("targeted container is stopped", func(ctx SpecContext, forced bool) {

--- a/injector/cpu_pressure.go
+++ b/injector/cpu_pressure.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"time"
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/command"
@@ -121,6 +122,13 @@ func (i *cpuPressureInjector) Clean() error {
 
 	if err := i.backgroundCmd.Stop(); err != nil && !errors.Is(err, os.ErrProcessDone) {
 		return fmt.Errorf("unable to stop background process: %w", err)
+	}
+
+	// Wait for the child process to fully exit before a potential re-inject during pulse mode.
+	select {
+	case <-i.backgroundCmd.Done():
+	case <-time.After(5 * time.Second):
+		i.config.Log.Warnw("timed out waiting for background process to exit")
 	}
 
 	return nil

--- a/injector/cpu_pressure.go
+++ b/injector/cpu_pressure.go
@@ -7,11 +7,8 @@ package injector
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
-	"os"
-	"time"
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/command"
@@ -114,22 +111,5 @@ func (i *cpuPressureInjector) UpdateConfig(config Config) {
 }
 
 func (i *cpuPressureInjector) Clean() error {
-	if i.backgroundCmd == nil {
-		return nil
-	}
-
-	defer i.cancel()
-
-	if err := i.backgroundCmd.Stop(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-		return fmt.Errorf("unable to stop background process: %w", err)
-	}
-
-	// Wait for the child process to fully exit before a potential re-inject during pulse mode.
-	select {
-	case <-i.backgroundCmd.Done():
-	case <-time.After(5 * time.Second):
-		i.config.Log.Warnw("timed out waiting for background process to exit")
-	}
-
-	return nil
+	return stopAndWaitForBackgroundCmd(i.config.Log, i.backgroundCmd, i.cancel)
 }

--- a/injector/cpu_pressure.go
+++ b/injector/cpu_pressure.go
@@ -94,7 +94,9 @@ func (i *cpuPressureInjector) Inject() error {
 	}
 
 	if err := i.backgroundCmd.Start(); err != nil {
-		defer i.cancel()
+		i.cancel()
+		i.backgroundCmd = nil
+		i.cancel = nil
 
 		return fmt.Errorf("unable to start process for injector: %w", err)
 	}

--- a/injector/cpu_pressure_test.go
+++ b/injector/cpu_pressure_test.go
@@ -120,9 +120,13 @@ var _ = Describe("CPU pressure", func() {
 		})
 
 		It("succeed and call stop after proper inject", func() {
+			doneCh := make(chan struct{})
+			close(doneCh)
+
 			background.EXPECT().Start().Return(nil).Once()
 			background.EXPECT().KeepAlive().Once()
 			background.EXPECT().Stop().Return(nil).Once()
+			background.EXPECT().Done().Return((<-chan struct{})(doneCh)).Once()
 
 			inj := NewCPUPressureInjector(config, "100%", factory, args)
 

--- a/injector/factory.go
+++ b/injector/factory.go
@@ -65,12 +65,21 @@ func (i injectorCmdFactory) NewInjectorBackgroundCmd(deadline time.Time, disrupt
 		disruptionArgs.TargetContainers = map[string]string{target: targetContainerID}
 	}
 
+	// Child subprocesses should not inherit pulse args — the parent process handles pulsing.
+	// Passing pulse args to children causes: (1) double-pulsing at node level where both
+	// parent and child independently pulse, and (2) re-spawned children unnecessarily
+	// waiting for pulse initial delay on every re-inject cycle.
+	childArgs := disruptionArgs
+	childArgs.PulseActiveDuration = 0
+	childArgs.PulseDormantDuration = 0
+	childArgs.PulseInitialDelay = 0
+
 	args = append(
 		args,
 		ParentPIDFlag.String(), strconv.Itoa(i.processManager.ProcessID()),
 		DeadlineFlag.String(), deadline.Format(time.RFC3339),
 	)
-	args = disruptionArgs.CreateCmdArgs(args)
+	args = childArgs.CreateCmdArgs(args)
 
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	cmd := i.cmdBuilder.NewCmd(ctx, ChaosInjectorBinaryLocation, args)

--- a/injector/injector.go
+++ b/injector/injector.go
@@ -7,10 +7,14 @@ package injector
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
 	"time"
 
 	chaosapi "github.com/DataDog/chaos-controller/api"
 	"github.com/DataDog/chaos-controller/cgroup"
+	"github.com/DataDog/chaos-controller/command"
 	"github.com/DataDog/chaos-controller/container"
 	"github.com/DataDog/chaos-controller/netns"
 	"github.com/DataDog/chaos-controller/o11y/metrics"
@@ -64,4 +68,26 @@ func (c Config) TargetName() string {
 	}
 
 	return UnknownTargetName
+}
+
+// stopAndWaitForBackgroundCmd stops a background command and waits for the process to fully exit
+// before returning. This prevents cgroup race conditions during pulse mode re-injection.
+func stopAndWaitForBackgroundCmd(log *zap.SugaredLogger, backgroundCmd command.BackgroundCmd, cancel context.CancelFunc) error {
+	if backgroundCmd == nil {
+		return nil
+	}
+
+	defer cancel()
+
+	if err := backgroundCmd.Stop(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("unable to stop background process: %w", err)
+	}
+
+	select {
+	case <-backgroundCmd.Done():
+	case <-time.After(5 * time.Second):
+		log.Warnw("timed out waiting for background process to exit")
+	}
+
+	return nil
 }

--- a/injector/injector.go
+++ b/injector/injector.go
@@ -87,6 +87,7 @@ func stopAndWaitForBackgroundCmd(log *zap.SugaredLogger, backgroundCmd command.B
 	case <-backgroundCmd.Done():
 	case <-time.After(5 * time.Second):
 		log.Warnw("timed out waiting for background process to exit")
+		return fmt.Errorf("timed out waiting for background process to exit")
 	}
 
 	return nil

--- a/injector/memory_pressure.go
+++ b/injector/memory_pressure.go
@@ -107,5 +107,13 @@ func (i *memoryPressureInjector) Clean() error {
 		return fmt.Errorf("unable to stop background process: %w", err)
 	}
 
+	// Wait for the child process to fully exit so cgroup memory accounting is updated
+	// before a potential re-inject during pulse mode.
+	select {
+	case <-i.backgroundCmd.Done():
+	case <-time.After(5 * time.Second):
+		i.config.Log.Warnw("timed out waiting for background process to exit")
+	}
+
 	return nil
 }

--- a/injector/memory_pressure.go
+++ b/injector/memory_pressure.go
@@ -7,9 +7,7 @@ package injector
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
@@ -97,23 +95,5 @@ func (i *memoryPressureInjector) UpdateConfig(config Config) {
 }
 
 func (i *memoryPressureInjector) Clean() error {
-	if i.backgroundCmd == nil {
-		return nil
-	}
-
-	defer i.cancel()
-
-	if err := i.backgroundCmd.Stop(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-		return fmt.Errorf("unable to stop background process: %w", err)
-	}
-
-	// Wait for the child process to fully exit so cgroup memory accounting is updated
-	// before a potential re-inject during pulse mode.
-	select {
-	case <-i.backgroundCmd.Done():
-	case <-time.After(5 * time.Second):
-		i.config.Log.Warnw("timed out waiting for background process to exit")
-	}
-
-	return nil
+	return stopAndWaitForBackgroundCmd(i.config.Log, i.backgroundCmd, i.cancel)
 }

--- a/injector/memory_pressure.go
+++ b/injector/memory_pressure.go
@@ -78,7 +78,9 @@ func (i *memoryPressureInjector) Inject() error {
 	}
 
 	if err := i.backgroundCmd.Start(); err != nil {
-		defer i.cancel()
+		i.cancel()
+		i.backgroundCmd = nil
+		i.cancel = nil
 
 		return fmt.Errorf("unable to start process for injector: %w", err)
 	}

--- a/injector/memory_pressure_test.go
+++ b/injector/memory_pressure_test.go
@@ -85,9 +85,13 @@ var _ = Describe("Memory pressure", func() {
 		})
 
 		It("succeeds and calls stop after proper inject", func() {
+			doneCh := make(chan struct{})
+			close(doneCh)
+
 			background.EXPECT().Start().Return(nil).Once()
 			background.EXPECT().KeepAlive().Once()
 			background.EXPECT().Stop().Return(nil).Once()
+			background.EXPECT().Done().Return((<-chan struct{})(doneCh)).Once()
 
 			inj := NewMemoryPressureInjector(config, "50%", time.Duration(0), factory, args)
 


### PR DESCRIPTION
## Summary

Fix pulse mode for memory and CPU pressure disruptions. Three root causes were identified and fixed:

### Bug 1: Child subprocesses enter their own pulse loop (node-level)

In `cli/injector/main.go`, the switch statement routes node-level disruptions into the pulse loop **without checking if the current process is a child subprocess**. The parent spawns a child (memory-stress/cpu-stress), but that child inherits the `--level node` flag and enters its own independent pulse loop — both parent and child try to pulse, causing chaotic behavior.

**Fix:** Added `parentPID == 0 &&` guard so only the parent process enters the node-level pulse loop.

### Bug 2: Pulse args leak to child subprocesses

In `injector/factory.go`, `CreateCmdArgs()` passes `--pulse-active-duration`, `--pulse-dormant-duration`, and `--pulse-initial-delay` to child subprocesses. If `PulseInitialDelay >= PulseActiveDuration`, the child subprocess is killed by its own pulse timer before it ever allocates memory or starts stressing CPU. The child thinks *it* should pulse, but pulsing is the parent's responsibility (clean → re-inject cycle).

**Fix:** Zero out pulse args (`PulseActiveDuration`, `PulseDormantDuration`, `PulseInitialDelay`) before passing them to the child subprocess command.

### Bug 3: Clean() doesn't wait for child process to exit

In `injector/memory_pressure.go` and `injector/cpu_pressure.go`, `Clean()` sends SIGTERM and returns immediately. During pulse mode, the parent calls `Clean()` then `Inject()` in quick succession. The old child may still be dying (holding mmap'd memory in the cgroup) when the new child starts. The new child reads cgroup memory usage, sees it's at/above target, calculates `targetBytes <= 0`, and skips allocation — producing no stress during the next pulse.

**Fix:** Added a `Done()` channel to `BackgroundCmd` that closes when the child process exits. `Clean()` now blocks on `<-Done()` (with 5s timeout) before returning, ensuring cgroup accounting reflects freed memory before re-injection.

## Changed files

- `cli/injector/main.go` — Guard node-level pulse loop with `parentPID == 0`
- `injector/factory.go` — Zero out pulse args for child subprocesses
- `command/command.go` — Add `Done()` channel to `BackgroundCmd` interface
- `command/background_cmd_mock.go` — Add `Done()` mock method
- `injector/memory_pressure.go` — Wait for child exit in `Clean()`
- `injector/cpu_pressure.go` — Wait for child exit in `Clean()`
- `injector/cpu_pressure_test.go` — Add `Done()` mock expectation
- `injector/memory_pressure_test.go` — Add `Done()` mock expectation

## Test plan

- [x] Unit tests pass (`command`, `injector`, `services` packages)
- [x] Regenerate mocks with `make generate-mocks`
- [x] Run full test suite (`make test`)
- [x] E2E: deploy memory pressure disruption with pulse mode, verify pulses cycle correctly
- [x] E2E: deploy CPU pressure disruption with pulse mode, verify pulses cycle correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)