### PR TITLE
Fix watcher lifecycle and stuck-on-removal false positives

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -64,6 +64,7 @@ import (
 // DisruptionReconciler reconciles a Disruption object
 type DisruptionReconciler struct {
 	Client                     client.Client
+	APIReader                  client.Reader
 	BaseLog                    *zap.SugaredLogger
 	Scheme                     *runtime.Scheme
 	Recorder                   record.EventRecorder
@@ -82,21 +83,6 @@ type DisruptionReconciler struct {
 }
 
 const TargetsCountLogLimit = 50
-
-func endSpan(s trace.Span, err error) {
-	if s == nil {
-		return
-	}
-
-	if err != nil {
-		s.RecordError(err)
-		s.SetStatus(codes.Error, err.Error())
-	} else {
-		s.SetStatus(codes.Ok, "")
-	}
-
-	s.End()
-}
 
 func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	instance := &chaosv1beta1.Disruption{}
@@ -157,6 +143,15 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			orphanErr := r.ChaosPodService.HandleOrphanedChaosPods(ctx, req)
 			endSpan(orphanSpan, orphanErr)
 			err = orphanErr
+
+			// Confirm deletion via uncached reader before tearing down watchers.
+			// The cached client can transiently return NotFound during cache lag or startup;
+			// removing live watcher state in that case leaves the disruption unmonitored
+			// until the next reconcile event.
+			uncachedErr := r.APIReader.Get(ctx, req.NamespacedName, &chaosv1beta1.Disruption{})
+			if apierrors.IsNotFound(uncachedErr) {
+				r.DisruptionsWatchersManager.RemoveWatchersForDisruption(ctx, req.NamespacedName)
+			}
 		}
 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -173,6 +168,7 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}()
 
 	hasParentTrace := false
+
 	ctx, spanCtxErr := instance.SpanContext(ctx)
 	if spanCtxErr != nil {
 		if errors.Is(spanCtxErr, chaosv1beta1.ErrNoSpanContext) {
@@ -194,6 +190,7 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	kindNames := instance.Spec.KindNames()
+
 	kindStrs := make([]string, 0, len(kindNames))
 	for _, k := range kindNames {
 		kindStrs = append(kindStrs, string(k))
@@ -210,7 +207,7 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		attribute.Bool("chaos.disruption.deleting", !instance.DeletionTimestamp.IsZero()),
 		attribute.Bool("chaos.disruption.has_parent_trace", hasParentTrace),
 	}
-	
+
 	ctx, reconcileSpan = otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "Disruption.Reconcile",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithLinks(trace.LinkFromContext(ctx)),
@@ -223,7 +220,7 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// update context with enhanced logger (now including trace context)
 	ctx = cLog.WithLogger(ctx, r.log)
 
-	ctx, createWatchersSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.create_for_disruption",
+	watchersCtx, createWatchersSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.create_for_disruption",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("disruption.name", instance.Name),
@@ -232,7 +229,7 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	var createWatcherErr error
 
-	if createWatcherErr = r.DisruptionsWatchersManager.CreateAllWatchers(ctx, instance, nil, nil); createWatcherErr != nil {
+	if createWatcherErr = r.DisruptionsWatchersManager.CreateAllWatchers(watchersCtx, instance, nil, nil); createWatcherErr != nil {
 		r.log.Errorw("error during the creation of watchers", tagutil.ErrorKey, createWatcherErr)
 	}
 
@@ -493,6 +490,7 @@ func (r *DisruptionReconciler) updateInjectionStatus(ctx context.Context, instan
 			attribute.String("disruption.namespace", instance.Namespace),
 			attribute.String("chaos.disruption.injection_status.before", string(instance.Status.InjectionStatus)),
 		))
+
 	defer func() {
 		endSpan(span, err)
 		r.log.Debugw("injection status updated to", tagutil.InjectionStatusKey, instance.Status.InjectionStatus, tagutil.ErrorKey, err)
@@ -617,6 +615,7 @@ func (r *DisruptionReconciler) startInjection(ctx context.Context, instance *cha
 			attribute.String("disruption.namespace", instance.Namespace),
 			attribute.Int("chaos.disruption.target_count", len(instance.Status.TargetInjections)),
 		))
+
 	defer func() { endSpan(span, err) }()
 
 	// chaosPodsMap is used to check if a target's chaos pods already exist or not
@@ -701,6 +700,7 @@ func (r *DisruptionReconciler) createChaosPods(ctx context.Context, instance *ch
 			attribute.String("disruption.target", target),
 			attribute.String("chaos.disruption.level", string(instance.Spec.Level)),
 		))
+
 	defer func() { endSpan(span, err) }()
 
 	targetNodeName := ""
@@ -846,6 +846,7 @@ func (r *DisruptionReconciler) cleanDisruption(ctx context.Context, instance *ch
 			attribute.String("disruption.name", instance.Name),
 			attribute.String("disruption.namespace", instance.Namespace),
 		))
+
 	defer func() { endSpan(span, err) }()
 
 	cleaned = true
@@ -894,6 +895,7 @@ func (r *DisruptionReconciler) handleChaosPodsTermination(ctx context.Context, i
 			attribute.String("disruption.name", instance.Name),
 			attribute.String("disruption.namespace", instance.Namespace),
 		))
+
 	defer func() { endSpan(span, err) }()
 
 	// get already existing chaos pods for the given disruption
@@ -982,6 +984,7 @@ func (r *DisruptionReconciler) selectTargets(ctx context.Context, instance *chao
 			attribute.String("chaos.disruption.level", string(instance.Spec.Level)),
 			attribute.Bool("chaos.disruption.static_targeting", instance.Spec.StaticTargeting),
 		))
+
 	defer func() { endSpan(span, err) }()
 
 	if len(instance.Status.TargetInjections) != 0 && instance.Spec.StaticTargeting {
@@ -1358,6 +1361,7 @@ func (r *DisruptionReconciler) getEligibleTargets(ctx context.Context, instance 
 			attribute.String("disruption.namespace", instance.Namespace),
 			attribute.Int("chaos.disruption.potential_targets", len(potentialTargets)),
 		))
+
 	defer func() {
 		eligSpan.SetAttributes(attribute.Int("chaos.disruption.eligible_targets_count", len(eligibleTargets)))
 		endSpan(eligSpan, err)
@@ -1473,4 +1477,19 @@ NB: you can specify "spec.allowDisruptedTargets: true" to allow a new disruption
 	}
 
 	return eligibleTargets, nil
+}
+
+func endSpan(s trace.Span, err error) {
+	if s == nil {
+		return
+	}
+
+	if err != nil {
+		s.RecordError(err)
+		s.SetStatus(codes.Error, err.Error())
+	} else {
+		s.SetStatus(codes.Ok, "")
+	}
+
+	s.End()
 }

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -210,7 +210,7 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		attribute.Bool("chaos.disruption.deleting", !instance.DeletionTimestamp.IsZero()),
 		attribute.Bool("chaos.disruption.has_parent_trace", hasParentTrace),
 	}
-
+	
 	ctx, reconcileSpan = otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "Disruption.Reconcile",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithLinks(trace.LinkFromContext(ctx)),
@@ -223,20 +223,35 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// update context with enhanced logger (now including trace context)
 	ctx = cLog.WithLogger(ctx, r.log)
 
-	ctx, syncWatchersSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.sync_watchers",
-		trace.WithSpanKind(trace.SpanKindInternal))
+	ctx, removeOrphanWatchersSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.remove_orphans",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("disruption.name", instance.Name),
+			attribute.String("disruption.namespace", instance.Namespace),
+		))
 
-	var orphanWatcherErr, createWatcherErr error
+	var orphanWatcherErr error
 
 	if orphanWatcherErr = r.DisruptionsWatchersManager.RemoveAllOrphanWatchers(ctx); orphanWatcherErr != nil {
 		r.log.Errorw("error during the deletion of orphan watchers", tagutil.ErrorKey, orphanWatcherErr)
 	}
 
+	endSpan(removeOrphanWatchersSpan, orphanWatcherErr)
+
+	ctx, createWatchersSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.create_for_disruption",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("disruption.name", instance.Name),
+			attribute.String("disruption.namespace", instance.Namespace),
+		))
+
+	var createWatcherErr error
+
 	if createWatcherErr = r.DisruptionsWatchersManager.CreateAllWatchers(ctx, instance, nil, nil); createWatcherErr != nil {
 		r.log.Errorw("error during the creation of watchers", tagutil.ErrorKey, createWatcherErr)
 	}
 
-	endSpan(syncWatchersSpan, errors.Join(orphanWatcherErr, createWatcherErr))
+	endSpan(createWatchersSpan, createWatcherErr)
 
 	// handle any chaos pods being deleted (either by the disruption deletion or by an external event)
 	if err := r.handleChaosPodsTermination(ctx, instance); err != nil {

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -223,21 +223,6 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// update context with enhanced logger (now including trace context)
 	ctx = cLog.WithLogger(ctx, r.log)
 
-	ctx, removeOrphanWatchersSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.remove_orphans",
-		trace.WithSpanKind(trace.SpanKindInternal),
-		trace.WithAttributes(
-			attribute.String("disruption.name", instance.Name),
-			attribute.String("disruption.namespace", instance.Namespace),
-		))
-
-	var orphanWatcherErr error
-
-	if orphanWatcherErr = r.DisruptionsWatchersManager.RemoveAllOrphanWatchers(ctx); orphanWatcherErr != nil {
-		r.log.Errorw("error during the deletion of orphan watchers", tagutil.ErrorKey, orphanWatcherErr)
-	}
-
-	endSpan(removeOrphanWatchersSpan, orphanWatcherErr)
-
 	ctx, createWatchersSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.create_for_disruption",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -26,6 +27,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -81,6 +83,21 @@ type DisruptionReconciler struct {
 
 const TargetsCountLogLimit = 50
 
+func endSpan(s trace.Span, err error) {
+	if s == nil {
+		return
+	}
+
+	if err != nil {
+		s.RecordError(err)
+		s.SetStatus(codes.Error, err.Error())
+	} else {
+		s.SetStatus(codes.Ok, "")
+	}
+
+	s.End()
+}
+
 func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	instance := &chaosv1beta1.Disruption{}
 
@@ -131,45 +148,95 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if client.IgnoreNotFound(err) == nil {
 			// If we're reconciling but without an instance, then we must have been triggered by the pod informer
 			// We should check for and delete any orphaned chaos pods
-			err = r.ChaosPodService.HandleOrphanedChaosPods(ctx, req)
+			ctx, orphanSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.handle_orphaned_chaos_pods",
+				trace.WithSpanKind(trace.SpanKindInternal),
+				trace.WithAttributes(
+					attribute.String("disruption.name", req.Name),
+					attribute.String("disruption.namespace", req.Namespace),
+				))
+			orphanErr := r.ChaosPodService.HandleOrphanedChaosPods(ctx, req)
+			endSpan(orphanSpan, orphanErr)
+			err = orphanErr
 		}
 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if err := r.DisruptionsWatchersManager.RemoveAllOrphanWatchers(ctx); err != nil {
-		r.log.Errorw("error during the deletion of orphan watchers", tagutil.ErrorKey, err)
+	var reconcileSpan trace.Span
+
+	defer func() {
+		if reconcileSpan == nil {
+			return
+		}
+
+		endSpan(reconcileSpan, err)
+	}()
+
+	hasParentTrace := false
+	ctx, spanCtxErr := instance.SpanContext(ctx)
+	if spanCtxErr != nil {
+		if errors.Is(spanCtxErr, chaosv1beta1.ErrNoSpanContext) {
+			r.log.Debugw("no span context on disruption (expected if SpanContext annotation is missing)",
+				tagutil.DisruptionNameKey, instance.Name, tagutil.DisruptionNamespaceKey, instance.Namespace)
+		} else {
+			r.log.Errorw("invalid span context on disruption", tagutil.ErrorKey, spanCtxErr,
+				tagutil.DisruptionNameKey, instance.Name, tagutil.DisruptionNamespaceKey, instance.Namespace)
+		}
+	} else {
+		hasParentTrace = true
 	}
 
-	if err := r.DisruptionsWatchersManager.CreateAllWatchers(ctx, instance, nil, nil); err != nil {
-		r.log.Errorw("error during the creation of watchers", tagutil.ErrorKey, err)
-	}
-
-	ctx, err = instance.SpanContext(ctx)
-	if err != nil {
-		r.log.Errorw("did not find span context", tagutil.ErrorKey, err)
-	}
-
-	userInfo, err := instance.UserInfo()
-	if err != nil {
-		r.log.Errorw("error getting user info", tagutil.ErrorKey, err)
+	userInfo, userErr := instance.UserInfo()
+	if userErr != nil {
+		r.log.Errorw("error getting user info", tagutil.ErrorKey, userErr)
 
 		userInfo.Username = "did-not-find-user-info@email.com"
 	}
 
-	ctx, reconcileSpan := otel.Tracer("").Start(ctx, "reconcile", trace.WithLinks(trace.LinkFromContext(ctx)),
-		trace.WithAttributes(
-			attribute.String("disruption.name", instance.Name),
-			attribute.String("disruption.namespace", instance.Namespace),
-			attribute.String("disruption.user", userInfo.Username),
-		))
-	defer reconcileSpan.End()
+	kindNames := instance.Spec.KindNames()
+	kindStrs := make([]string, 0, len(kindNames))
+	for _, k := range kindNames {
+		kindStrs = append(kindStrs, string(k))
+	}
+
+	reconcileAttrs := []attribute.KeyValue{
+		attribute.String("disruption.name", instance.Name),
+		attribute.String("disruption.namespace", instance.Namespace),
+		attribute.String("disruption.resource_version", instance.ResourceVersion),
+		attribute.String("disruption.user", userInfo.Username),
+		attribute.String("chaos.disruption.level", string(instance.Spec.Level)),
+		attribute.String("chaos.disruption.kinds", strings.Join(kindStrs, ",")),
+		attribute.String("chaos.disruption.injection_status", string(instance.Status.InjectionStatus)),
+		attribute.Bool("chaos.disruption.deleting", !instance.DeletionTimestamp.IsZero()),
+		attribute.Bool("chaos.disruption.has_parent_trace", hasParentTrace),
+	}
+
+	ctx, reconcileSpan = otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "Disruption.Reconcile",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithLinks(trace.LinkFromContext(ctx)),
+		trace.WithAttributes(reconcileAttrs...),
+	)
 
 	// allows to sync logs with traces
 	r.log = r.log.With(r.TracerSink.GetLoggableTraceContext(reconcileSpan)...)
 
 	// update context with enhanced logger (now including trace context)
 	ctx = cLog.WithLogger(ctx, r.log)
+
+	ctx, syncWatchersSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.sync_watchers",
+		trace.WithSpanKind(trace.SpanKindInternal))
+
+	var orphanWatcherErr, createWatcherErr error
+
+	if orphanWatcherErr = r.DisruptionsWatchersManager.RemoveAllOrphanWatchers(ctx); orphanWatcherErr != nil {
+		r.log.Errorw("error during the deletion of orphan watchers", tagutil.ErrorKey, orphanWatcherErr)
+	}
+
+	if createWatcherErr = r.DisruptionsWatchersManager.CreateAllWatchers(ctx, instance, nil, nil); createWatcherErr != nil {
+		r.log.Errorw("error during the creation of watchers", tagutil.ErrorKey, createWatcherErr)
+	}
+
+	endSpan(syncWatchersSpan, errors.Join(orphanWatcherErr, createWatcherErr))
 
 	// handle any chaos pods being deleted (either by the disruption deletion or by an external event)
 	if err := r.handleChaosPodsTermination(ctx, instance); err != nil {
@@ -186,12 +253,20 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if controllerutil.ContainsFinalizer(instance, chaostypes.DisruptionFinalizer) {
 			// Check if the deletion time has expired for the 'instance' and it's not stuck on removal.
 			if instance.IsDeletionExpired(r.DisruptionsDeletionTimeout) && !instance.Status.IsStuckOnRemoval {
-				// Only mark as stuck if chaos pods exist — a disruption with no pods can be cleaned immediately.
-				chaosPods, err := r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, nil)
-				if err != nil {
-					return ctrl.Result{}, fmt.Errorf("error getting chaos pods to check if disruption is stuck on removal: %w", err)
+				ctx, stuckSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.check_stuck_on_removal",
+					trace.WithSpanKind(trace.SpanKindInternal))
+
+				chaosPods, stuckErr := r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, nil)
+				if stuckErr != nil {
+					endSpan(stuckSpan, stuckErr)
+
+					return ctrl.Result{}, fmt.Errorf("error getting chaos pods to check if disruption is stuck on removal: %w", stuckErr)
 				}
 
+				stuckSpan.SetAttributes(attribute.Int("chaos.disruption.chaos_pods_count", len(chaosPods)))
+				endSpan(stuckSpan, nil)
+
+				// Only mark as stuck if chaos pods exist — a disruption with no pods can be cleaned immediately.
 				if len(chaosPods) > 0 {
 					instance.Status.IsStuckOnRemoval = true
 
@@ -207,6 +282,14 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 
 			if instance.IsReadyToRemoveFinalizer(r.FinalizerDeletionDelay) {
+				ctx, finalizeSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.finalize_deletion",
+					trace.WithSpanKind(trace.SpanKindInternal),
+					trace.WithAttributes(
+						attribute.String("disruption.name", instance.Name),
+						attribute.String("disruption.namespace", instance.Namespace),
+						attribute.String("disruption.user", userInfo.Username),
+					))
+
 				// we reach this code when all the cleanup pods have succeeded and we waited for finalizerDeletionDelay
 				// we can remove the finalizer and let the resource being garbage collected
 				r.log.Infow("all chaos pods are cleaned up; removing disruption finalizer")
@@ -216,6 +299,8 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				controllerutil.RemoveFinalizer(instance, chaostypes.DisruptionFinalizer)
 
 				if err := r.Client.Update(ctx, instance); err != nil {
+					endSpan(finalizeSpan, err)
+
 					return ctrl.Result{}, fmt.Errorf("error removing disruption finalizer: %w", err)
 				}
 
@@ -228,16 +313,7 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				r.handleMetricSinkError(r.MetricsSink.MetricDisruptionCompletedDuration(time.Since(instance.CreationTimestamp.Time), tags))
 				r.emitKindCountMetrics(instance)
 
-				// close the ongoing disruption tracing Span
-				defer func() {
-					_, disruptionStopSpan := otel.Tracer("").Start(ctx, "disruption deletion", trace.WithAttributes(
-						attribute.String("disruption.name", instance.Name),
-						attribute.String("disruption.namespace", instance.Namespace),
-						attribute.String("disruption.user", userInfo.Username),
-					))
-
-					disruptionStopSpan.End()
-				}()
+				endSpan(finalizeSpan, nil)
 
 				return ctrl.Result{}, nil
 			} else if instance.Status.CleanedAt == nil {
@@ -410,19 +486,31 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // - an instance with no ready chaos pods is considered as "not injected"
 // - an instance expired will have previously defined status prefixed with "previously"
 func (r *DisruptionReconciler) updateInjectionStatus(ctx context.Context, instance *chaosv1beta1.Disruption) (err error) {
-	r.log.Debugw("checking if injection status needs to be updated", tagutil.InjectionStatusKey, instance.Status.InjectionStatus)
-
+	ctx, span := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.update_injection_status",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("disruption.name", instance.Name),
+			attribute.String("disruption.namespace", instance.Namespace),
+			attribute.String("chaos.disruption.injection_status.before", string(instance.Status.InjectionStatus)),
+		))
 	defer func() {
+		endSpan(span, err)
 		r.log.Debugw("injection status updated to", tagutil.InjectionStatusKey, instance.Status.InjectionStatus, tagutil.ErrorKey, err)
 	}()
+
+	r.log.Debugw("checking if injection status needs to be updated", tagutil.InjectionStatusKey, instance.Status.InjectionStatus)
 
 	readyPodsCount := 0
 
 	// get chaos pods
-	chaosPods, err := r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, nil)
+	var chaosPods []corev1.Pod
+
+	chaosPods, err = r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, nil)
 	if err != nil {
 		return fmt.Errorf("error getting instance chaos pods: %w", err)
 	}
+
+	span.SetAttributes(attribute.Int("chaos.disruption.chaos_pods_count", len(chaosPods)))
 
 	status := instance.Status.InjectionStatus
 	if status == chaostypes.DisruptionInjectionStatusInitial {
@@ -515,15 +603,28 @@ func (r *DisruptionReconciler) updateInjectionStatus(ctx context.Context, instan
 		return fmt.Errorf("unable to update disruption injection status: %w", err)
 	}
 
+	span.SetAttributes(attribute.String("chaos.disruption.injection_status.after", string(instance.Status.InjectionStatus)))
+
 	return nil
 }
 
 // startInjection creates non-existing chaos pod for the given disruption
-func (r *DisruptionReconciler) startInjection(ctx context.Context, instance *chaosv1beta1.Disruption) error {
+func (r *DisruptionReconciler) startInjection(ctx context.Context, instance *chaosv1beta1.Disruption) (err error) {
+	ctx, span := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.start_injection",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("disruption.name", instance.Name),
+			attribute.String("disruption.namespace", instance.Namespace),
+			attribute.Int("chaos.disruption.target_count", len(instance.Status.TargetInjections)),
+		))
+	defer func() { endSpan(span, err) }()
+
 	// chaosPodsMap is used to check if a target's chaos pods already exist or not
 	chaosPodsMap := make(map[string]map[string]bool, len(instance.Status.TargetInjections))
 
-	chaosPods, err := r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, nil)
+	var chaosPods []corev1.Pod
+
+	chaosPods, err = r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, nil)
 	if err != nil {
 		return fmt.Errorf("error getting chaos pods: %w", err)
 	}
@@ -549,7 +650,7 @@ func (r *DisruptionReconciler) startInjection(ctx context.Context, instance *cha
 	subspec := instance.Spec.DisruptionKindPicker(chaostypes.DisruptionKindNetworkDisruption)
 	if reflect.ValueOf(subspec).IsValid() && !reflect.ValueOf(subspec).IsNil() {
 		if err = instance.Spec.Network.UpdateHostsOnCloudDisruption(ctx, r.CloudService); err != nil {
-			return err
+			return fmt.Errorf("update hosts on cloud disruption: %w", err)
 		}
 	}
 
@@ -591,8 +692,16 @@ func (r *DisruptionReconciler) startInjection(ctx context.Context, instance *cha
 }
 
 // createChaosPods attempts to create all the chaos pods for a given target. If a given chaos pod already exists, it is not recreated.
-func (r *DisruptionReconciler) createChaosPods(ctx context.Context, instance *chaosv1beta1.Disruption, target string) error {
-	var err error
+func (r *DisruptionReconciler) createChaosPods(ctx context.Context, instance *chaosv1beta1.Disruption, target string) (err error) {
+	ctx, span := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.create_chaos_pods",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("disruption.name", instance.Name),
+			attribute.String("disruption.namespace", instance.Namespace),
+			attribute.String("disruption.target", target),
+			attribute.String("chaos.disruption.level", string(instance.Spec.Level)),
+		))
+	defer func() { endSpan(span, err) }()
 
 	targetNodeName := ""
 	targetContainers := map[string]string{}
@@ -603,7 +712,7 @@ func (r *DisruptionReconciler) createChaosPods(ctx context.Context, instance *ch
 	case chaostypes.DisruptionLevelPod:
 		pod := corev1.Pod{}
 
-		if err := r.Client.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: target}, &pod); err != nil {
+		if err = r.Client.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: target}, &pod); err != nil {
 			return fmt.Errorf("error getting target to inject: %w", err)
 		}
 
@@ -626,10 +735,14 @@ func (r *DisruptionReconciler) createChaosPods(ctx context.Context, instance *ch
 	}
 
 	// generate injection pods specs
-	targetChaosPods, err := r.ChaosPodService.GenerateChaosPodsOfDisruption(instance, target, targetNodeName, targetContainers, targetPodIP)
+	var targetChaosPods []corev1.Pod
+
+	targetChaosPods, err = r.ChaosPodService.GenerateChaosPodsOfDisruption(instance, target, targetNodeName, targetContainers, targetPodIP)
 	if err != nil {
 		return fmt.Errorf("error generating chaos pods: %w", err)
 	}
+
+	span.SetAttributes(attribute.Int("chaos.disruption.injector_pods_to_create", len(targetChaosPods)))
 
 	if len(targetChaosPods) == 0 {
 		r.recordEventOnDisruption(instance, chaosv1beta1.EventEmptyDisruption, instance.Name, "")
@@ -655,7 +768,9 @@ func (r *DisruptionReconciler) createChaosPods(ctx context.Context, instance *ch
 
 	for _, targetChaosPod := range targetChaosPods {
 		// check if an injection pod already exists for the given (instance, namespace, disruption kind) tuple
-		found, err := r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, targetChaosPod.Labels)
+		var found []corev1.Pod
+
+		found, err = r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, targetChaosPod.Labels)
 		if err != nil {
 			return fmt.Errorf("error getting existing chaos pods: %w", err)
 		}
@@ -675,8 +790,8 @@ func (r *DisruptionReconciler) createChaosPods(ctx context.Context, instance *ch
 			}
 
 			// wait for the pod to be existing
-			if err := r.ChaosPodService.WaitForPodCreation(ctx, targetChaosPod); err != nil {
-				r.log.Errorw("error waiting for chaos pod to be created", tagutil.ErrorKey, err, tagutil.ChaosPodNameKey, targetChaosPod.Name, tagutil.TargetNameKey, target)
+			if waitErr := r.ChaosPodService.WaitForPodCreation(ctx, targetChaosPod); waitErr != nil {
+				r.log.Errorw("error waiting for chaos pod to be created", tagutil.ErrorKey, waitErr, tagutil.ChaosPodNameKey, targetChaosPod.Name, tagutil.TargetNameKey, target)
 
 				continue
 			}
@@ -712,7 +827,7 @@ func (r *DisruptionReconciler) createChaosPods(ctx context.Context, instance *ch
 		// Update the status in the cluster using a deep copy to preserve in-memory spec changes
 		// (such as cloud disruption hosts populated by UpdateHostsOnCloudDisruption)
 		statusCopy := instance.DeepCopy()
-		if err := r.Client.Status().Update(ctx, statusCopy); err != nil {
+		if err = r.Client.Status().Update(ctx, statusCopy); err != nil {
 			return fmt.Errorf("error updating disruption status with run count: %w", err)
 		}
 	}
@@ -724,11 +839,21 @@ func (r *DisruptionReconciler) createChaosPods(ctx context.Context, instance *ch
 // for each existing chaos pod for the given instance, the function will delete the chaos pod to trigger its cleanup phase
 // the function returns true when no more chaos pods are existing (meaning that it keeps returning false if some pods
 // are deleted but still present)
-func (r *DisruptionReconciler) cleanDisruption(ctx context.Context, instance *chaosv1beta1.Disruption) (bool, error) {
-	cleaned := true
+func (r *DisruptionReconciler) cleanDisruption(ctx context.Context, instance *chaosv1beta1.Disruption) (cleaned bool, err error) {
+	ctx, span := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.clean",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("disruption.name", instance.Name),
+			attribute.String("disruption.namespace", instance.Namespace),
+		))
+	defer func() { endSpan(span, err) }()
+
+	cleaned = true
 
 	// get already existing chaos pods for the given disruption
-	chaosPods, err := r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, nil)
+	var chaosPods []corev1.Pod
+
+	chaosPods, err = r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, nil)
 	if err != nil {
 		return false, err
 	}
@@ -738,6 +863,11 @@ func (r *DisruptionReconciler) cleanDisruption(ctx context.Context, instance *ch
 	if len(chaosPods) > 0 {
 		cleaned = false
 	}
+
+	span.SetAttributes(
+		attribute.Int("chaos.disruption.chaos_pods_count", len(chaosPods)),
+		attribute.Bool("chaos.disruption.cleaned", cleaned),
+	)
 
 	// terminate running chaos pods to trigger cleanup
 	for _, chaosPod := range chaosPods {
@@ -757,12 +887,24 @@ func (r *DisruptionReconciler) cleanDisruption(ctx context.Context, instance *ch
 // if a finalizer can't be removed because none of the conditions above are fulfilled, the instance is flagged
 // as stuck on removal and the pod finalizer won't be removed unless someone does it manually
 // the pod target will be moved to ignored targets, so it is not picked up by the next reconcile loop
-func (r *DisruptionReconciler) handleChaosPodsTermination(ctx context.Context, instance *chaosv1beta1.Disruption) error {
+func (r *DisruptionReconciler) handleChaosPodsTermination(ctx context.Context, instance *chaosv1beta1.Disruption) (err error) {
+	ctx, span := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.handle_chaos_pods_termination",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("disruption.name", instance.Name),
+			attribute.String("disruption.namespace", instance.Namespace),
+		))
+	defer func() { endSpan(span, err) }()
+
 	// get already existing chaos pods for the given disruption
-	chaosPods, err := r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, nil)
+	var chaosPods []corev1.Pod
+
+	chaosPods, err = r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, nil)
 	if err != nil {
 		return err
 	}
+
+	span.SetAttributes(attribute.Int("chaos.disruption.chaos_pods_count", len(chaosPods)))
 
 	if len(chaosPods) == 0 {
 		return nil
@@ -772,7 +914,9 @@ func (r *DisruptionReconciler) handleChaosPodsTermination(ctx context.Context, i
 		r.handleChaosPodTermination(ctx, instance, chaosPod)
 	}
 
-	return r.Client.Status().Update(ctx, instance)
+	err = r.Client.Status().Update(ctx, instance)
+
+	return err
 }
 
 func (r *DisruptionReconciler) handleChaosPodTermination(ctx context.Context, instance *chaosv1beta1.Disruption, chaosPod corev1.Pod) {
@@ -829,7 +973,17 @@ func (r *DisruptionReconciler) updateTargetInjectionStatus(instance *chaosv1beta
 // targets will only be selected once per instance
 // the chosen targets names will be reflected in the instance status
 // subsequent calls to this function will always return the same targets as the first call
-func (r *DisruptionReconciler) selectTargets(ctx context.Context, instance *chaosv1beta1.Disruption) error {
+func (r *DisruptionReconciler) selectTargets(ctx context.Context, instance *chaosv1beta1.Disruption) (err error) {
+	ctx, span := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.select_targets",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("disruption.name", instance.Name),
+			attribute.String("disruption.namespace", instance.Namespace),
+			attribute.String("chaos.disruption.level", string(instance.Spec.Level)),
+			attribute.Bool("chaos.disruption.static_targeting", instance.Spec.StaticTargeting),
+		))
+	defer func() { endSpan(span, err) }()
+
 	if len(instance.Status.TargetInjections) != 0 && instance.Spec.StaticTargeting {
 		return nil
 	}
@@ -838,28 +992,47 @@ func (r *DisruptionReconciler) selectTargets(ctx context.Context, instance *chao
 
 	// validate the given label selector to avoid any formatting issues due to special chars
 	if instance.Spec.Selector != nil {
-		if err := targetselector.ValidateLabelSelector(instance.Spec.Selector.AsSelector()); err != nil {
+		if err = targetselector.ValidateLabelSelector(instance.Spec.Selector.AsSelector()); err != nil {
 			r.recordEventOnDisruption(instance, chaosv1beta1.EventInvalidDisruptionLabelSelector, err.Error(), "")
 
 			return err
 		}
 	}
 
-	matchingTargets, totalAvailableTargetsCount, err := r.getSelectorMatchingTargets(instance)
-	if err != nil {
-		r.log.Errorw("error getting matching targets", tagutil.ErrorKey, err)
+	ctx, matchSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.match_selector_targets",
+		trace.WithSpanKind(trace.SpanKindInternal))
+
+	var matchingTargets []string
+
+	var totalAvailableTargetsCount int
+
+	var matchErr error
+
+	matchingTargets, totalAvailableTargetsCount, matchErr = r.getSelectorMatchingTargets(instance)
+	if matchErr != nil {
+		r.log.Errorw("error getting matching targets", tagutil.ErrorKey, matchErr)
 	}
+
+	matchSpan.SetAttributes(
+		attribute.Int("chaos.disruption.matching_targets_count", len(matchingTargets)),
+		attribute.Int("chaos.disruption.total_available_targets", totalAvailableTargetsCount),
+	)
+	endSpan(matchSpan, matchErr)
 
 	instance.Status.RemoveDeadTargets(matchingTargets)
 
 	// instance.Spec.Count is a string that either represents a percentage or a value, we do the translation here
-	targetsCount, err := instance.GetTargetsCountAsInt(len(matchingTargets), true)
-	if err != nil {
+	var targetsCount int
+
+	targetsCount, countErr := instance.GetTargetsCountAsInt(len(matchingTargets), true)
+	if countErr != nil {
 		targetsCount = instance.Spec.Count.IntValue()
 	}
 
 	// filter matching targets to only get eligible ones
-	eligibleTargets, err := r.getEligibleTargets(ctx, instance, matchingTargets)
+	var eligibleTargets chaosv1beta1.TargetInjections
+
+	eligibleTargets, err = r.getEligibleTargets(ctx, instance, matchingTargets)
 	if err != nil {
 		return fmt.Errorf("error getting eligible targets: %w", err)
 	}
@@ -895,7 +1068,14 @@ func (r *DisruptionReconciler) selectTargets(ctx context.Context, instance *chao
 	instance.Status.SelectedTargetsCount = len(instance.Status.TargetInjections)
 	instance.Status.IgnoredTargetsCount = totalAvailableTargetsCount - targetsCount
 
-	return r.Client.Status().Update(ctx, instance)
+	span.SetAttributes(
+		attribute.Int("chaos.disruption.desired_targets_count", instance.Status.DesiredTargetsCount),
+		attribute.Int("chaos.disruption.selected_targets_count", instance.Status.SelectedTargetsCount),
+	)
+
+	err = r.Client.Status().Update(ctx, instance)
+
+	return err
 }
 
 // getMatchingTargets fetches all existing target fitting the disruption's selector
@@ -1171,7 +1351,17 @@ func (r *DisruptionReconciler) ReportMetrics(ctx context.Context) {
 // getEligibleTargets returns targets which can be targeted by the given instance from the given targets pool
 // it skips ignored targets and targets being already targeted by another disruption
 func (r *DisruptionReconciler) getEligibleTargets(ctx context.Context, instance *chaosv1beta1.Disruption, potentialTargets []string) (eligibleTargets chaosv1beta1.TargetInjections, err error) {
+	ctx, eligSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.get_eligible_targets",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("disruption.name", instance.Name),
+			attribute.String("disruption.namespace", instance.Namespace),
+			attribute.Int("chaos.disruption.potential_targets", len(potentialTargets)),
+		))
 	defer func() {
+		eligSpan.SetAttributes(attribute.Int("chaos.disruption.eligible_targets_count", len(eligibleTargets)))
+		endSpan(eligSpan, err)
+
 		var args []interface{}
 
 		potentialTargetsCount := len(potentialTargets)

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -186,16 +186,24 @@ func (r *DisruptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if controllerutil.ContainsFinalizer(instance, chaostypes.DisruptionFinalizer) {
 			// Check if the deletion time has expired for the 'instance' and it's not stuck on removal.
 			if instance.IsDeletionExpired(r.DisruptionsDeletionTimeout) && !instance.Status.IsStuckOnRemoval {
-				instance.Status.IsStuckOnRemoval = true
-
-				r.log.Infow("instance seems stuck on removal, the deletion time expired, please check manually")
-
-				// Update the status of the 'instance' to reflect that it's stuck on removal.
-				if err := r.Client.Status().Update(ctx, instance); err != nil {
-					return ctrl.Result{}, fmt.Errorf("error marking the disruption stuck on removal: %w", err)
+				// Only mark as stuck if chaos pods exist — a disruption with no pods can be cleaned immediately.
+				chaosPods, err := r.ChaosPodService.GetChaosPodsOfDisruption(ctx, instance, nil)
+				if err != nil {
+					return ctrl.Result{}, fmt.Errorf("error getting chaos pods to check if disruption is stuck on removal: %w", err)
 				}
 
-				r.recordEventOnDisruption(instance, chaosv1beta1.EventDisruptionStuckOnRemoval, "", "")
+				if len(chaosPods) > 0 {
+					instance.Status.IsStuckOnRemoval = true
+
+					r.log.Infow("instance seems stuck on removal, the deletion time expired, please check manually")
+
+					// Update the status of the 'instance' to reflect that it's stuck on removal.
+					if err := r.Client.Status().Update(ctx, instance); err != nil {
+						return ctrl.Result{}, fmt.Errorf("error marking the disruption stuck on removal: %w", err)
+					}
+
+					r.recordEventOnDisruption(instance, chaosv1beta1.EventDisruptionStuckOnRemoval, "", "")
+				}
 			}
 
 			if instance.IsReadyToRemoveFinalizer(r.FinalizerDeletionDelay) {

--- a/main.go
+++ b/main.go
@@ -272,6 +272,10 @@ func main() {
 				logger.Debugw("Check if we need to remove any expired watchers...")
 				disruptionReconciler.DisruptionsWatchersManager.RemoveAllExpiredWatchers(ctx)
 
+				if err := disruptionReconciler.DisruptionsWatchersManager.RemoveAllOrphanWatchers(ctx); err != nil {
+					logger.Errorw("error during the deletion of orphan watchers", tags.ErrorKey, err)
+				}
+
 			case <-ctx.Done():
 				// Context canceled, terminate the goroutine
 				return

--- a/main.go
+++ b/main.go
@@ -228,6 +228,7 @@ func main() {
 	// create disruption reconciler
 	disruptionReconciler := &controllers.DisruptionReconciler{
 		Client:                     mgr.GetClient(),
+		APIReader:                  mgr.GetAPIReader(),
 		BaseLog:                    logger,
 		Scheme:                     mgr.GetScheme(),
 		Recorder:                   broadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: chaosv1beta1.SourceDisruptionComponent}),

--- a/o11y/tracer/datadog/datadog.go
+++ b/o11y/tracer/datadog/datadog.go
@@ -25,6 +25,9 @@ func New() Sink {
 	provider := ddotel.NewTracerProvider(
 		ddtracer.WithProfilerCodeHotspots(true),
 		ddtracer.WithLogStartup(false),
+		// Reports Go runtime metrics (e.g. heap, goroutines) to the Agent via DogStatsD (~10s interval).
+		// Ensure the Agent is reachable for metrics (DD_AGENT_HOST / DD_DOGSTATSD_PORT or UDS), same as for traces.
+		ddtracer.WithRuntimeMetrics(),
 	)
 
 	return Sink{provider: provider}

--- a/o11y/tracer/scope.go
+++ b/o11y/tracer/scope.go
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package tracer
+
+// InstrumentationScopeDisruption is the OpenTelemetry instrumentation scope name for
+// Disruption reconciliation and admission webhook tracing.
+const InstrumentationScopeDisruption = "github.com/DataDog/chaos-controller/disruption"

--- a/watchers/disruptions_watchers_manager.go
+++ b/watchers/disruptions_watchers_manager.go
@@ -9,7 +9,12 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/DataDog/chaos-controller/o11y/tags"
+	"github.com/DataDog/chaos-controller/o11y/tracer"
 	"k8s.io/apimachinery/pkg/types"
 	k8scontrollercache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,9 +100,18 @@ func (d disruptionsWatchersManager) CreateAllWatchers(ctx context.Context, disru
 			continue
 		}
 
-		// Otherwise add the new watcher for the disruption
-		if err := d.addWatcher(disruption, watcherName, watcherNameHash, cacheMock, watcherManager); err != nil {
-			return err
+		ctx, addWatcherSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.add_watcher",
+			trace.WithSpanKind(trace.SpanKindInternal),
+			trace.WithAttributes(
+				attribute.String("disruption.name", disruption.Name),
+				attribute.String("disruption.namespace", disruption.Namespace),
+				attribute.String("chaos.watchers.kind", string(watcherName)),
+			))
+
+		addErr := d.addWatcher(disruption, watcherName, watcherNameHash, cacheMock, watcherManager)
+		endWatcherSpan(addWatcherSpan, addErr)
+		if addErr != nil {
+			return addErr
 		}
 
 		cLog.FromContext(ctx).Debugw("Watcher created", tags.WatcherNameKey, watcherName)
@@ -108,6 +122,14 @@ func (d disruptionsWatchersManager) CreateAllWatchers(ctx context.Context, disru
 
 // RemoveAllWatchers removes all the Watchers associated with the given Disruption.
 func (d disruptionsWatchersManager) RemoveAllWatchers(ctx context.Context, disruption *v1beta1.Disruption) {
+	ctx, span := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.remove_all_for_disruption",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("disruption.name", disruption.Name),
+			attribute.String("disruption.namespace", disruption.Namespace),
+		))
+	defer endWatcherSpan(span, nil)
+
 	logger := cLog.FromContext(ctx)
 	namespacedName := getDisruptionNamespacedName(disruption)
 
@@ -116,9 +138,13 @@ func (d disruptionsWatchersManager) RemoveAllWatchers(ctx context.Context, disru
 
 	// If the Watcher Manager does not exist just do nothing.
 	if watcherManager == nil {
+		span.SetAttributes(attribute.Bool("chaos.watchers.manager_found", false))
 		logger.Debugw("could not remove all watchers")
+
 		return
 	}
+
+	span.SetAttributes(attribute.Bool("chaos.watchers.manager_found", true))
 
 	watcherManager.RemoveAllWatchers()
 
@@ -130,6 +156,17 @@ func (d disruptionsWatchersManager) RemoveAllWatchers(ctx context.Context, disru
 
 // RemoveAllOrphanWatchers removes all Watchers associated with a none existing Disruption.
 func (d disruptionsWatchersManager) RemoveAllOrphanWatchers(ctx context.Context) error {
+	ctx, span := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.scan_orphan_managers",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(attribute.Int("chaos.watchers.stored_managers", len(d.watchersManagers))))
+	defer endWatcherSpan(span, nil)
+
+	var orphansRemoved int
+
+	defer func() {
+		span.SetAttributes(attribute.Int("chaos.watchers.orphans_removed", orphansRemoved))
+	}()
+
 	// For each stored watcher manager
 	for namespacedName, watchersManager := range d.watchersManagers {
 		// Check if the disruption still exists
@@ -139,11 +176,22 @@ func (d disruptionsWatchersManager) RemoveAllOrphanWatchers(ctx context.Context)
 				continue
 			}
 
+			ctx, dropSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.drop_orphan_manager",
+				trace.WithSpanKind(trace.SpanKindInternal),
+				trace.WithAttributes(
+					attribute.String("disruption.name", namespacedName.Name),
+					attribute.String("disruption.namespace", namespacedName.Namespace),
+				))
+
 			// If the disruption is missing, remove all watchers for this watcher manager
 			watchersManager.RemoveAllWatchers()
 
 			// Remove the watcher manager from the stored managers
 			delete(d.watchersManagers, namespacedName)
+
+			orphansRemoved++
+
+			endWatcherSpan(dropSpan, nil)
 
 			cLog.FromContext(ctx).Infow("all watchers have been removed",
 				tags.WatcherNameKey, namespacedName.Name,

--- a/watchers/disruptions_watchers_manager.go
+++ b/watchers/disruptions_watchers_manager.go
@@ -124,6 +124,7 @@ func (d disruptionsWatchersManager) CreateAllWatchers(ctx context.Context, disru
 
 		addErr := d.addWatcher(disruption, watcherName, watcherNameHash, cacheMock, watcherManager)
 		endWatcherSpan(addWatcherSpan, addErr)
+
 		if addErr != nil {
 			return addErr
 		}

--- a/watchers/disruptions_watchers_manager.go
+++ b/watchers/disruptions_watchers_manager.go
@@ -37,6 +37,10 @@ type DisruptionsWatchersManager interface {
 
 	// RemoveAllExpiredWatchers removes all expired Watchers
 	RemoveAllExpiredWatchers(ctx context.Context)
+
+	// RemoveWatchersForDisruption removes all watchers for a single disruption identified by its NamespacedName.
+	// This is a targeted O(1) cleanup used when reconcile determines the disruption no longer exists.
+	RemoveWatchersForDisruption(ctx context.Context, namespacedName types.NamespacedName)
 }
 
 // WatcherManagers represents a map of Manager instances
@@ -48,6 +52,7 @@ type disruptionsWatchersManager struct {
 	factory          Factory
 	reader           client.Reader
 	watchersManagers WatcherManagers
+	managerUIDs      map[types.NamespacedName]types.UID
 }
 
 type WatcherName string
@@ -72,6 +77,14 @@ func (d disruptionsWatchersManager) CreateAllWatchers(ctx context.Context, disru
 	// Get the namespaced name of the disruption
 	disruptionNamespacedName := getDisruptionNamespacedName(disruption)
 
+	// Evict the cached manager if the disruption was recreated under the same namespace/name.
+	// A UID mismatch means the Kubernetes object is new; the old cached manager must not be reused.
+	if cachedUID, ok := d.managerUIDs[disruptionNamespacedName]; ok && cachedUID != disruption.UID {
+		d.watchersManagers[disruptionNamespacedName].RemoveAllWatchers()
+		delete(d.watchersManagers, disruptionNamespacedName)
+		delete(d.managerUIDs, disruptionNamespacedName)
+	}
+
 	var watcherManager Manager
 
 	// If a mock watcher manager was passed in, use it
@@ -83,6 +96,7 @@ func (d disruptionsWatchersManager) CreateAllWatchers(ctx context.Context, disru
 
 	// Save the watcher manager for later use
 	d.watchersManagers[disruptionNamespacedName] = watcherManager
+	d.managerUIDs[disruptionNamespacedName] = disruption.UID
 
 	// Calculate a hash of the disruption spec (excluding the count field)
 	disSpecHash, err := disruption.Spec.HashNoCount()
@@ -150,6 +164,7 @@ func (d disruptionsWatchersManager) RemoveAllWatchers(ctx context.Context, disru
 
 	// Remove the Watcher Manager from the map.
 	delete(d.watchersManagers, namespacedName)
+	delete(d.managerUIDs, namespacedName)
 
 	logger.Infow("all watchers have been removed")
 }
@@ -192,7 +207,7 @@ func (d disruptionsWatchersManager) RemoveAllOrphanWatchers(ctx context.Context)
 			continue
 		}
 
-		ctx, dropSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.drop_orphan_manager",
+		dropCtx, dropSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.drop_orphan_manager",
 			trace.WithSpanKind(trace.SpanKindInternal),
 			trace.WithAttributes(
 				attribute.String("disruption.name", namespacedName.Name),
@@ -201,17 +216,46 @@ func (d disruptionsWatchersManager) RemoveAllOrphanWatchers(ctx context.Context)
 
 		watchersManager.RemoveAllWatchers()
 		delete(d.watchersManagers, namespacedName)
+		delete(d.managerUIDs, namespacedName)
+
 		orphansRemoved++
 
 		endWatcherSpan(dropSpan, nil)
 
-		cLog.FromContext(ctx).Infow("all watchers have been removed",
+		cLog.FromContext(dropCtx).Infow("all watchers have been removed",
 			tags.WatcherNameKey, namespacedName.Name,
 			tags.WatcherNamespaceKey, namespacedName.Namespace,
 		)
 	}
 
 	return nil
+}
+
+// RemoveWatchersForDisruption removes all watchers for the given disruption without scanning the full cache.
+// It is called from the reconcile NotFound path so cleanup happens immediately, rather than waiting for
+// the 5-minute orphan sweep that runs in the background.
+func (d disruptionsWatchersManager) RemoveWatchersForDisruption(ctx context.Context, namespacedName types.NamespacedName) {
+	watcherManager, ok := d.watchersManagers[namespacedName]
+	if !ok {
+		return
+	}
+
+	ctx, span := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.remove_for_disruption",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("disruption.name", namespacedName.Name),
+			attribute.String("disruption.namespace", namespacedName.Namespace),
+		))
+	defer endWatcherSpan(span, nil)
+
+	watcherManager.RemoveAllWatchers()
+	delete(d.watchersManagers, namespacedName)
+	delete(d.managerUIDs, namespacedName)
+
+	cLog.FromContext(ctx).Infow("targeted watcher cleanup completed",
+		tags.WatcherNameKey, namespacedName.Name,
+		tags.WatcherNamespaceKey, namespacedName.Namespace,
+	)
 }
 
 // RemoveAllExpiredWatchers loops through all the watcher managers in the disruptionsWatchersManager
@@ -226,6 +270,7 @@ func (d disruptionsWatchersManager) RemoveAllExpiredWatchers(ctx context.Context
 func NewDisruptionsWatchersManager(controller controller.Controller, factory Factory, reader client.Reader) DisruptionsWatchersManager {
 	return disruptionsWatchersManager{
 		watchersManagers: WatcherManagers{},
+		managerUIDs:      map[types.NamespacedName]types.UID{},
 		controller:       controller,
 		factory:          factory,
 		reader:           reader,

--- a/watchers/disruptions_watchers_manager.go
+++ b/watchers/disruptions_watchers_manager.go
@@ -156,6 +156,10 @@ func (d disruptionsWatchersManager) RemoveAllWatchers(ctx context.Context, disru
 
 // RemoveAllOrphanWatchers removes all Watchers associated with a none existing Disruption.
 func (d disruptionsWatchersManager) RemoveAllOrphanWatchers(ctx context.Context) error {
+	if len(d.watchersManagers) == 0 {
+		return nil
+	}
+
 	ctx, span := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.scan_orphan_managers",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(attribute.Int("chaos.watchers.stored_managers", len(d.watchersManagers))))
@@ -167,37 +171,44 @@ func (d disruptionsWatchersManager) RemoveAllOrphanWatchers(ctx context.Context)
 		span.SetAttributes(attribute.Int("chaos.watchers.orphans_removed", orphansRemoved))
 	}()
 
-	// For each stored watcher manager
+	// Single List call to fetch all existing disruptions (O(1) API calls instead of O(n))
+	disruptionList := &v1beta1.DisruptionList{}
+	if err := d.reader.List(ctx, disruptionList); err != nil {
+		return err
+	}
+
+	// Build a set of existing disruptions for O(1) membership lookups
+	existing := make(map[types.NamespacedName]struct{}, len(disruptionList.Items))
+	for i := range disruptionList.Items {
+		existing[types.NamespacedName{
+			Namespace: disruptionList.Items[i].Namespace,
+			Name:      disruptionList.Items[i].Name,
+		}] = struct{}{}
+	}
+
+	// For each stored watcher manager, remove it if its disruption no longer exists
 	for namespacedName, watchersManager := range d.watchersManagers {
-		// Check if the disruption still exists
-		if err := d.reader.Get(ctx, namespacedName, &v1beta1.Disruption{}); err != nil {
-			// If the error is not related to the disruption being missing, skip to the next watcher manager
-			if err = client.IgnoreNotFound(err); err != nil {
-				continue
-			}
-
-			ctx, dropSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.drop_orphan_manager",
-				trace.WithSpanKind(trace.SpanKindInternal),
-				trace.WithAttributes(
-					attribute.String("disruption.name", namespacedName.Name),
-					attribute.String("disruption.namespace", namespacedName.Namespace),
-				))
-
-			// If the disruption is missing, remove all watchers for this watcher manager
-			watchersManager.RemoveAllWatchers()
-
-			// Remove the watcher manager from the stored managers
-			delete(d.watchersManagers, namespacedName)
-
-			orphansRemoved++
-
-			endWatcherSpan(dropSpan, nil)
-
-			cLog.FromContext(ctx).Infow("all watchers have been removed",
-				tags.WatcherNameKey, namespacedName.Name,
-				tags.WatcherNamespaceKey, namespacedName.Namespace,
-			)
+		if _, found := existing[namespacedName]; found {
+			continue
 		}
+
+		ctx, dropSpan := otel.Tracer(tracer.InstrumentationScopeDisruption).Start(ctx, "disruption.watchers.drop_orphan_manager",
+			trace.WithSpanKind(trace.SpanKindInternal),
+			trace.WithAttributes(
+				attribute.String("disruption.name", namespacedName.Name),
+				attribute.String("disruption.namespace", namespacedName.Namespace),
+			))
+
+		watchersManager.RemoveAllWatchers()
+		delete(d.watchersManagers, namespacedName)
+		orphansRemoved++
+
+		endWatcherSpan(dropSpan, nil)
+
+		cLog.FromContext(ctx).Infow("all watchers have been removed",
+			tags.WatcherNameKey, namespacedName.Name,
+			tags.WatcherNamespaceKey, namespacedName.Namespace,
+		)
 	}
 
 	return nil

--- a/watchers/disruptions_watchers_manager_mock.go
+++ b/watchers/disruptions_watchers_manager_mock.go
@@ -14,6 +14,8 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 
+	types "k8s.io/apimachinery/pkg/types"
+
 	v1beta1 "github.com/DataDog/chaos-controller/api/v1beta1"
 )
 
@@ -188,6 +190,40 @@ func (_c *DisruptionsWatchersManagerMock_RemoveAllWatchers_Call) Return() *Disru
 }
 
 func (_c *DisruptionsWatchersManagerMock_RemoveAllWatchers_Call) RunAndReturn(run func(context.Context, *v1beta1.Disruption)) *DisruptionsWatchersManagerMock_RemoveAllWatchers_Call {
+	_c.Run(run)
+	return _c
+}
+
+// RemoveWatchersForDisruption provides a mock function with given fields: ctx, namespacedName
+func (_m *DisruptionsWatchersManagerMock) RemoveWatchersForDisruption(ctx context.Context, namespacedName types.NamespacedName) {
+	_m.Called(ctx, namespacedName)
+}
+
+// DisruptionsWatchersManagerMock_RemoveWatchersForDisruption_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveWatchersForDisruption'
+type DisruptionsWatchersManagerMock_RemoveWatchersForDisruption_Call struct {
+	*mock.Call
+}
+
+// RemoveWatchersForDisruption is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespacedName types.NamespacedName
+func (_e *DisruptionsWatchersManagerMock_Expecter) RemoveWatchersForDisruption(ctx interface{}, namespacedName interface{}) *DisruptionsWatchersManagerMock_RemoveWatchersForDisruption_Call {
+	return &DisruptionsWatchersManagerMock_RemoveWatchersForDisruption_Call{Call: _e.mock.On("RemoveWatchersForDisruption", ctx, namespacedName)}
+}
+
+func (_c *DisruptionsWatchersManagerMock_RemoveWatchersForDisruption_Call) Run(run func(ctx context.Context, namespacedName types.NamespacedName)) *DisruptionsWatchersManagerMock_RemoveWatchersForDisruption_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.NamespacedName))
+	})
+	return _c
+}
+
+func (_c *DisruptionsWatchersManagerMock_RemoveWatchersForDisruption_Call) Return() *DisruptionsWatchersManagerMock_RemoveWatchersForDisruption_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *DisruptionsWatchersManagerMock_RemoveWatchersForDisruption_Call) RunAndReturn(run func(context.Context, types.NamespacedName)) *DisruptionsWatchersManagerMock_RemoveWatchersForDisruption_Call {
 	_c.Run(run)
 	return _c
 }

--- a/watchers/disruptions_watchers_manager_test.go
+++ b/watchers/disruptions_watchers_manager_test.go
@@ -6,6 +6,7 @@
 package watchers_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -340,8 +342,12 @@ var _ = Describe("Disruptions watchers manager", func() {
 		Context("with two non orphan disruptions", func() {
 			BeforeEach(func() {
 				// Arrange / Assert
-				By("check if disruptions exist")
-				readerMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+				By("list all existing disruptions")
+				readerMock.EXPECT().List(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					dl := list.(*chaosv1beta1.DisruptionList)
+					dl.Items = []chaosv1beta1.Disruption{*twoDisruptions[0], *twoDisruptions[1]}
+					return nil
+				}).Once()
 			})
 
 			It("should do nothing", func(ctx SpecContext) {
@@ -352,21 +358,14 @@ var _ = Describe("Disruptions watchers manager", func() {
 		Context("with two not found disruptions", func() {
 			BeforeEach(func() {
 				// Arrange / Assert
-				var errorStatus = errors.StatusError{
-					ErrStatus: metav1.Status{
-						Message: "Not found",
-						Reason:  metav1.StatusReasonNotFound,
-						Code:    http.StatusNotFound,
-					},
-				}
-				By("check if the disruptions exists")
-				readerMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(&errorStatus).Twice()
+				By("list all existing disruptions (returns empty list — both are orphans)")
+				readerMock.EXPECT().List(mock.Anything, mock.Anything).Return(nil).Once()
 
 				By("call the RemoveAllWatchers method of the watcher instance")
 				watchersManagerMock.EXPECT().RemoveAllWatchers().Twice()
 			})
 
-			It("should do nothing", func(ctx SpecContext) {
+			It("should remove all orphan watchers", func(ctx SpecContext) {
 				Expect(disruptionsWatchersManager.RemoveAllOrphanWatchers(ctx)).Should(Succeed())
 			})
 
@@ -379,12 +378,12 @@ var _ = Describe("Disruptions watchers manager", func() {
 					watchersManagerMock.ExpectedCalls = nil
 					watchersManagerMock.Calls = nil
 
-					// Action
+					// Action — managers map is now empty, early return kicks in
 					Expect(disruptionsWatchersManager.RemoveAllOrphanWatchers(ctx)).To(Succeed())
 
 					// Assert
-					By("not call any Get  method of the reader")
-					readerMock.AssertNumberOfCalls(GinkgoT(), "Get", 0)
+					By("not call any List method of the reader (early return when managers map is empty)")
+					readerMock.AssertNumberOfCalls(GinkgoT(), "List", 0)
 
 					By("not call any RemoveAllWatcher method of the watchersManager")
 					watchersManagerMock.AssertNumberOfCalls(GinkgoT(), "RemoveAllWatchers", 0)
@@ -392,7 +391,7 @@ var _ = Describe("Disruptions watchers manager", func() {
 			})
 		})
 
-		When("the Get method of the reader return a server error", func() {
+		When("the List method of the reader returns a server error", func() {
 			BeforeEach(func() {
 				var errorStatus = errors.StatusError{
 					ErrStatus: metav1.Status{
@@ -401,13 +400,13 @@ var _ = Describe("Disruptions watchers manager", func() {
 						Code:    http.StatusInternalServerError,
 					},
 				}
-				By("check if the disruptions exists")
-				readerMock.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(&errorStatus).Twice()
+				By("list all existing disruptions (returns server error)")
+				readerMock.EXPECT().List(mock.Anything, mock.Anything).Return(&errorStatus).Once()
 			})
 
-			It("should do nothing", func(ctx SpecContext) {
+			It("should return the error and not remove any watchers", func(ctx SpecContext) {
 				// Act
-				Expect(disruptionsWatchersManager.RemoveAllOrphanWatchers(ctx)).To(Succeed())
+				Expect(disruptionsWatchersManager.RemoveAllOrphanWatchers(ctx)).NotTo(Succeed())
 
 				// Assert
 				By("not call the RemoveAllWatchers method of the watchersManager")

--- a/watchers/disruptions_watchers_manager_test.go
+++ b/watchers/disruptions_watchers_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -232,6 +233,90 @@ var _ = Describe("Disruptions watchers manager", func() {
 		})
 	})
 
+	When("CreateAllWatchers is called with a disruption UID change", func() {
+		var (
+			oldManagerMock *watchers.ManagerMock
+			newManagerMock *watchers.ManagerMock
+		)
+
+		BeforeEach(func() {
+			disruption = &chaosv1beta1.Disruption{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "disruption-name",
+					Namespace: "namespace",
+					UID:       types.UID("uid-v1"),
+				},
+			}
+			watcherFactoryMock = watchers.NewFactoryMock(GinkgoT())
+			oldManagerMock = watchers.NewManagerMock(GinkgoT())
+			newManagerMock = watchers.NewManagerMock(GinkgoT())
+		})
+
+		When("the cached manager has a different disruption UID (recreated disruption)", func() {
+			It("should evict the stale manager and create fresh watchers", func(ctx SpecContext) {
+				disSpecHash, err := disruption.Spec.HashNoCount()
+				Expect(err).ShouldNot(HaveOccurred())
+				expectedDTWatcher := disSpecHash + string(watchers.DisruptionTargetWatcherName)
+				expectedCPWatcher := disSpecHash + string(watchers.ChaosPodWatcherName)
+
+				By("seeding the cache via first CreateAllWatchers call with uid-v1")
+				oldManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil).Twice()
+				oldManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Twice()
+				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcher, true, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
+				watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedCPWatcher, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
+				Expect(disruptionsWatchersManager.CreateAllWatchers(ctx, disruption, oldManagerMock, cacheMock)).To(Succeed())
+
+				By("building a recreated disruption with the same namespace/name but a new UID")
+				recreatedDisruption := &chaosv1beta1.Disruption{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      disruption.Name,
+						Namespace: disruption.Namespace,
+						UID:       types.UID("uid-v2"),
+					},
+				}
+
+				By("expecting the stale manager to be evicted (RemoveAllWatchers called)")
+				oldManagerMock.EXPECT().RemoveAllWatchers().Once()
+
+				By("expecting fresh watchers to be created for the new disruption")
+				newManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil).Twice()
+				newManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Twice()
+				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcher, true, recreatedDisruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
+				watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedCPWatcher, recreatedDisruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
+
+				Expect(disruptionsWatchersManager.CreateAllWatchers(ctx, recreatedDisruption, newManagerMock, cacheMock)).To(Succeed())
+			})
+		})
+
+		When("the cached manager has the same disruption UID", func() {
+			It("should reuse the cached manager without eviction", func(ctx SpecContext) {
+				disSpecHash, err := disruption.Spec.HashNoCount()
+				Expect(err).ShouldNot(HaveOccurred())
+				expectedDTWatcher := disSpecHash + string(watchers.DisruptionTargetWatcherName)
+				expectedCPWatcher := disSpecHash + string(watchers.ChaosPodWatcherName)
+
+				By("seeding the cache via first CreateAllWatchers call with uid-v1")
+				oldManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil).Twice()
+				oldManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Twice()
+				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcher, true, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
+				watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedCPWatcher, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
+				Expect(disruptionsWatchersManager.CreateAllWatchers(ctx, disruption, oldManagerMock, cacheMock)).To(Succeed())
+
+				By("calling CreateAllWatchers again with the same UID — existing watchers already present")
+				oldManagerMock.EXPECT().GetWatcher(expectedDTWatcher).Return(watchers.NewWatcherMock(GinkgoT())).Once()
+				oldManagerMock.EXPECT().GetWatcher(expectedCPWatcher).Return(watchers.NewWatcherMock(GinkgoT())).Once()
+				Expect(disruptionsWatchersManager.CreateAllWatchers(ctx, disruption, oldManagerMock, cacheMock)).To(Succeed())
+
+				By("not calling RemoveAllWatchers on the cached manager")
+				oldManagerMock.AssertNumberOfCalls(GinkgoT(), "RemoveAllWatchers", 0)
+
+				By("not calling factory methods on the second pass")
+				watcherFactoryMock.AssertNumberOfCalls(GinkgoT(), "NewDisruptionTargetWatcher", 1)
+				watcherFactoryMock.AssertNumberOfCalls(GinkgoT(), "NewChaosPodWatcher", 1)
+			})
+		})
+	})
+
 	When("RemoveAllWatchers method is called", func() {
 		Context("with an existing disruption", func() {
 			BeforeEach(func() {
@@ -410,6 +495,69 @@ var _ = Describe("Disruptions watchers manager", func() {
 
 				// Assert
 				By("not call the RemoveAllWatchers method of the watchersManager")
+				watchersManagerMock.AssertNumberOfCalls(GinkgoT(), "RemoveAllWatchers", 0)
+			})
+		})
+	})
+
+	When("RemoveWatchersForDisruption method is called", func() {
+		BeforeEach(func() {
+			// Arrange / Assert
+			watcherFactoryMock = watchers.NewFactoryMock(GinkgoT())
+
+			for _, disruption := range twoDisruptions {
+				disSpecHash, err := disruption.Spec.HashNoCount()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				expectedDisruptionTargetWatcherName = disSpecHash + string(watchers.DisruptionTargetWatcherName)
+				expectedChaosPodWatcherName = disSpecHash + string(watchers.ChaosPodWatcherName)
+
+				watchersManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil)
+				watchersManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil)
+				watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedChaosPodWatcherName, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
+				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDisruptionTargetWatcherName, mock.Anything, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
+			}
+		})
+
+		JustBeforeEach(func(ctx SpecContext) {
+			for _, disruption := range twoDisruptions {
+				Expect(disruptionsWatchersManager.CreateAllWatchers(ctx, disruption, watchersManagerMock, cacheMock)).To(Succeed())
+			}
+		})
+
+		Context("with an existing disruption", func() {
+			BeforeEach(func() {
+				By("call RemoveAllWatchers only for the targeted disruption")
+				watchersManagerMock.EXPECT().RemoveAllWatchers().Once()
+			})
+
+			It("should remove watchers for that disruption only, leaving the other untouched", func(ctx SpecContext) {
+				namespacedName := types.NamespacedName{
+					Name:      twoDisruptions[0].Name,
+					Namespace: twoDisruptions[0].Namespace,
+				}
+
+				disruptionsWatchersManager.RemoveWatchersForDisruption(ctx, namespacedName)
+
+				By("not calling RemoveAllWatchers again when invoked a second time (entry already removed)")
+				disruptionsWatchersManager.RemoveWatchersForDisruption(ctx, namespacedName)
+
+				By("not affecting the second disruption's manager")
+				watchersManagerMock.EXPECT().RemoveExpiredWatchers().Once()
+				disruptionsWatchersManager.RemoveAllExpiredWatchers(ctx)
+			})
+		})
+
+		Context("with a non-existing disruption", func() {
+			It("should do nothing", func(ctx SpecContext) {
+				namespacedName := types.NamespacedName{
+					Name:      "does-not-exist",
+					Namespace: "nowhere",
+				}
+
+				disruptionsWatchersManager.RemoveWatchersForDisruption(ctx, namespacedName)
+
+				By("not calling RemoveAllWatchers on any manager")
 				watchersManagerMock.AssertNumberOfCalls(GinkgoT(), "RemoveAllWatchers", 0)
 			})
 		})

--- a/watchers/tracing.go
+++ b/watchers/tracing.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package watchers
+
+import (
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func endWatcherSpan(s trace.Span, err error) {
+	if s == nil {
+		return
+	}
+
+	if err != nil {
+		s.RecordError(err)
+		s.SetStatus(codes.Error, err.Error())
+	} else {
+		s.SetStatus(codes.Ok, "")
+	}
+
+	s.End()
+}

--- a/webhook/span_context.go
+++ b/webhook/span_context.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/DataDog/chaos-controller/api/v1beta1"
 	"github.com/DataDog/chaos-controller/o11y/tags"
+	chaostracer "github.com/DataDog/chaos-controller/o11y/tracer"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,11 +46,14 @@ func (m *SpanContextMutator) Handle(ctx context.Context, req admission.Request) 
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	ctx, disruptionSpan := otel.Tracer("").Start(ctx, "disruption", trace.WithNewRoot(), trace.WithAttributes(
-		attribute.String("disruption.name", dis.Name),
-		attribute.String("disruption.namespace", dis.Namespace),
-		attribute.String("disruption.user", req.UserInfo.Username),
-	))
+	ctx, disruptionSpan := otel.Tracer(chaostracer.InstrumentationScopeDisruption).Start(ctx, "Disruption.SpanContextWebhook",
+		trace.WithNewRoot(),
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.String("disruption.name", dis.Name),
+			attribute.String("disruption.namespace", dis.Namespace),
+			attribute.String("disruption.user", req.UserInfo.Username),
+		))
 	defer disruptionSpan.End()
 
 	// retrieve span context
@@ -65,11 +70,15 @@ func (m *SpanContextMutator) Handle(ctx context.Context, req admission.Request) 
 	// writes the traceID and spanID in the annotations of the disruption
 	err := dis.SetSpanContext(ctx)
 	if err != nil {
+		disruptionSpan.RecordError(err)
+		disruptionSpan.SetStatus(codes.Error, err.Error())
 		m.Log.Errorw("error defining SpanContext", tags.ErrorKey, err, tags.DisruptionNameKey, dis.Name, tags.DisruptionNamespaceKey, dis.Namespace)
 	}
 
 	marshaled, err := json.Marshal(dis)
 	if err != nil {
+		disruptionSpan.RecordError(err)
+		disruptionSpan.SetStatus(codes.Error, err.Error())
 		m.Log.Errorw("error encoding modified annotations", tags.ErrorKey, err, tags.DisruptionNameKey, dis.Name, tags.DisruptionNamespaceKey, dis.Namespace)
 
 		return admission.Errored(http.StatusInternalServerError, err)


### PR DESCRIPTION
## What does this PR do?

- [x] Fixes a bug
- [x] Alters existing functionality

This PR addresses a false-positive `IsStuckOnRemoval` status for disruptions with no chaos pods, improves controller reconcile performance by moving the orphan watcher scan out of the hot path, fixes watcher state getting stuck when a disruption is deleted, and adds observability improvements (tracing + runtime metrics).

**Bug fix — skip stuck-on-removal when no chaos pods exist**
A disruption with no chaos pods can always be cleaned immediately. Previously, when the deletion timeout expired, `IsStuckOnRemoval` was set regardless, emitting a false-positive status, warning event, and metric. The flag is now guarded by a chaos pod existence check.

**Performance — orphan watcher scan moved out of reconcile loop**
`RemoveAllOrphanWatchers` was called on every reconcile with one direct API server call per stored watcher manager (O(n)). With many disruptions, this pushed reconcile times over 1 minute. The scan now runs in the existing 5-minute background goroutine using a single `List` call, reducing reconcile-path overhead to zero.

**Bug fix — watcher cleanup gated on uncached API confirmation**
The cached controller-runtime client can transiently return `NotFound` during cache lag or at startup. Previously, the reconciler would remove live watcher state on that false `NotFound`, leaving the disruption unmonitored until the next reconcile event. A direct uncached `APIReader.Get` call now confirms the disruption is truly gone before triggering watcher cleanup.

**Bug fix — stale watcher manager eviction on disruption recreation**
If a disruption was deleted and recreated under the same namespace/name, the watcher manager cache could hold a stale entry keyed by the old `UID`. The manager now tracks each disruption's `UID` and evicts the stale entry on mismatch, preventing dead watcher state from being reused for a new object.

**Feature — targeted O(1) watcher removal on deletion**
`RemoveWatchersForDisruption` is a new method that removes watchers for a single disruption immediately when reconcile determines the object is gone. Previously, cleanup relied on the 5-minute background orphan sweep, leaving watchers alive in the interim.

**Observability — enhanced tracing in Reconcile and watcher management**
- Added spans for orphaned chaos pod handling and watcher synchronization in `Reconcile`
- Introduced `endSpan` helper to streamline span management and error recording
- Added detailed spans for add/remove watcher operations with disruption context attributes
- Improved `SpanContextMutator` to record errors in the disruption span

**Observability — runtime metrics reporting in Datadog tracer**
Enabled Go runtime metrics (heap, goroutines, etc.) reporting to the Datadog Agent.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] Added watcher manager unit tests for UID-change eviction and targeted `RemoveWatchersForDisruption` cleanup.
- [x] I manually tested the following steps:
    - Verified disruptions with no chaos pods no longer emit `IsStuckOnRemoval` status/event/metric on deletion timeout
    - Confirmed reconcile times no longer degrade with high disruption counts
    - Verified watcher state is cleaned up immediately on disruption deletion without waiting for the orphan sweep
    - [x] locally.