### PR TITLE
Scope chaos pod watch to stop OOM loops

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -1212,10 +1212,24 @@ func (r *DisruptionReconciler) recordEventOnTarget(ctx context.Context, instance
 
 // SetupWithManager setups the current reconciler with the given manager
 func (r *DisruptionReconciler) SetupWithManager(mgr ctrl.Manager, kubeInformerFactory kubeinformers.SharedInformerFactory) (controller.Controller, error) {
-	podToDisruption := func(ctx context.Context, d *corev1.Pod) []reconcile.Request {
+	if kubeInformerFactory == nil {
+		return nil, fmt.Errorf("kubernetes informer factory cannot be nil")
+	}
+
+	podToDisruption := func(ctx context.Context, o client.Object) []reconcile.Request {
+		d, ok := o.(*corev1.Pod)
+		if !ok {
+			return nil
+		}
+
 		// podtoDisruption is a function that maps pods to disruptions. it is meant to be used as an event handler on a pod informer
 		// this function should safely return an empty list of requests to reconcile if the object we receive is not actually a chaos pod
 		// which we determine by checking the object labels for the name and namespace labels that we add to all injector pods
+		requests := mapPodToDisruptionRequests(d)
+		if len(requests) == 0 {
+			return nil
+		}
+
 		if r.BaseLog != nil {
 			r.BaseLog.Debugw("watching event from pod", tagutil.ChaosPodNameKey, d.GetName(), tagutil.ChaosPodNamespaceKey, d.GetNamespace())
 		}
@@ -1225,19 +1239,38 @@ func (r *DisruptionReconciler) SetupWithManager(mgr ctrl.Manager, kubeInformerFa
 			tagutil.FormatTag(tagutil.PodNamespaceKey, d.GetNamespace()),
 		}))
 
-		podLabels := d.GetLabels()
-		name := podLabels[chaostypes.DisruptionNameLabel]
-		namespace := podLabels[chaostypes.DisruptionNamespaceLabel]
+		return requests
+	}
 
-		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}}}
+	podInformerSource := &source.Informer{
+		Informer: kubeInformerFactory.Core().V1().Pods().Informer(),
+		Handler:  handler.EnqueueRequestsFromMapFunc(podToDisruption),
+		Predicates: []predicate.Predicate{
+			chaosEventsPredicate(),
+		},
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&chaosv1beta1.Disruption{}).
 		WithOptions(controller.Options{RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](time.Second, time.Hour)}).
-		WatchesRawSource(source.Kind(mgr.GetCache(), &corev1.Pod{}, handler.TypedEnqueueRequestsFromMapFunc(podToDisruption))).
-		WithEventFilter(chaosEventsPredicate()).
+		WatchesRawSource(podInformerSource).
 		Build(r)
+}
+
+func mapPodToDisruptionRequests(pod *corev1.Pod) []reconcile.Request {
+	if pod == nil {
+		return nil
+	}
+
+	podLabels := pod.GetLabels()
+	name := podLabels[chaostypes.DisruptionNameLabel]
+	namespace := podLabels[chaostypes.DisruptionNamespaceLabel]
+
+	if name == "" || namespace == "" {
+		return nil
+	}
+
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}}}
 }
 
 // chaosEventsPredicate determines if given event is a chaos related one or not

--- a/controllers/disruption_controller_pod_mapping_test.go
+++ b/controllers/disruption_controller_pod_mapping_test.go
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package controllers
+
+import (
+	"testing"
+
+	chaosv1beta1 "github.com/DataDog/chaos-controller/api/v1beta1"
+	chaostypes "github.com/DataDog/chaos-controller/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestMapPodToDisruptionRequests(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected []reconcile.Request
+	}{
+		{
+			name:     "returns empty list for nil pod",
+			pod:      nil,
+			expected: nil,
+		},
+		{
+			name: "returns empty list for pod without disruption labels",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "target",
+					Namespace: "target-namespace",
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "returns empty list for pod missing disruption namespace label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "chaos-pod",
+					Namespace: "chaos-engineering",
+					Labels: map[string]string{
+						chaostypes.DisruptionNameLabel: "disruption-a",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "maps pod with disruption labels to reconcile request",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "chaos-pod",
+					Namespace: "chaos-engineering",
+					Labels: map[string]string{
+						chaostypes.DisruptionNameLabel:      "disruption-a",
+						chaostypes.DisruptionNamespaceLabel: "ns-a",
+					},
+				},
+			},
+			expected: []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      "disruption-a",
+						Namespace: "ns-a",
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := mapPodToDisruptionRequests(testCase.pod)
+
+			if len(result) != len(testCase.expected) {
+				t.Fatalf("unexpected number of requests: got %d, expected %d", len(result), len(testCase.expected))
+			}
+
+			for i := range testCase.expected {
+				if result[i] != testCase.expected[i] {
+					t.Fatalf("unexpected request at index %d: got %#v, expected %#v", i, result[i], testCase.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestShouldTriggerReconcile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns true for disruption objects", func(t *testing.T) {
+		t.Parallel()
+		if !shouldTriggerReconcile(&chaosv1beta1.Disruption{}) {
+			t.Fatal("expected disruption object to trigger reconcile")
+		}
+	})
+
+	t.Run("returns false for pod without disruption labels", func(t *testing.T) {
+		t.Parallel()
+		if shouldTriggerReconcile(&corev1.Pod{}) {
+			t.Fatal("expected pod without disruption labels to not trigger reconcile")
+		}
+	})
+
+	t.Run("returns true for pod with disruption labels", func(t *testing.T) {
+		t.Parallel()
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					chaostypes.DisruptionNameLabel:      "disruption-a",
+					chaostypes.DisruptionNamespaceLabel: "ns-a",
+				},
+			},
+		}
+
+		if !shouldTriggerReconcile(pod) {
+			t.Fatal("expected pod with disruption labels to trigger reconcile")
+		}
+	})
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"7468fb19-673e-44c2-850b-6d747131fcbf","source":"chat","resourceId":"785d898a-f8a0-48fe-84c2-ee042c8bd791","workflowId":"b9fbe3ee-cb6c-47a6-8bdb-cc122a8056b9","codeChangeId":"b9fbe3ee-cb6c-47a6-8bdb-cc122a8056b9","sourceType":"bits_ai_sre"} -->
## What does this PR do?

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/ce273aca-3bf9-4500-bee1-a425f5d2ec7a)

- [ ] Adds new functionality
- [x] Alters existing functionality
- [x] Fixes a bug
- [x] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- Prevents the disruption controller from handling every pod event through an unfiltered raw watch path, which could enqueue non-chaos pods and contribute to high memory usage and OOM crash loops.
- Switches pod event wiring to the namespace-scoped informer from `kubeInformerFactory` and applies `chaosEventsPredicate()` directly on that source.
- Adds `mapPodToDisruptionRequests` so pods missing disruption labels never enqueue reconcile requests, even if predicate behavior changes.
- Adds focused unit tests for pod-to-disruption request mapping and reconcile trigger predicate behavior.

## Code Quality Checklist

- [ ] The documentation is up to date.
- [ ] My code is sufficiently commented and passes continuous integration checks.
- [ ] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [ ] by depending on existing `unit` tests or `end-to-end` tests.
    - [x] by adding new `unit` tests or `end-to-end` tests.
- [x] I manually tested the following steps:
    - `go test ./controllers -run 'TestMapPodToDisruptionRequests|TestShouldTriggerReconcile' -count=1`
    - `GOOS=linux /tmp/bin/golangci-lint run ./controllers`
    - [x] locally.
    - [ ] as a canary deployment to a cluster.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/785d898a-f8a0-48fe-84c2-ee042c8bd791)

Comment @datadog to request changes