### PR TITLE
chore(deps): upgrade ubuntu base images 20.04/22.04 → 24.04 LTS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ check-lockfile:
   tags: ["arch:amd64"]
   script:
     - apt-get update && apt-get install -y --no-install-recommends python3 python3-pip git ca-certificates
-    - python3 -m pip install --upgrade pip uv --break-system-packages
+    - python3 -m pip install uv --break-system-packages
     - uv pip compile --python-platform linux tasks/requirements.in -o tasks/requirements.txt.tmp
     - grep -v '^#' tasks/requirements.txt > tasks/requirements.txt.no-comments
     - grep -v '^#' tasks/requirements.txt.tmp > tasks/requirements.txt.tmp.no-comments

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ check-lockfile:
   tags: ["arch:amd64"]
   script:
     - apt-get update && apt-get install -y --no-install-recommends python3 python3-pip git ca-certificates
-    - python3 -m pip install --upgrade pip uv
+    - python3 -m pip install --upgrade pip uv --break-system-packages
     - uv pip compile --python-platform linux tasks/requirements.in -o tasks/requirements.txt.tmp
     - grep -v '^#' tasks/requirements.txt > tasks/requirements.txt.no-comments
     - grep -v '^#' tasks/requirements.txt.tmp > tasks/requirements.txt.tmp.no-comments

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ stages:
 
 check-lockfile:
   stage: check
-  image: registry.ddbuild.io/images/mirror/ubuntu:22.04
+  image: registry.ddbuild.io/images/mirror/ubuntu:24.04
   tags: ["arch:amd64"]
   script:
     - apt-get update && apt-get install -y --no-install-recommends python3 python3-pip git ca-certificates

--- a/examples/demo.yaml
+++ b/examples/demo.yaml
@@ -120,7 +120,7 @@ spec:
               memory: 32Mi
               cpu: 10m
         - name: read-file
-          image: ubuntu:focal-20240918
+          image: ubuntu:noble
           command: ["/bin/bash"]
           args:
             - -c
@@ -136,7 +136,7 @@ spec:
               memory: 32Mi
               cpu: 100m
         - name: write-file
-          image: ubuntu:focal-20240918
+          image: ubuntu:noble
           command: ["/bin/bash"]
           args:
             - -c

--- a/lima.yaml
+++ b/lima.yaml
@@ -17,9 +17,9 @@ vmOpts:
       binfmt: true
 
 images:
-  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img"
     arch: "x86_64"
-  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
     arch: "aarch64"
 
 # disable mounts


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [ ] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Upgrades Ubuntu image references from 20.04/22.04 to 24.04 LTS (Noble) across `lima.yaml`, `.gitlab-ci.yml`, and `examples/demo.yaml` to align with the version already used in production Dockerfiles
- Fixes the GitLab CI `check-lockfile` job for Ubuntu 24.04: adds `--break-system-packages` (required by PEP 668) and removes the `--upgrade pip` step (apt-managed pip cannot uninstall itself)

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - Triggered GitLab CI pipeline — `check-lockfile` job passes with Ubuntu 24.04.
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.