### PR TITLE
[FIX][CHAOS] Fix CI for fork contributors and harden workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 env:
   GOPATH: /home/runner/go
@@ -45,6 +48,7 @@ jobs:
           cache: true
       - name: Get Datadog credentials
         id: dd-sts
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
         with:
           policy: chaos-controller
@@ -53,9 +57,9 @@ jobs:
       - name: Run unit tests
         run: make test GINKGO_PROCS=2
         env:
-          DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+          DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key || '' }}
       - name: Upload code coverage
-        if: success()
+        if: success() && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push')
         run: ./bin/tools/datadog-ci coverage upload --format go-coverprofile --flags "type:unit-tests" cover.profile
         env:
           DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
@@ -98,6 +102,7 @@ jobs:
           cache: true
       - name: Get Datadog credentials
         id: dd-sts
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
         with:
           policy: chaos-controller
@@ -122,7 +127,7 @@ jobs:
         run: make minikube-load-all
       - name: Run e2e tests
         env:
-          DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+          DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key || '' }}
         run: |
           for attempt in 1 2 3; do
             echo "=== Attempt ${attempt}/3 ==="


### PR DESCRIPTION
## What does this PR do?

- [ ] Adds new functionality
- [x] Alters existing functionality
- [x] Fixes a bug
- [ ] Improves documentation or testing

Please briefly describe your changes as well as the motivation behind them:
- External contributors submitting PRs from forks had CI failing because the `Get Datadog credentials` step requires an OIDC token that GitHub does not grant to fork PRs. This adds `if:` guards to skip that step for forks, `|| ''` fallbacks on `DATADOG_API_KEY` (Make's `ifdef` treats empty as unset, so the optional JUnit upload is silently skipped), and gates the coverage upload on internal PRs only.
- Adds a top-level `permissions: contents: read` to restrict the default GITHUB_TOKEN scope across all jobs that previously inherited repository defaults.
- Scopes the concurrency group with `github.repository` to prevent a fork contributor from cancelling upstream runs by crafting a matching branch name.

## Code Quality Checklist

- [x] The documentation is up to date.
- [x] My code is sufficiently commented and passes continuous integration checks.
- [x] I have signed my commit (see [Contributing Docs](../CONTRIBUTING.md)).

## Testing

- [x] I leveraged continuous integration testing
    - [x] by depending on existing `unit` tests or `end-to-end` tests.
    - [ ] by adding new `unit` tests or `end-to-end` tests.
- [ ] I manually tested the following steps:
    - Verified fork PRs skip credential steps and run tests without errors.
    - Verified internal PRs still upload JUnit reports and coverage to Datadog.
    - [ ] locally.
    - [ ] as a canary deployment to a cluster.