### PR TITLE
Reduce no-target event spam on requeues

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -96,6 +96,8 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// inject contextual logger into context for propagation to dependencies
 	ctx = cLog.WithLogger(ctx, r.log)
 
+	r.log.Debug("reconciling disruption", tagutil.DisruptionNameKey, req.Name, tagutil.DisruptionNamespaceKey, req.Namespace)
+
 	// reconcile metrics
 	r.handleMetricSinkError(r.MetricsSink.MetricReconcile())
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -924,12 +924,25 @@ func (r *DisruptionReconciler) getSelectorMatchingTargets(instance *chaosv1beta1
 	// return an error if the selector returned no targets
 	if len(healthyMatchingTargets) == 0 {
 		r.log.Infow("the given label selector did not return any targets, skipping", tagutil.SelectorKey, instance.Spec.Selector)
-		r.recordEventOnDisruption(instance, chaosv1beta1.EventDisruptionNoTargetsFound, "", "")
+		if shouldRecordNoTargetsFoundEvent(instance.Status.InjectionStatus) {
+			r.recordEventOnDisruption(instance, chaosv1beta1.EventDisruptionNoTargetsFound, "", "")
+		}
 
 		return nil, 0, nil
 	}
 
 	return healthyMatchingTargets, totalAvailableTargetsCount, nil
+}
+
+func shouldRecordNoTargetsFoundEvent(injectionStatus chaostypes.DisruptionInjectionStatus) bool {
+	switch injectionStatus {
+	case chaostypes.DisruptionInjectionStatusNotInjected,
+		chaostypes.DisruptionInjectionStatusPausedInjected,
+		chaostypes.DisruptionInjectionStatusPausedPartiallyInjected:
+		return false
+	default:
+		return true
+	}
 }
 
 // deleteChaosPods deletes a chaos pod using the client

--- a/controllers/disruption_controller_unit_test.go
+++ b/controllers/disruption_controller_unit_test.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package controllers
+
+import (
+	"testing"
+
+	chaosv1beta1 "github.com/DataDog/chaos-controller/api/v1beta1"
+	"github.com/DataDog/chaos-controller/mocks"
+	"github.com/DataDog/chaos-controller/targetselector"
+	chaostypes "github.com/DataDog/chaos-controller/types"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetSelectorMatchingTargetsNoTargetsEventDeduplication(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		status      chaostypes.DisruptionInjectionStatus
+		expectEvent bool
+	}{
+		{
+			name:        "emits event when disruption is initial",
+			status:      chaostypes.DisruptionInjectionStatusInitial,
+			expectEvent: true,
+		},
+		{
+			name:        "does not emit event when disruption is not injected",
+			status:      chaostypes.DisruptionInjectionStatusNotInjected,
+			expectEvent: false,
+		},
+		{
+			name:        "does not emit event when disruption is paused injected",
+			status:      chaostypes.DisruptionInjectionStatusPausedInjected,
+			expectEvent: false,
+		},
+		{
+			name:        "does not emit event when disruption is paused partially injected",
+			status:      chaostypes.DisruptionInjectionStatusPausedPartiallyInjected,
+			expectEvent: false,
+		},
+		{
+			name:        "emits event when disruption is injected",
+			status:      chaostypes.DisruptionInjectionStatusInjected,
+			expectEvent: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			disruption := &chaosv1beta1.Disruption{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "disruption",
+					Namespace: "default",
+				},
+				Spec: chaosv1beta1.DisruptionSpec{
+					Level:    chaostypes.DisruptionLevelPod,
+					Selector: map[string]string{"app": "demo"},
+				},
+				Status: chaosv1beta1.DisruptionStatus{
+					InjectionStatus: tc.status,
+				},
+			}
+
+			recorderMock := mocks.NewEventRecorderMock(t)
+			targetSelectorMock := targetselector.NewTargetSelectorMock(t)
+			targetSelectorMock.EXPECT().GetMatchingPodsOverTotalPods(mock.Anything, disruption).Return(&corev1.PodList{}, 0, nil).Once()
+
+			if tc.expectEvent {
+				recorderMock.EXPECT().Event(disruption, mock.Anything, mock.Anything, mock.Anything).Once()
+			}
+
+			reconciler := &DisruptionReconciler{
+				Recorder:       recorderMock,
+				TargetSelector: targetSelectorMock,
+				log:            zap.NewNop().Sugar(),
+			}
+
+			targets, totalCount, err := reconciler.getSelectorMatchingTargets(disruption)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			if targets != nil {
+				t.Fatalf("expected nil targets, got %v", targets)
+			}
+
+			if totalCount != 0 {
+				t.Fatalf("expected total count to be 0, got %d", totalCount)
+			}
+
+			if !tc.expectEvent {
+				recorderMock.AssertNotCalled(t, "Event", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ea9fff8c-2b20-463f-b69a-97e686e907ed","source":"chat","resourceId":"167122a0-0d3b-4eff-a423-2f5e814d618a","workflowId":"d7dcf739-91de-417f-b341-daa4719a3ca5","codeChangeId":"d7dcf739-91de-417f-b341-daa4719a3ca5","sourceType":"error_tracking_investigator"} -->
## What does this PR do?

Error Tracking • [View in Error Tracking](https://ddstaging.datadoghq.com/error-tracking/issue/51f8d69e-db81-11f0-adc1-da7ad0900002)

- [ ] Adds new functionality
- [x] Alters existing functionality
- [x] Fixes a bug
- [x] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Motivation: disruptions with selectors matching no targets were recording `EventDisruptionNoTargetsFound` on every requeue cycle, which can trigger Kubernetes event API rate limiting (HTTP 429) and drop useful lifecycle events.
- Changes:
  - Added a guard in `controllers/disruption_controller.go` so `EventDisruptionNoTargetsFound` is only recorded when the disruption is entering a no-target state (initial/injected/partially injected), and skipped while already in `NotInjected`, `PausedInjected`, or `PausedPartiallyInjected` states.
  - Added focused unit tests in `controllers/disruption_controller_unit_test.go` to validate event emission behavior across relevant injection states.
- Testing:
  - `gofmt -w controllers/disruption_controller.go controllers/disruption_controller_unit_test.go`
  - `go test ./controllers -run TestGetSelectorMatchingTargetsNoTargetsEventDeduplication -count=1`
  - `go vet ./controllers`
  - `Lint` tool was attempted, but `golangci-lint` could not run in this environment because its build Go version (1.24) is lower than the repository target Go version (1.25.6).

## Code Quality Checklist

- [ ] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - `x`
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.

---

PR by Bits - [View session in Datadog](https://ddstaging.datadoghq.com/code/167122a0-0d3b-4eff-a423-2f5e814d618a)

Comment @datadog to request changes