### PR TITLE
[CHAOS-76][FIX] Replace per-disruption caches with shared caches to reduce Watch connections

### DIFF
--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -1255,6 +1255,7 @@ func (r *DisruptionReconciler) SetupWithManager(mgr ctrl.Manager) (controller.Co
 		r.Recorder,
 		r.BaseLog,
 		watchers.NewWatcherMetricsAdapter(r.MetricsSink, r.BaseLog),
+		mgr.Elected(), // gate event/metric emission on leadership in HA deployments
 	)
 
 	if _, err := podInformer.AddEventHandler(sharedHandler); err != nil {

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -712,7 +712,7 @@ func (r *DisruptionReconciler) createChaosPods(ctx context.Context, instance *ch
 	case chaostypes.DisruptionLevelPod:
 		pod := corev1.Pod{}
 
-		if err = r.Client.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: target}, &pod); err != nil {
+		if err = r.APIReader.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: target}, &pod); err != nil {
 			return fmt.Errorf("error getting target to inject: %w", err)
 		}
 
@@ -1089,7 +1089,7 @@ func (r *DisruptionReconciler) getSelectorMatchingTargets(instance *chaosv1beta1
 	// select either pods or nodes depending on the disruption level
 	switch instance.Spec.Level {
 	case chaostypes.DisruptionLevelPod:
-		pods, totalCount, err := r.TargetSelector.GetMatchingPodsOverTotalPods(r.Client, instance)
+		pods, totalCount, err := r.TargetSelector.GetMatchingPodsOverTotalPods(r.APIReader, instance)
 		if err != nil {
 			return nil, 0, fmt.Errorf("can't get pods matching the given label selector: %w", err)
 		}
@@ -1100,7 +1100,7 @@ func (r *DisruptionReconciler) getSelectorMatchingTargets(instance *chaosv1beta1
 
 		totalAvailableTargetsCount = totalCount
 	case chaostypes.DisruptionLevelNode:
-		nodes, totalCount, err := r.TargetSelector.GetMatchingNodesOverTotalNodes(r.Client, instance)
+		nodes, totalCount, err := r.TargetSelector.GetMatchingNodesOverTotalNodes(r.APIReader, instance)
 		if err != nil {
 			return nil, 0, fmt.Errorf("can't get nodes matching the given label selector: %w", err)
 		}
@@ -1189,7 +1189,7 @@ func (r *DisruptionReconciler) recordEventOnTarget(ctx context.Context, instance
 	case chaostypes.DisruptionLevelPod:
 		p := &corev1.Pod{}
 
-		if err := r.Client.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: target}, p); err != nil {
+		if err := r.APIReader.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: target}, p); err != nil {
 			r.log.Errorw("event failed to be registered on target", tagutil.ErrorKey, err, tagutil.TargetNameKey, target)
 		}
 
@@ -1197,7 +1197,7 @@ func (r *DisruptionReconciler) recordEventOnTarget(ctx context.Context, instance
 	case chaostypes.DisruptionLevelNode:
 		n := &corev1.Node{}
 
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: target}, n); err != nil {
+		if err := r.APIReader.Get(ctx, types.NamespacedName{Name: target}, n); err != nil {
 			r.log.Errorw("event failed to be registered on target", tagutil.ErrorKey, err, tagutil.TargetNameKey, target)
 		}
 

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -1231,12 +1231,37 @@ func (r *DisruptionReconciler) SetupWithManager(mgr ctrl.Manager) (controller.Co
 		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}}}
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	cont, err := ctrl.NewControllerManagedBy(mgr).
 		For(&chaosv1beta1.Disruption{}).
 		WithOptions(controller.Options{RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](time.Second, time.Hour)}).
 		WatchesRawSource(source.Kind(mgr.GetCache(), &corev1.Pod{}, handler.TypedEnqueueRequestsFromMapFunc(podToDisruption))).
 		WithEventFilter(chaosEventsPredicate()).
 		Build(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Register a single shared chaos pod handler on the manager's pod informer.
+	// This replaces per-disruption ChaosPodWatcher caches: all chaos pod events are
+	// handled by one shared handler that dispatches by reading disruption labels from
+	// the pod at event time.
+	podInformer, err := mgr.GetCache().GetInformer(context.Background(), &corev1.Pod{})
+	if err != nil {
+		return nil, fmt.Errorf("SetupWithManager: failed to get pod informer: %w", err)
+	}
+
+	sharedHandler := watchers.NewSharedChaosPodHandler(
+		r.APIReader,
+		r.Recorder,
+		r.BaseLog,
+		watchers.NewWatcherMetricsAdapter(r.MetricsSink, r.BaseLog),
+	)
+
+	if _, err := podInformer.AddEventHandler(sharedHandler); err != nil {
+		return nil, fmt.Errorf("SetupWithManager: failed to register shared chaos pod handler: %w", err)
+	}
+
+	return cont, nil
 }
 
 // chaosEventsPredicate determines if given event is a chaos related one or not

--- a/controllers/disruption_controller.go
+++ b/controllers/disruption_controller.go
@@ -35,7 +35,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -1211,7 +1210,7 @@ func (r *DisruptionReconciler) recordEventOnTarget(ctx context.Context, instance
 }
 
 // SetupWithManager setups the current reconciler with the given manager
-func (r *DisruptionReconciler) SetupWithManager(mgr ctrl.Manager, kubeInformerFactory kubeinformers.SharedInformerFactory) (controller.Controller, error) {
+func (r *DisruptionReconciler) SetupWithManager(mgr ctrl.Manager) (controller.Controller, error) {
 	podToDisruption := func(ctx context.Context, d *corev1.Pod) []reconcile.Request {
 		// podtoDisruption is a function that maps pods to disruptions. it is meant to be used as an event handler on a pod informer
 		// this function should safely return an empty list of requests to reconcile if the object we receive is not actually a chaos pod

--- a/main.go
+++ b/main.go
@@ -301,7 +301,9 @@ func main() {
 
 	defer cancel()
 
-	stopCh := make(chan struct{})
+	// Buffered so the send at mgr.Start failure doesn't block when rollout informers
+	// are disabled and nobody is reading the channel.
+	stopCh := make(chan struct{}, 1)
 
 	go disruptionReconciler.ReportMetrics(ctx)
 

--- a/main.go
+++ b/main.go
@@ -271,6 +271,7 @@ func main() {
 		Reader:         mgr.GetAPIReader(),
 		Recorder:       disruptionReconciler.Recorder,
 		ChaosNamespace: cfg.Injector.ChaosNamespace,
+		CachePool:      watchers.NewNamespaceCachePool(ctrl.GetConfigOrDie()),
 	}
 	watcherFactory := watchers.NewWatcherFactory(watchersFactoryConfig)
 	disruptionReconciler.DisruptionsWatchersManager = watchers.NewDisruptionsWatchersManager(cont, watcherFactory, mgr.GetAPIReader())

--- a/main.go
+++ b/main.go
@@ -135,6 +135,16 @@ func main() {
 		}),
 		Cache: ctrlcache.Options{
 			DefaultTransform: ctrlcache.TransformStripManagedFields(),
+			// Restrict pod watch to the chaos namespace only. The controller only
+			// needs pod events for chaos pods (all in ChaosNamespace). Target pods
+			// in user namespaces are read via APIReader on the reconcile path.
+			ByObject: map[client.Object]ctrlcache.ByObject{
+				&corev1.Pod{}: {
+					Namespaces: map[string]ctrlcache.Config{
+						cfg.Injector.ChaosNamespace: {},
+					},
+				},
+			},
 		},
 	})
 	if err != nil {
@@ -208,6 +218,7 @@ func main() {
 
 	chaosPodService, err := services.NewChaosPodService(services.ChaosPodServiceConfig{
 		Client:         mgr.GetClient(),
+		Reader:         mgr.GetAPIReader(),
 		ChaosNamespace: cfg.Injector.ChaosNamespace,
 		TargetSelector: targetSelector,
 		Injector: services.ChaosPodServiceInjectorConfig{

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -132,6 +133,9 @@ func main() {
 			Port:    cfg.Controller.Webhook.Port,
 			CertDir: cfg.Controller.Webhook.CertDir,
 		}),
+		Cache: ctrlcache.Options{
+			DefaultTransform: ctrlcache.TransformStripManagedFields(),
+		},
 	})
 	if err != nil {
 		logger.Fatalw("unable to start manager", tags.ErrorKey, err)
@@ -244,9 +248,8 @@ func main() {
 	}
 
 	informerClient := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())
-	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(informerClient, time.Hour*24, kubeinformers.WithNamespace(cfg.Injector.ChaosNamespace))
 
-	cont, err := disruptionReconciler.SetupWithManager(mgr, kubeInformerFactory)
+	cont, err := disruptionReconciler.SetupWithManager(mgr)
 	if err != nil {
 		logger.Fatalw("unable to create controller", tags.ControllerKey, chaosv1beta1.DisruptionKind, tags.ErrorKey, err)
 	}
@@ -287,7 +290,6 @@ func main() {
 	defer cancel()
 
 	stopCh := make(chan struct{})
-	kubeInformerFactory.Start(stopCh)
 
 	go disruptionReconciler.ReportMetrics(ctx)
 

--- a/services/chaospod.go
+++ b/services/chaospod.go
@@ -111,6 +111,13 @@ func NewChaosPodService(config ChaosPodServiceConfig) (ChaosPodService, error) {
 		return nil, fmt.Errorf("you must provide a non nil Kubernetes client")
 	}
 
+	// Default Reader to Client for backwards compatibility: callers that do not set
+	// Reader explicitly still get a working implementation (cached reads) rather than
+	// a nil-pointer panic during TargetIsHealthy / HandleOrphanedChaosPods.
+	if config.Reader == nil {
+		config.Reader = config.Client
+	}
+
 	return &chaosPodService{
 		config: config,
 	}, nil

--- a/services/chaospod.go
+++ b/services/chaospod.go
@@ -80,6 +80,7 @@ type ChaosPodServiceInjectorConfig struct {
 // ChaosPodServiceConfig contains configuration options for the chaosPodService.
 type ChaosPodServiceConfig struct {
 	Client           client.Client                 // Kubernetes client for interacting with the API server.
+	Reader           client.Reader                 // Uncached reader for target pods in user namespaces.
 	ChaosNamespace   string                        // Namespace where chaos-related resources are located.
 	TargetSelector   targetselector.TargetSelector // Target selector for selecting target pods.
 	Injector         ChaosPodServiceInjectorConfig // Configuration options for the injector.
@@ -141,7 +142,7 @@ func (m *chaosPodService) HandleChaosPodTermination(ctx context.Context, disrupt
 	target := chaosPod.Labels[chaostypes.TargetLabel]
 
 	// Check if the target of the disruption is healthy (running and ready).
-	if err := m.config.TargetSelector.TargetIsHealthy(target, m.config.Client, disruption); err != nil {
+	if err := m.config.TargetSelector.TargetIsHealthy(target, m.config.Reader, disruption); err != nil {
 		// return the error unless we have a specific reason to ignore it.
 		if !apierrors.IsNotFound(err) && chaosPodAllowedErrors.isNotAllowed(strings.ToLower(err.Error())) {
 			return false, err
@@ -412,7 +413,7 @@ func (m *chaosPodService) HandleOrphanedChaosPods(ctx context.Context, req ctrl.
 		logger.Infow("checking if we can clean up orphaned chaos pod", tagutil.ChaosPodNameKey, pod.Name, tagutil.TargetNameKey, target)
 
 		// if target doesn't exist, we can try to clean up the chaos pod
-		if err = m.config.Client.Get(ctx, types.NamespacedName{Name: target, Namespace: req.Namespace}, &p); apierrors.IsNotFound(err) {
+		if err = m.config.Reader.Get(ctx, types.NamespacedName{Name: target, Namespace: req.Namespace}, &p); apierrors.IsNotFound(err) {
 			logger.Warnw("orphaned chaos pod detected, will attempt to delete", tagutil.ChaosPodNameKey, pod.Name)
 
 			if err = m.removeFinalizerForChaosPod(ctx, &pod); err != nil {

--- a/services/chaospod_test.go
+++ b/services/chaospod_test.go
@@ -88,6 +88,9 @@ var _ = Describe("Chaos Pod Service", func() {
 		if chaosPodServiceConfig.Client == nil {
 			chaosPodServiceConfig.Client = k8sClientMock
 		}
+		if chaosPodServiceConfig.Reader == nil {
+			chaosPodServiceConfig.Reader = k8sClientMock
+		}
 
 		// Action
 		chaosPodService, err = services.NewChaosPodService(chaosPodServiceConfig)

--- a/targetselector/running_target_selector.go
+++ b/targetselector/running_target_selector.go
@@ -33,7 +33,7 @@ func NewRunningTargetSelector(controllerEnableSafeguards bool, controllerNodeNam
 }
 
 // GetMatchingPodsOverTotalPods returns a pods list containing all running pods matching the given label selector and namespace and the count of pods matching the selector
-func (r runningTargetSelector) GetMatchingPodsOverTotalPods(c client.Client, instance *chaosv1beta1.Disruption) (*corev1.PodList, int, error) {
+func (r runningTargetSelector) GetMatchingPodsOverTotalPods(c client.Reader, instance *chaosv1beta1.Disruption) (*corev1.PodList, int, error) {
 	// get parsed selector
 	selector, err := GetLabelSelectorFromInstance(instance)
 	if err != nil {
@@ -115,7 +115,7 @@ podLoop:
 }
 
 // GetMatchingNodesOverTotalNodes returns a nodes list containing all nodes matching the given label selector and the count of nodes matching the selector
-func (r runningTargetSelector) GetMatchingNodesOverTotalNodes(c client.Client, instance *chaosv1beta1.Disruption) (*corev1.NodeList, int, error) {
+func (r runningTargetSelector) GetMatchingNodesOverTotalNodes(c client.Reader, instance *chaosv1beta1.Disruption) (*corev1.NodeList, int, error) {
 	// get parsed selector
 	selector, err := GetLabelSelectorFromInstance(instance)
 	if err != nil {
@@ -174,7 +174,7 @@ nodeLoop:
 }
 
 // TargetIsHealthy returns an error if the given target is unhealthy or does not exist
-func (r runningTargetSelector) TargetIsHealthy(target string, c client.Client, instance *chaosv1beta1.Disruption) error {
+func (r runningTargetSelector) TargetIsHealthy(target string, c client.Reader, instance *chaosv1beta1.Disruption) error {
 	switch instance.Spec.Level {
 	case chaostypes.DisruptionLevelPod:
 		var p corev1.Pod

--- a/targetselector/target_selector.go
+++ b/targetselector/target_selector.go
@@ -18,13 +18,13 @@ import (
 // TargetSelector is an interface for applying network disruptions to a Kubernetes Cluster
 type TargetSelector interface {
 	// GetMatchingPodsOverTotalPods Returns list of matching ready and untargeted pods and number of total pods
-	GetMatchingPodsOverTotalPods(c client.Client, instance *chaosv1beta1.Disruption) (*corev1.PodList, int, error)
+	GetMatchingPodsOverTotalPods(c client.Reader, instance *chaosv1beta1.Disruption) (*corev1.PodList, int, error)
 
 	// GetMatchingNodesOverTotalNodes Returns list of matching ready and untargeted nodes and number of total nodes
-	GetMatchingNodesOverTotalNodes(c client.Client, instance *chaosv1beta1.Disruption) (*corev1.NodeList, int, error)
+	GetMatchingNodesOverTotalNodes(c client.Reader, instance *chaosv1beta1.Disruption) (*corev1.NodeList, int, error)
 
 	// TargetIsHealthy Returns an error if the given target is unhealthy or does not exist
-	TargetIsHealthy(target string, c client.Client, instance *chaosv1beta1.Disruption) error
+	TargetIsHealthy(target string, c client.Reader, instance *chaosv1beta1.Disruption) error
 }
 
 // ValidateLabelSelector assert label selector matches valid grammar, avoids CORE-414

--- a/targetselector/target_selector_mock.go
+++ b/targetselector/target_selector_mock.go
@@ -30,7 +30,7 @@ func (_m *TargetSelectorMock) EXPECT() *TargetSelectorMock_Expecter {
 }
 
 // GetMatchingNodesOverTotalNodes provides a mock function with given fields: c, instance
-func (_m *TargetSelectorMock) GetMatchingNodesOverTotalNodes(c client.Client, instance *v1beta1.Disruption) (*v1.NodeList, int, error) {
+func (_m *TargetSelectorMock) GetMatchingNodesOverTotalNodes(c client.Reader, instance *v1beta1.Disruption) (*v1.NodeList, int, error) {
 	ret := _m.Called(c, instance)
 
 	if len(ret) == 0 {
@@ -40,10 +40,10 @@ func (_m *TargetSelectorMock) GetMatchingNodesOverTotalNodes(c client.Client, in
 	var r0 *v1.NodeList
 	var r1 int
 	var r2 error
-	if rf, ok := ret.Get(0).(func(client.Client, *v1beta1.Disruption) (*v1.NodeList, int, error)); ok {
+	if rf, ok := ret.Get(0).(func(client.Reader, *v1beta1.Disruption) (*v1.NodeList, int, error)); ok {
 		return rf(c, instance)
 	}
-	if rf, ok := ret.Get(0).(func(client.Client, *v1beta1.Disruption) *v1.NodeList); ok {
+	if rf, ok := ret.Get(0).(func(client.Reader, *v1beta1.Disruption) *v1.NodeList); ok {
 		r0 = rf(c, instance)
 	} else {
 		if ret.Get(0) != nil {
@@ -51,13 +51,13 @@ func (_m *TargetSelectorMock) GetMatchingNodesOverTotalNodes(c client.Client, in
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(client.Client, *v1beta1.Disruption) int); ok {
+	if rf, ok := ret.Get(1).(func(client.Reader, *v1beta1.Disruption) int); ok {
 		r1 = rf(c, instance)
 	} else {
 		r1 = ret.Get(1).(int)
 	}
 
-	if rf, ok := ret.Get(2).(func(client.Client, *v1beta1.Disruption) error); ok {
+	if rf, ok := ret.Get(2).(func(client.Reader, *v1beta1.Disruption) error); ok {
 		r2 = rf(c, instance)
 	} else {
 		r2 = ret.Error(2)
@@ -72,15 +72,15 @@ type TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call struct {
 }
 
 // GetMatchingNodesOverTotalNodes is a helper method to define mock.On call
-//   - c client.Client
+//   - c client.Reader
 //   - instance *v1beta1.Disruption
 func (_e *TargetSelectorMock_Expecter) GetMatchingNodesOverTotalNodes(c interface{}, instance interface{}) *TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call {
 	return &TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call{Call: _e.mock.On("GetMatchingNodesOverTotalNodes", c, instance)}
 }
 
-func (_c *TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call) Run(run func(c client.Client, instance *v1beta1.Disruption)) *TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call {
+func (_c *TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call) Run(run func(c client.Reader, instance *v1beta1.Disruption)) *TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(client.Client), args[1].(*v1beta1.Disruption))
+		run(args[0].(client.Reader), args[1].(*v1beta1.Disruption))
 	})
 	return _c
 }
@@ -90,13 +90,13 @@ func (_c *TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call) Return(_a0 *v1
 	return _c
 }
 
-func (_c *TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call) RunAndReturn(run func(client.Client, *v1beta1.Disruption) (*v1.NodeList, int, error)) *TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call {
+func (_c *TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call) RunAndReturn(run func(client.Reader, *v1beta1.Disruption) (*v1.NodeList, int, error)) *TargetSelectorMock_GetMatchingNodesOverTotalNodes_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetMatchingPodsOverTotalPods provides a mock function with given fields: c, instance
-func (_m *TargetSelectorMock) GetMatchingPodsOverTotalPods(c client.Client, instance *v1beta1.Disruption) (*v1.PodList, int, error) {
+func (_m *TargetSelectorMock) GetMatchingPodsOverTotalPods(c client.Reader, instance *v1beta1.Disruption) (*v1.PodList, int, error) {
 	ret := _m.Called(c, instance)
 
 	if len(ret) == 0 {
@@ -106,10 +106,10 @@ func (_m *TargetSelectorMock) GetMatchingPodsOverTotalPods(c client.Client, inst
 	var r0 *v1.PodList
 	var r1 int
 	var r2 error
-	if rf, ok := ret.Get(0).(func(client.Client, *v1beta1.Disruption) (*v1.PodList, int, error)); ok {
+	if rf, ok := ret.Get(0).(func(client.Reader, *v1beta1.Disruption) (*v1.PodList, int, error)); ok {
 		return rf(c, instance)
 	}
-	if rf, ok := ret.Get(0).(func(client.Client, *v1beta1.Disruption) *v1.PodList); ok {
+	if rf, ok := ret.Get(0).(func(client.Reader, *v1beta1.Disruption) *v1.PodList); ok {
 		r0 = rf(c, instance)
 	} else {
 		if ret.Get(0) != nil {
@@ -117,13 +117,13 @@ func (_m *TargetSelectorMock) GetMatchingPodsOverTotalPods(c client.Client, inst
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(client.Client, *v1beta1.Disruption) int); ok {
+	if rf, ok := ret.Get(1).(func(client.Reader, *v1beta1.Disruption) int); ok {
 		r1 = rf(c, instance)
 	} else {
 		r1 = ret.Get(1).(int)
 	}
 
-	if rf, ok := ret.Get(2).(func(client.Client, *v1beta1.Disruption) error); ok {
+	if rf, ok := ret.Get(2).(func(client.Reader, *v1beta1.Disruption) error); ok {
 		r2 = rf(c, instance)
 	} else {
 		r2 = ret.Error(2)
@@ -138,15 +138,15 @@ type TargetSelectorMock_GetMatchingPodsOverTotalPods_Call struct {
 }
 
 // GetMatchingPodsOverTotalPods is a helper method to define mock.On call
-//   - c client.Client
+//   - c client.Reader
 //   - instance *v1beta1.Disruption
 func (_e *TargetSelectorMock_Expecter) GetMatchingPodsOverTotalPods(c interface{}, instance interface{}) *TargetSelectorMock_GetMatchingPodsOverTotalPods_Call {
 	return &TargetSelectorMock_GetMatchingPodsOverTotalPods_Call{Call: _e.mock.On("GetMatchingPodsOverTotalPods", c, instance)}
 }
 
-func (_c *TargetSelectorMock_GetMatchingPodsOverTotalPods_Call) Run(run func(c client.Client, instance *v1beta1.Disruption)) *TargetSelectorMock_GetMatchingPodsOverTotalPods_Call {
+func (_c *TargetSelectorMock_GetMatchingPodsOverTotalPods_Call) Run(run func(c client.Reader, instance *v1beta1.Disruption)) *TargetSelectorMock_GetMatchingPodsOverTotalPods_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(client.Client), args[1].(*v1beta1.Disruption))
+		run(args[0].(client.Reader), args[1].(*v1beta1.Disruption))
 	})
 	return _c
 }
@@ -156,13 +156,13 @@ func (_c *TargetSelectorMock_GetMatchingPodsOverTotalPods_Call) Return(_a0 *v1.P
 	return _c
 }
 
-func (_c *TargetSelectorMock_GetMatchingPodsOverTotalPods_Call) RunAndReturn(run func(client.Client, *v1beta1.Disruption) (*v1.PodList, int, error)) *TargetSelectorMock_GetMatchingPodsOverTotalPods_Call {
+func (_c *TargetSelectorMock_GetMatchingPodsOverTotalPods_Call) RunAndReturn(run func(client.Reader, *v1beta1.Disruption) (*v1.PodList, int, error)) *TargetSelectorMock_GetMatchingPodsOverTotalPods_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // TargetIsHealthy provides a mock function with given fields: target, c, instance
-func (_m *TargetSelectorMock) TargetIsHealthy(target string, c client.Client, instance *v1beta1.Disruption) error {
+func (_m *TargetSelectorMock) TargetIsHealthy(target string, c client.Reader, instance *v1beta1.Disruption) error {
 	ret := _m.Called(target, c, instance)
 
 	if len(ret) == 0 {
@@ -170,7 +170,7 @@ func (_m *TargetSelectorMock) TargetIsHealthy(target string, c client.Client, in
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, client.Client, *v1beta1.Disruption) error); ok {
+	if rf, ok := ret.Get(0).(func(string, client.Reader, *v1beta1.Disruption) error); ok {
 		r0 = rf(target, c, instance)
 	} else {
 		r0 = ret.Error(0)
@@ -186,15 +186,15 @@ type TargetSelectorMock_TargetIsHealthy_Call struct {
 
 // TargetIsHealthy is a helper method to define mock.On call
 //   - target string
-//   - c client.Client
+//   - c client.Reader
 //   - instance *v1beta1.Disruption
 func (_e *TargetSelectorMock_Expecter) TargetIsHealthy(target interface{}, c interface{}, instance interface{}) *TargetSelectorMock_TargetIsHealthy_Call {
 	return &TargetSelectorMock_TargetIsHealthy_Call{Call: _e.mock.On("TargetIsHealthy", target, c, instance)}
 }
 
-func (_c *TargetSelectorMock_TargetIsHealthy_Call) Run(run func(target string, c client.Client, instance *v1beta1.Disruption)) *TargetSelectorMock_TargetIsHealthy_Call {
+func (_c *TargetSelectorMock_TargetIsHealthy_Call) Run(run func(target string, c client.Reader, instance *v1beta1.Disruption)) *TargetSelectorMock_TargetIsHealthy_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(client.Client), args[2].(*v1beta1.Disruption))
+		run(args[0].(string), args[1].(client.Reader), args[2].(*v1beta1.Disruption))
 	})
 	return _c
 }
@@ -204,7 +204,7 @@ func (_c *TargetSelectorMock_TargetIsHealthy_Call) Return(_a0 error) *TargetSele
 	return _c
 }
 
-func (_c *TargetSelectorMock_TargetIsHealthy_Call) RunAndReturn(run func(string, client.Client, *v1beta1.Disruption) error) *TargetSelectorMock_TargetIsHealthy_Call {
+func (_c *TargetSelectorMock_TargetIsHealthy_Call) RunAndReturn(run func(string, client.Reader, *v1beta1.Disruption) error) *TargetSelectorMock_TargetIsHealthy_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/watchers/disruptions_watchers_manager.go
+++ b/watchers/disruptions_watchers_manager.go
@@ -63,8 +63,10 @@ const (
 	DisruptionTargetWatcherName WatcherName = "DisruptionTarget"
 )
 
+// Only DisruptionTargetWatcher is created per-disruption.
+// Chaos pod watching is handled globally by SharedChaosPodHandler registered in
+// SetupWithManager, eliminating one informer cache per active disruption.
 var watchersNames = []WatcherName{
-	ChaosPodWatcherName,
 	DisruptionTargetWatcherName,
 }
 

--- a/watchers/disruptions_watchers_manager_test.go
+++ b/watchers/disruptions_watchers_manager_test.go
@@ -25,17 +25,16 @@ import (
 
 var _ = Describe("Disruptions watchers manager", func() {
 	var (
-		chaosPodWatcherMock                                              *watchers.WatcherMock
-		cacheMock                                                        *mocks.CacheCacheMock
-		disruption                                                       *chaosv1beta1.Disruption
-		disruptionsWatchersManager                                       watchers.DisruptionsWatchersManager
-		disruptionTargetWatcherMock                                      *watchers.WatcherMock
-		err                                                              error
-		expectedDisruptionTargetWatcherName, expectedChaosPodWatcherName string
-		twoDisruptions                                                   []*chaosv1beta1.Disruption
-		watchersManagerMock                                              *watchers.ManagerMock
-		watcherFactoryMock                                               *watchers.FactoryMock
-		readerMock                                                       *mocks.ReaderMock
+		cacheMock                   *mocks.CacheCacheMock
+		disruption                  *chaosv1beta1.Disruption
+		disruptionsWatchersManager  watchers.DisruptionsWatchersManager
+		disruptionTargetWatcherMock *watchers.WatcherMock
+		err                         error
+		expectedDTWatcherName       string
+		twoDisruptions              []*chaosv1beta1.Disruption
+		watchersManagerMock         *watchers.ManagerMock
+		watcherFactoryMock          *watchers.FactoryMock
+		readerMock                  *mocks.ReaderMock
 	)
 
 	BeforeEach(func() {
@@ -86,10 +85,8 @@ var _ = Describe("Disruptions watchers manager", func() {
 				disSpecHash, err := disruption.Spec.HashNoCount()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				expectedDisruptionTargetWatcherName = disSpecHash + string(watchers.DisruptionTargetWatcherName)
-				expectedChaosPodWatcherName = disSpecHash + string(watchers.ChaosPodWatcherName)
+				expectedDTWatcherName = disSpecHash + string(watchers.DisruptionTargetWatcherName)
 
-				chaosPodWatcherMock = watchers.NewWatcherMock(GinkgoT())
 				disruptionTargetWatcherMock = watchers.NewWatcherMock(GinkgoT())
 				watchersManagerMock = watchers.NewManagerMock(GinkgoT())
 			})
@@ -103,19 +100,14 @@ var _ = Describe("Disruptions watchers manager", func() {
 
 				BeforeEach(func() {
 					// Arrange / Assert
-					By("check once the presence of both watchers")
-					watchersManagerMock.EXPECT().GetWatcher(expectedDisruptionTargetWatcherName).Return(nil).Once()
-					watchersManagerMock.EXPECT().GetWatcher(expectedChaosPodWatcherName).Return(nil).Once()
+					By("check once the presence of the DisruptionTarget watcher")
+					watchersManagerMock.EXPECT().GetWatcher(expectedDTWatcherName).Return(nil).Once()
 
 					By("create the Disruption Target watcher")
-					watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDisruptionTargetWatcherName, true, disruption, cacheMock).Return(disruptionTargetWatcherMock, nil).Once()
+					watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcherName, true, disruption, cacheMock).Return(disruptionTargetWatcherMock, nil).Once()
 
-					By("create the Chaos Pod watcher")
-					watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedChaosPodWatcherName, disruption, cacheMock).Return(chaosPodWatcherMock, nil).Once()
-
-					By("adding both watchers into the watcherManager")
+					By("adding the watcher into the watcherManager")
 					watchersManagerMock.EXPECT().AddWatcher(disruptionTargetWatcherMock).Return(nil).Once()
-					watchersManagerMock.EXPECT().AddWatcher(chaosPodWatcherMock).Return(nil).Once()
 				})
 
 				It("should not return an error", func() {
@@ -127,9 +119,8 @@ var _ = Describe("Disruptions watchers manager", func() {
 						// Arrange / Assert
 						watchersManagerMock = watchers.NewManagerMock(GinkgoT())
 
-						By("check once the presence of both watchers")
-						watchersManagerMock.EXPECT().GetWatcher(expectedDisruptionTargetWatcherName).Return(disruptionTargetWatcherMock).Once()
-						watchersManagerMock.EXPECT().GetWatcher(expectedChaosPodWatcherName).Return(chaosPodWatcherMock).Once()
+						By("check once the presence of the DisruptionTarget watcher")
+						watchersManagerMock.EXPECT().GetWatcher(expectedDTWatcherName).Return(disruptionTargetWatcherMock).Once()
 
 						// Act
 						Expect(disruptionsWatchersManager.CreateAllWatchers(ctx, disruption, watchersManagerMock, cacheMock)).Should(Succeed())
@@ -151,11 +142,10 @@ var _ = Describe("Disruptions watchers manager", func() {
 					BeforeEach(func() {
 						// Arrange / Assert
 						watchersManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Maybe()
-						watchersManagerMock.EXPECT().GetWatcher(expectedDisruptionTargetWatcherName).Return(nil)
+						watchersManagerMock.EXPECT().GetWatcher(expectedDTWatcherName).Return(nil)
 
 						watcherFactoryMock = watchers.NewFactoryMock(GinkgoT())
-						watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDisruptionTargetWatcherName, true, disruption, cacheMock).Return(disruptionTargetWatcherMock, fmt.Errorf("NewDisruptionTargetWatcher error")).Once()
-						watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedChaosPodWatcherName, disruption, cacheMock).Return(disruptionTargetWatcherMock, nil).Maybe()
+						watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcherName, true, disruption, cacheMock).Return(disruptionTargetWatcherMock, fmt.Errorf("NewDisruptionTargetWatcher error")).Once()
 					})
 
 					It("should return an error", func() {
@@ -165,52 +155,18 @@ var _ = Describe("Disruptions watchers manager", func() {
 					})
 				})
 
-				When("the NewChaosPodWatcher method of the factory return an error", func() {
-					BeforeEach(func() {
-						// Arrange / Assert
-						watchersManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Maybe()
-						watchersManagerMock.EXPECT().AddWatcher(disruptionTargetWatcherMock).Return(nil).Maybe()
-
-						watcherFactoryMock = watchers.NewFactoryMock(GinkgoT())
-						watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDisruptionTargetWatcherName, true, disruption, cacheMock).Return(disruptionTargetWatcherMock, nil).Maybe()
-						watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedChaosPodWatcherName, disruption, cacheMock).Return(disruptionTargetWatcherMock, fmt.Errorf("NewChaosPodWatcher error message")).Once()
-					})
-
-					It("should return an error", func() {
-						Expect(err).To(HaveOccurred())
-						Expect(err).To(MatchError("NewChaosPodWatcher error message"))
-					})
-				})
-
 				When("the AddWatcher method of the watcherManager return an error with the disruptionTargetWatcher in parameter", func() {
 					BeforeEach(func() {
 						// Arrange / Assert
 						watchersManagerMock.EXPECT().AddWatcher(disruptionTargetWatcherMock).Return(fmt.Errorf("disruptionTargetWatcher message")).Once()
 						watchersManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Maybe()
 
-						watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDisruptionTargetWatcherName, true, disruption, cacheMock).Return(disruptionTargetWatcherMock, nil).Once()
-						watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedChaosPodWatcherName, disruption, cacheMock).Return(chaosPodWatcherMock, nil).Once().Maybe()
+						watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcherName, true, disruption, cacheMock).Return(disruptionTargetWatcherMock, nil).Once()
 					})
 
 					It("should return an error", func() {
 						Expect(err).To(HaveOccurred())
 						Expect(err).To(MatchError("failed to create watcher: disruptionTargetWatcher message"))
-					})
-				})
-
-				When("the AddWatcher method of the watcherManager return an error with the chaosPodWatcher in parameter", func() {
-					BeforeEach(func() {
-						// Arrange / Assert
-						watchersManagerMock.EXPECT().AddWatcher(chaosPodWatcherMock).Return(fmt.Errorf("chaosPodWatcher error"))
-						watchersManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Maybe()
-
-						watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDisruptionTargetWatcherName, true, disruption, cacheMock).Return(disruptionTargetWatcherMock, nil).Maybe()
-						watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedChaosPodWatcherName, disruption, cacheMock).Return(chaosPodWatcherMock, nil).Once()
-					})
-
-					It("should return an error", func() {
-						Expect(err).To(HaveOccurred())
-						Expect(err).To(MatchError("failed to create watcher: chaosPodWatcher error"))
 					})
 				})
 			})
@@ -257,13 +213,11 @@ var _ = Describe("Disruptions watchers manager", func() {
 				disSpecHash, err := disruption.Spec.HashNoCount()
 				Expect(err).ShouldNot(HaveOccurred())
 				expectedDTWatcher := disSpecHash + string(watchers.DisruptionTargetWatcherName)
-				expectedCPWatcher := disSpecHash + string(watchers.ChaosPodWatcherName)
 
 				By("seeding the cache via first CreateAllWatchers call with uid-v1")
-				oldManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil).Twice()
-				oldManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Twice()
+				oldManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil).Once()
+				oldManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Once()
 				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcher, true, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
-				watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedCPWatcher, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
 				Expect(disruptionsWatchersManager.CreateAllWatchers(ctx, disruption, oldManagerMock, cacheMock)).To(Succeed())
 
 				By("building a recreated disruption with the same namespace/name but a new UID")
@@ -279,10 +233,9 @@ var _ = Describe("Disruptions watchers manager", func() {
 				oldManagerMock.EXPECT().RemoveAllWatchers().Once()
 
 				By("expecting fresh watchers to be created for the new disruption")
-				newManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil).Twice()
-				newManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Twice()
+				newManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil).Once()
+				newManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Once()
 				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcher, true, recreatedDisruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
-				watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedCPWatcher, recreatedDisruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
 
 				Expect(disruptionsWatchersManager.CreateAllWatchers(ctx, recreatedDisruption, newManagerMock, cacheMock)).To(Succeed())
 			})
@@ -293,18 +246,15 @@ var _ = Describe("Disruptions watchers manager", func() {
 				disSpecHash, err := disruption.Spec.HashNoCount()
 				Expect(err).ShouldNot(HaveOccurred())
 				expectedDTWatcher := disSpecHash + string(watchers.DisruptionTargetWatcherName)
-				expectedCPWatcher := disSpecHash + string(watchers.ChaosPodWatcherName)
 
 				By("seeding the cache via first CreateAllWatchers call with uid-v1")
-				oldManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil).Twice()
-				oldManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Twice()
+				oldManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil).Once()
+				oldManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil).Once()
 				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcher, true, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
-				watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedCPWatcher, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil).Once()
 				Expect(disruptionsWatchersManager.CreateAllWatchers(ctx, disruption, oldManagerMock, cacheMock)).To(Succeed())
 
-				By("calling CreateAllWatchers again with the same UID — existing watchers already present")
+				By("calling CreateAllWatchers again with the same UID — existing watcher already present")
 				oldManagerMock.EXPECT().GetWatcher(expectedDTWatcher).Return(watchers.NewWatcherMock(GinkgoT())).Once()
-				oldManagerMock.EXPECT().GetWatcher(expectedCPWatcher).Return(watchers.NewWatcherMock(GinkgoT())).Once()
 				Expect(disruptionsWatchersManager.CreateAllWatchers(ctx, disruption, oldManagerMock, cacheMock)).To(Succeed())
 
 				By("not calling RemoveAllWatchers on the cached manager")
@@ -312,7 +262,6 @@ var _ = Describe("Disruptions watchers manager", func() {
 
 				By("not calling factory methods on the second pass")
 				watcherFactoryMock.AssertNumberOfCalls(GinkgoT(), "NewDisruptionTargetWatcher", 1)
-				watcherFactoryMock.AssertNumberOfCalls(GinkgoT(), "NewChaosPodWatcher", 1)
 			})
 		})
 	})
@@ -331,10 +280,8 @@ var _ = Describe("Disruptions watchers manager", func() {
 				disSpecHash, err := disruption.Spec.HashNoCount()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				expectedDisruptionTargetWatcherName = disSpecHash + string(watchers.DisruptionTargetWatcherName)
-				expectedChaosPodWatcherName = disSpecHash + string(watchers.ChaosPodWatcherName)
+				expectedDTWatcherName = disSpecHash + string(watchers.DisruptionTargetWatcherName)
 
-				chaosPodWatcherMock = watchers.NewWatcherMock(GinkgoT())
 				disruptionTargetWatcherMock = watchers.NewWatcherMock(GinkgoT())
 
 				watchersManagerMock = watchers.NewManagerMock(GinkgoT())
@@ -342,8 +289,7 @@ var _ = Describe("Disruptions watchers manager", func() {
 				watchersManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil)
 
 				watcherFactoryMock = watchers.NewFactoryMock(GinkgoT())
-				watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedChaosPodWatcherName, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
-				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDisruptionTargetWatcherName, mock.Anything, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
+				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcherName, mock.Anything, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
 			})
 
 			JustBeforeEach(func(ctx SpecContext) {
@@ -405,16 +351,13 @@ var _ = Describe("Disruptions watchers manager", func() {
 				disSpecHash, err := disruption.Spec.HashNoCount()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				expectedDisruptionTargetWatcherName = disSpecHash + string(watchers.DisruptionTargetWatcherName)
-				expectedChaosPodWatcherName = disSpecHash + string(watchers.ChaosPodWatcherName)
+				expectedDTWatcherName = disSpecHash + string(watchers.DisruptionTargetWatcherName)
 
-				chaosPodWatcherMock = watchers.NewWatcherMock(GinkgoT())
 				disruptionTargetWatcherMock = watchers.NewWatcherMock(GinkgoT())
 
 				watchersManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil)
 				watchersManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil)
-				watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedChaosPodWatcherName, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
-				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDisruptionTargetWatcherName, mock.Anything, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
+				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcherName, mock.Anything, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
 			}
 		})
 
@@ -509,13 +452,11 @@ var _ = Describe("Disruptions watchers manager", func() {
 				disSpecHash, err := disruption.Spec.HashNoCount()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				expectedDisruptionTargetWatcherName = disSpecHash + string(watchers.DisruptionTargetWatcherName)
-				expectedChaosPodWatcherName = disSpecHash + string(watchers.ChaosPodWatcherName)
+				expectedDTWatcherName = disSpecHash + string(watchers.DisruptionTargetWatcherName)
 
 				watchersManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil)
 				watchersManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil)
-				watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedChaosPodWatcherName, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
-				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDisruptionTargetWatcherName, mock.Anything, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
+				watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcherName, mock.Anything, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
 			}
 		})
 
@@ -574,16 +515,13 @@ var _ = Describe("Disruptions watchers manager", func() {
 					disSpecHash, err := disruption.Spec.HashNoCount()
 					Expect(err).ShouldNot(HaveOccurred())
 
-					expectedDisruptionTargetWatcherName = disSpecHash + string(watchers.DisruptionTargetWatcherName)
-					expectedChaosPodWatcherName = disSpecHash + string(watchers.ChaosPodWatcherName)
+					expectedDTWatcherName = disSpecHash + string(watchers.DisruptionTargetWatcherName)
 
-					chaosPodWatcherMock = watchers.NewWatcherMock(GinkgoT())
 					disruptionTargetWatcherMock = watchers.NewWatcherMock(GinkgoT())
 
 					watchersManagerMock.EXPECT().AddWatcher(mock.Anything).Return(nil)
 					watchersManagerMock.EXPECT().GetWatcher(mock.Anything).Return(nil)
-					watcherFactoryMock.EXPECT().NewChaosPodWatcher(expectedChaosPodWatcherName, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
-					watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDisruptionTargetWatcherName, mock.Anything, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
+					watcherFactoryMock.EXPECT().NewDisruptionTargetWatcher(expectedDTWatcherName, mock.Anything, disruption, cacheMock).Return(watchers.NewWatcherMock(GinkgoT()), nil)
 				}
 			})
 

--- a/watchers/factory.go
+++ b/watchers/factory.go
@@ -38,6 +38,9 @@ type FactoryConfig struct {
 	Reader         client.Reader
 	Recorder       record.EventRecorder
 	ChaosNamespace string
+	// CachePool is the shared namespace cache pool used by DisruptionTargetWatcher.
+	// When nil, each watcher creates its own cache (legacy behaviour, kept for tests).
+	CachePool *NamespaceCachePool
 }
 
 // NewWatcherFactory creates a new instance of the factory for creating new watcher instances.
@@ -70,37 +73,57 @@ func (f factory) NewChaosPodWatcher(name string, disruption *v1beta1.Disruption,
 }
 
 // NewDisruptionTargetWatcher creates a new watcher instance for target pods of a disruption.
+// When a CachePool is configured on the factory, the watcher uses a shared per-namespace cache
+// instead of creating a dedicated cache, reducing goroutine and memory usage at scale.
 func (f factory) NewDisruptionTargetWatcher(name string, enableObserver bool, disruption *v1beta1.Disruption, cacheMock k8scache.Cache) (Watcher, error) {
-	// Add instance specific labels if provided
-	cacheOptions, err := newDisruptionTargetCacheOptions(disruption)
+	// Compute the label selector for this disruption's targets.
+	labelSelector, err := targetselector.GetLabelSelectorFromInstance(disruption)
 	if err != nil {
-		return nil, fmt.Errorf("could not create the %s disruption target watcher. Error: %w", name, err)
+		return nil, fmt.Errorf("could not create the %s disruption target watcher: %w", name, err)
 	}
 
 	// Create a new handler for this watcher instance
-	handler := DisruptionTargetHandler{
+	h := DisruptionTargetHandler{
 		recorder:       f.config.Recorder,
 		reader:         f.config.Reader,
 		enableObserver: enableObserver,
 		disruption:     disruption,
 		metricsAdapter: NewWatcherMetricsAdapter(f.config.MetricSink, f.config.Log),
 		log:            f.config.Log,
+		labelSelector:  labelSelector,
 	}
 
 	// targetObjectType can either be a pod or a node
 	var targetObjectType client.Object = &corev1.Pod{}
+
+	// Namespace for pool key: empty string for node-level (cluster-scoped).
+	targetNamespace := disruption.Namespace
 	if disruption.Spec.Level == chaostypes.DisruptionLevelNode {
 		targetObjectType = &corev1.Node{}
+		targetNamespace = ""
 	}
 
-	// Create a new watcher configuration object
 	watcherConfig := WatcherConfig{
 		Name:           name,
-		Handler:        &handler,
+		Handler:        &h,
 		ObjectType:     targetObjectType,
-		CacheOptions:   cacheOptions,
+		LabelSelector:  labelSelector,
 		Log:            f.config.Log,
 		NamespacedName: types.NamespacedName{Name: disruption.GetName(), Namespace: disruption.GetNamespace()},
+		Namespace:      targetNamespace,
+	}
+
+	if cacheMock == nil && f.config.CachePool != nil {
+		// Shared cache path: pool manages cache lifecycle.
+		watcherConfig.CachePool = f.config.CachePool
+	} else {
+		// Own cache path (tests or no pool configured).
+		cacheOptions, err := newDisruptionTargetCacheOptions(disruption)
+		if err != nil {
+			return nil, fmt.Errorf("could not create the %s disruption target watcher: %w", name, err)
+		}
+
+		watcherConfig.CacheOptions = cacheOptions
 	}
 
 	return NewWatcher(watcherConfig, cacheMock, nil)

--- a/watchers/factory_test.go
+++ b/watchers/factory_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Watcher factory", func() {
 
 			It("should return an error", func() {
 				Expect(err).Should(HaveOccurred())
-				Expect(err.Error()).Should(HavePrefix("could not create the name disruption target watcher. Error: error getting instance selector"))
+				Expect(err.Error()).Should(HavePrefix("could not create the name disruption target watcher:"))
 			})
 		})
 	})

--- a/watchers/namespace_cache_pool.go
+++ b/watchers/namespace_cache_pool.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package watchers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"k8s.io/client-go/rest"
+	k8scontrollercache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NamespaceCachePool manages one controller-runtime cache per target namespace.
+// Multiple DisruptionTargetWatcher instances targeting the same namespace share a
+// single cache, reducing the number of goroutines and Watch connections from
+// O(disruptions) to O(namespaces).
+type NamespaceCachePool struct {
+	mu        sync.Mutex
+	entries   map[string]*poolEntry
+	k8sConfig *rest.Config
+}
+
+type poolEntry struct {
+	cache    k8scontrollercache.Cache
+	ctx      context.Context
+	cancel   context.CancelFunc
+	refCount int
+}
+
+// NewNamespaceCachePool creates an empty pool. k8sConfig is used when creating new
+// namespace-scoped caches.
+func NewNamespaceCachePool(k8sConfig *rest.Config) *NamespaceCachePool {
+	return &NamespaceCachePool{
+		entries:   make(map[string]*poolEntry),
+		k8sConfig: k8sConfig,
+	}
+}
+
+// GetOrCreate returns the shared cache for the given namespace, creating one if it
+// does not yet exist. The caller must call Release when it no longer needs the cache.
+// For cluster-scoped resources (nodes), pass namespace="" to get a cluster-wide cache.
+func (p *NamespaceCachePool) GetOrCreate(namespace string, objectType client.Object) (k8scontrollercache.Cache, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if entry, ok := p.entries[namespace]; ok {
+		entry.refCount++
+		return entry.cache, nil
+	}
+
+	opts := k8scontrollercache.Options{}
+	if namespace != "" {
+		opts.ByObject = map[client.Object]k8scontrollercache.ByObject{
+			objectType: {
+				Namespaces: map[string]k8scontrollercache.Config{namespace: {}},
+			},
+		}
+	}
+
+	cache, err := k8scontrollercache.New(p.k8sConfig, opts)
+	if err != nil {
+		return nil, fmt.Errorf("namespace cache pool: failed to create cache for %q: %w", namespace, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118 - cancel is stored and called on Release
+
+	go func() {
+		// Ignoring error: cache.Start only errors on context cancellation,
+		// which is the normal clean shutdown path via Release().
+		_ = cache.Start(ctx) //nolint:errcheck
+	}()
+
+	p.entries[namespace] = &poolEntry{
+		cache:    cache,
+		ctx:      ctx,
+		cancel:   cancel,
+		refCount: 1,
+	}
+
+	return cache, nil
+}
+
+// Release decrements the reference count for the given namespace. When it reaches
+// zero the cache is stopped and removed from the pool.
+func (p *NamespaceCachePool) Release(namespace string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	entry, ok := p.entries[namespace]
+	if !ok {
+		return
+	}
+
+	entry.refCount--
+
+	if entry.refCount <= 0 {
+		entry.cancel()
+		delete(p.entries, namespace)
+	}
+}

--- a/watchers/namespace_cache_pool.go
+++ b/watchers/namespace_cache_pool.go
@@ -30,6 +30,7 @@ type poolEntry struct {
 	ctx      context.Context
 	cancel   context.CancelFunc
 	refCount int
+	started  bool // whether cache.Start has been called
 }
 
 // NewNamespaceCachePool creates an empty pool. k8sConfig is used when creating new
@@ -44,6 +45,10 @@ func NewNamespaceCachePool(k8sConfig *rest.Config) *NamespaceCachePool {
 // GetOrCreate returns the shared cache for the given namespace, creating one if it
 // does not yet exist. The caller must call Release when it no longer needs the cache.
 // For cluster-scoped resources (nodes), pass namespace="" to get a cluster-wide cache.
+//
+// The cache is NOT started here. Call StartCache after all informers have been
+// registered (i.e. after Watcher.Start) to avoid GetInformer blocking indefinitely
+// on an already-running cache when informer sync cannot complete.
 func (p *NamespaceCachePool) GetOrCreate(namespace string, objectType client.Object) (k8scontrollercache.Cache, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -69,20 +74,37 @@ func (p *NamespaceCachePool) GetOrCreate(namespace string, objectType client.Obj
 
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118 - cancel is stored and called on Release
 
-	go func() {
-		// Ignoring error: cache.Start only errors on context cancellation,
-		// which is the normal clean shutdown path via Release().
-		_ = cache.Start(ctx) //nolint:errcheck
-	}()
-
 	p.entries[namespace] = &poolEntry{
 		cache:    cache,
 		ctx:      ctx,
 		cancel:   cancel,
 		refCount: 1,
+		started:  false,
 	}
 
 	return cache, nil
+}
+
+// StartCache starts the shared cache for the given namespace if it has not already
+// been started. It should be called after all informers are registered on the cache
+// (i.e. after Watcher.Start) so that controller-runtime does not block GetInformer
+// calls on an already-running cache when informer sync cannot complete.
+func (p *NamespaceCachePool) StartCache(namespace string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	entry, ok := p.entries[namespace]
+	if !ok || entry.started {
+		return
+	}
+
+	entry.started = true
+
+	go func() {
+		// Ignoring error: cache.Start only errors on context cancellation,
+		// which is the normal clean shutdown path via Release().
+		_ = entry.cache.Start(entry.ctx) //nolint:errcheck
+	}()
 }
 
 // Release decrements the reference count for the given namespace. When it reaches

--- a/watchers/shared_chaos_pod_handler.go
+++ b/watchers/shared_chaos_pod_handler.go
@@ -26,25 +26,49 @@ import (
 //
 // The disruption is identified at event time from the pod's labels rather than being
 // pre-stored at construction time.
+//
+// In HA deployments, caches start on all replicas before leadership is acquired.
+// The elected channel (mgr.Elected()) is used to gate event/metric emission so that
+// only the leader replica acts on chaos pod failures, preventing duplicate K8s events.
 type SharedChaosPodHandler struct {
 	reader         client.Reader
 	recorder       record.EventRecorder
 	log            *zap.SugaredLogger
 	metricsAdapter WatcherMetricsAdapter
+	// elected is closed when this replica becomes the leader. Nil means no gating
+	// (single-replica deployments or tests).
+	elected <-chan struct{}
 }
 
 // NewSharedChaosPodHandler creates a SharedChaosPodHandler.
+// Pass mgr.Elected() as elected so standby replicas skip event/metric emission.
 func NewSharedChaosPodHandler(
 	reader client.Reader,
 	recorder record.EventRecorder,
 	log *zap.SugaredLogger,
 	metricsAdapter WatcherMetricsAdapter,
+	elected <-chan struct{},
 ) *SharedChaosPodHandler {
 	return &SharedChaosPodHandler{
 		reader:         reader,
 		recorder:       recorder,
 		log:            log,
 		metricsAdapter: metricsAdapter,
+		elected:        elected,
+	}
+}
+
+// isLeader returns true when this replica holds leadership (or leader election is disabled).
+func (h *SharedChaosPodHandler) isLeader() bool {
+	if h.elected == nil {
+		return true
+	}
+
+	select {
+	case <-h.elected:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -53,7 +77,12 @@ func (h *SharedChaosPodHandler) OnAdd(_ interface{}, _ bool) {}
 
 // OnUpdate emits metrics and sends a Kubernetes event to the parent Disruption when
 // a chaos pod unexpectedly transitions to a failed phase.
+// Only the leader replica acts so that standby replicas don't emit duplicate events.
 func (h *SharedChaosPodHandler) OnUpdate(oldObj, newObj interface{}) {
+	if !h.isLeader() {
+		return
+	}
+
 	oldPod, okOld := oldObj.(*corev1.Pod)
 	newPod, okNew := newObj.(*corev1.Pod)
 

--- a/watchers/shared_chaos_pod_handler.go
+++ b/watchers/shared_chaos_pod_handler.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package watchers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/chaos-controller/api/v1beta1"
+	"github.com/DataDog/chaos-controller/o11y/tags"
+	chaostypes "github.com/DataDog/chaos-controller/types"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SharedChaosPodHandler is a single shared event handler registered on the manager's pod
+// informer (chaos namespace only). It replaces per-disruption ChaosPodWatcher instances,
+// eliminating one informer cache per active disruption.
+//
+// The disruption is identified at event time from the pod's labels rather than being
+// pre-stored at construction time.
+type SharedChaosPodHandler struct {
+	reader         client.Reader
+	recorder       record.EventRecorder
+	log            *zap.SugaredLogger
+	metricsAdapter WatcherMetricsAdapter
+}
+
+// NewSharedChaosPodHandler creates a SharedChaosPodHandler.
+func NewSharedChaosPodHandler(
+	reader client.Reader,
+	recorder record.EventRecorder,
+	log *zap.SugaredLogger,
+	metricsAdapter WatcherMetricsAdapter,
+) *SharedChaosPodHandler {
+	return &SharedChaosPodHandler{
+		reader:         reader,
+		recorder:       recorder,
+		log:            log,
+		metricsAdapter: metricsAdapter,
+	}
+}
+
+// OnAdd is a no-op — chaos pod creation does not require notification.
+func (h *SharedChaosPodHandler) OnAdd(_ interface{}, _ bool) {}
+
+// OnUpdate emits metrics and sends a Kubernetes event to the parent Disruption when
+// a chaos pod unexpectedly transitions to a failed phase.
+func (h *SharedChaosPodHandler) OnUpdate(oldObj, newObj interface{}) {
+	oldPod, okOld := oldObj.(*corev1.Pod)
+	newPod, okNew := newObj.(*corev1.Pod)
+
+	if !okOld || !okNew {
+		return
+	}
+
+	disruptionName := newPod.Labels[chaostypes.DisruptionNameLabel]
+	disruptionNamespace := newPod.Labels[chaostypes.DisruptionNamespaceLabel]
+
+	if disruptionName == "" || disruptionNamespace == "" {
+		return
+	}
+
+	// Build a minimal stub for metrics — only name/namespace are needed there.
+	stub := &v1beta1.Disruption{ObjectMeta: metav1.ObjectMeta{Name: disruptionName, Namespace: disruptionNamespace}}
+	h.metricsAdapter.OnChange(stub, ChaosPodHandlerName, newPod, nil, true, false, WatcherUpdateEvent)
+
+	if oldPod.Status.Phase == newPod.Status.Phase {
+		return
+	}
+
+	// Running→Failed is expected (injection completed), do not notify.
+	if oldPod.Status.Phase == corev1.PodRunning && newPod.Status.Phase == corev1.PodFailed {
+		return
+	}
+
+	if newPod.Status.Phase == corev1.PodFailed {
+		h.sendEvent(newPod, disruptionName, disruptionNamespace)
+	}
+}
+
+// OnDelete is a no-op.
+func (h *SharedChaosPodHandler) OnDelete(_ interface{}) {}
+
+func (h *SharedChaosPodHandler) sendEvent(pod *corev1.Pod, disruptionName, disruptionNamespace string) {
+	disruption := &v1beta1.Disruption{}
+	if err := h.reader.Get(context.Background(), types.NamespacedName{Name: disruptionName, Namespace: disruptionNamespace}, disruption); err != nil {
+		h.log.Warnw("SharedChaosPodHandler: could not fetch disruption to send event",
+			tags.ErrorKey, err,
+			tags.DisruptionNameKey, disruptionName,
+			tags.DisruptionNamespaceKey, disruptionNamespace,
+		)
+
+		return
+	}
+
+	eventReason := v1beta1.EventChaosPodFailedState
+	eventType := v1beta1.Events[eventReason].Type
+	eventMessage := fmt.Sprintf(v1beta1.Events[eventReason].OnDisruptionTemplateMessage,
+		pod.Name,
+		pod.Status.Phase,
+		pod.Status.Reason,
+	)
+
+	h.recorder.Event(disruption, eventType, string(eventReason), eventMessage)
+
+	h.log.Debugw("SharedChaosPodHandler UPDATE - Send event",
+		tags.DisruptionKey, eventMessage,
+		tags.EventTypeKey, eventType,
+		tags.DisruptionNameKey, disruptionName,
+		tags.DisruptionNamespaceKey, disruptionNamespace,
+		tags.ChaosPodNameKey, pod.Name,
+	)
+}

--- a/watchers/target_pod_handler.go
+++ b/watchers/target_pod_handler.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,12 +33,37 @@ type DisruptionTargetHandler struct {
 	disruption     *v1beta1.Disruption
 	log            *zap.SugaredLogger
 	metricsAdapter WatcherMetricsAdapter
+	// labelSelector filters events when the handler is registered on a shared namespace
+	// cache. Only objects matching the selector are processed; others are skipped.
+	labelSelector labels.Selector
 }
 
 const DisruptionTargetHandlerName = "DisruptionTargetHandler"
 
+// matchesSelector returns false when a shared-cache label selector is configured and
+// the object's labels do not match it — allowing the handler to skip objects that
+// belong to other disruptions sharing the same namespace cache.
+func (d DisruptionTargetHandler) matchesSelector(obj interface{}) bool {
+	if d.labelSelector == nil {
+		return true
+	}
+
+	switch o := obj.(type) {
+	case *corev1.Pod:
+		return d.labelSelector.Matches(labels.Set(o.Labels))
+	case *corev1.Node:
+		return d.labelSelector.Matches(labels.Set(o.Labels))
+	}
+
+	return true
+}
+
 // OnAdd new target
 func (d DisruptionTargetHandler) OnAdd(obj interface{}, _ bool) {
+	if !d.matchesSelector(obj) {
+		return
+	}
+
 	pod, okPod := obj.(*corev1.Pod)
 	node, okNode := obj.(*corev1.Node)
 
@@ -55,6 +81,10 @@ func (d DisruptionTargetHandler) OnAdd(obj interface{}, _ bool) {
 
 // OnDelete target
 func (d DisruptionTargetHandler) OnDelete(obj interface{}) {
+	if !d.matchesSelector(obj) {
+		return
+	}
+
 	pod, okPod := obj.(*corev1.Pod)
 	node, okNode := obj.(*corev1.Node)
 
@@ -72,6 +102,10 @@ func (d DisruptionTargetHandler) OnDelete(obj interface{}) {
 
 // OnUpdate target
 func (d DisruptionTargetHandler) OnUpdate(oldObj, newObj interface{}) {
+	if !d.matchesSelector(newObj) {
+		return
+	}
+
 	oldPod, okOldPod := oldObj.(*corev1.Pod)
 	newPod, okNewPod := newObj.(*corev1.Pod)
 	oldNode, okOldNode := oldObj.(*corev1.Node)

--- a/watchers/target_pod_handler.go
+++ b/watchers/target_pod_handler.go
@@ -55,7 +55,9 @@ func (d DisruptionTargetHandler) matchesSelector(obj interface{}) bool {
 		return d.labelSelector.Matches(labels.Set(o.Labels))
 	}
 
-	return true
+	// Unknown type (e.g. cache.DeletedFinalStateUnknown tombstone): skip rather than
+	// matching all disruptions, which would produce spurious metrics and log entries.
+	return false
 }
 
 // OnAdd new target

--- a/watchers/watcher.go
+++ b/watchers/watcher.go
@@ -108,12 +108,16 @@ type watcher struct {
 	// The Kubernetes resource cache that stores watched resources
 	cache k8scontrollercache.Cache
 
-	// informer is stored so that the per-disruption event handler can be removed when the watcher
+	// informer is stored so that per-disruption event handlers can be removed when the watcher
 	// is cleaned up while the shared namespace cache (pool) is still alive for other disruptions.
 	informer k8scontrollercache.Informer
 
-	// handlerReg is the registration returned by AddEventHandler. Used to remove the handler on cleanup.
+	// handlerReg is the registration for w.config.Handler (metrics/events). Removed on cleanup.
 	handlerReg k8sclientcache.ResourceEventHandlerRegistration
+
+	// sharedSource is set when using CachePool. It owns the enqueue-handler registration on
+	// the shared informer and must be stopped during Clean().
+	sharedSource *sharedCacheEnqueueSource
 
 	// The source that provides the cache with Kubernetes resource updates
 	cacheSource source.SyncingSource
@@ -172,18 +176,21 @@ func NewWatcher(config WatcherConfig, cacheMock k8scontrollercache.Cache, cacheC
 }
 
 // Clean stops the watcher. For own-cache watchers, it cancels the cache goroutine.
-// For shared-cache watchers, it removes the per-disruption event handler from the shared
-// informer (so it stops firing for this disruption) and releases the pool reference.
+// For shared-cache watchers, it removes both registered handlers from the shared informer
+// (the metrics/events handler and the reconcile-enqueue handler) so they stop firing for
+// this disruption even while the cache stays alive for other disruptions.
 func (w *watcher) Clean() {
 	w.ctxTuple.CancelFunc()
 
 	if w.cacheCancelFunc != nil {
 		w.cacheCancelFunc()
 	} else if w.config.CachePool != nil {
-		// Remove the event handler so it stops processing events for this disruption
-		// even if the shared cache remains alive for other disruptions.
 		if w.informer != nil && w.handlerReg != nil {
 			_ = w.informer.RemoveEventHandler(w.handlerReg)
+		}
+
+		if w.sharedSource != nil {
+			w.sharedSource.stop()
 		}
 
 		w.config.CachePool.Release(w.config.Namespace)
@@ -262,30 +269,36 @@ func (w *watcher) Start() error {
 	}
 	// Shared cache: already started by the pool.
 
-	// Build the SyncingSource.
-	// No label-selector filter is applied here intentionally:
-	//  - Own caches: the cache is already restricted to matching pods via CacheOptions,
-	//    so only matching pod events arrive — filtering would be a no-op.
-	//  - Shared namespace caches: filtering only the NEW labels would miss update events
-	//    where a pod is relabeled OUT of the selector, preventing RemoveDeadTargets from
-	//    running and leaving chaos pods on targets the user removed from the selector.
-	//    Allowing all namespace events through is correct; the reconciler handles it.
-	// The watcher context check stops enqueuing after the watcher is cleaned up.
-	innerSource := source.Kind(w.cache, w.config.ObjectType, handler.TypedEnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
-		if w.ctxTuple.Ctx.Err() != nil {
-			return nil
+	if w.config.CachePool != nil {
+		// Shared cache path: bypass source.Kind entirely.
+		//
+		// source.Kind discards the ResourceEventHandlerRegistration it receives from
+		// AddEventHandlerWithOptions, so there is no way to deregister it — the handler
+		// would accumulate on the shared informer across disruption create/delete cycles.
+		//
+		// Instead, register the enqueue handler directly on the informer and store its
+		// registration so Clean() can remove it. The sharedCacheEnqueueSource also handles
+		// the relabel-out case by checking old OR new labels on update events (not just new).
+		sharedSrc := &sharedCacheEnqueueSource{
+			informer:       info,
+			cache:          w.cache,
+			watcherCtx:     w.ctxTuple.Ctx,
+			namespacedName: w.ctxTuple.NamespacedName,
+			labelSelector:  w.config.LabelSelector,
 		}
 
-		return []reconcile.Request{{NamespacedName: w.ctxTuple.NamespacedName}}
-	}))
-
-	if w.config.CachePool != nil {
-		// Shared cache: wrap the source so its internal informer handler is deregistered
-		// when the watcher context is cancelled, preventing stale handlers from accumulating
-		// on the shared informer across disruption create/delete cycles.
-		w.cacheSource = &watcherBoundSource{inner: innerSource, watcherCtx: w.ctxTuple.Ctx}
+		w.sharedSource = sharedSrc
+		w.cacheSource = sharedSrc
 	} else {
-		w.cacheSource = innerSource
+		// Own cache: use source.Kind. The cache is already label-filtered via CacheOptions
+		// so only matching pod events arrive; the context check is a safety net.
+		w.cacheSource = source.Kind(w.cache, w.config.ObjectType, handler.TypedEnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+			if w.ctxTuple.Ctx.Err() != nil {
+				return nil
+			}
+
+			return []reconcile.Request{{NamespacedName: w.ctxTuple.NamespacedName}}
+		}))
 	}
 
 	return nil
@@ -296,32 +309,114 @@ func (w *watcher) GetConfig() WatcherConfig {
 	return w.config
 }
 
-// watcherBoundSource wraps a SyncingSource and ties its lifecycle to a watcher context.
-// When the watcher context is cancelled (via Clean()), a merged context is cancelled,
-// which causes the inner source to deregister its internal queue handler from the shared
-// informer — preventing stale handlers from accumulating on long-running controllers.
-type watcherBoundSource struct {
-	inner      source.SyncingSource
-	watcherCtx context.Context
+// sharedCacheEnqueueSource is a SyncingSource used for shared-cache (NamespaceCachePool) watchers.
+// It registers the reconcile-enqueue handler directly on the informer in Start(), storing the
+// registration so it can be removed in stop(). This avoids source.Kind, which would silently
+// discard its AddEventHandlerWithOptions registration and leave a stale handler on the shared
+// informer across disruption create/delete cycles.
+//
+// It also fixes the relabel-out case: on Update events it checks old OR new labels, so a pod
+// that is removed from the disruption's selector still triggers a reconcile and RemoveDeadTargets.
+type sharedCacheEnqueueSource struct {
+	informer       k8scontrollercache.Informer
+	cache          k8scontrollercache.Cache
+	watcherCtx     context.Context
+	namespacedName types.NamespacedName
+	labelSelector  labels.Selector
+	enqueueReg     k8sclientcache.ResourceEventHandlerRegistration
 }
 
-func (s *watcherBoundSource) Start(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
-	// Merge the controller's context with the watcher's lifecycle context so the source
-	// stops (and deregisters its informer handler) when either is cancelled.
-	mergedCtx, cancel := context.WithCancel(ctx) //nolint:gosec // G118 - cancel is fired by the goroutine below
+func (s *sharedCacheEnqueueSource) Start(_ context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
+	h := &sharedEnqueueHandler{
+		ctx:            s.watcherCtx,
+		queue:          q,
+		namespacedName: s.namespacedName,
+		labelSelector:  s.labelSelector,
+	}
 
-	go func() {
-		defer cancel()
+	reg, err := s.informer.AddEventHandler(h)
+	if err != nil {
+		return fmt.Errorf("failed to register enqueue handler on shared informer: %w", err)
+	}
 
-		select {
-		case <-s.watcherCtx.Done():
-		case <-ctx.Done():
-		}
-	}()
+	s.enqueueReg = reg
 
-	return s.inner.Start(mergedCtx, q)
+	return nil
 }
 
-func (s *watcherBoundSource) WaitForSync(ctx context.Context) error {
-	return s.inner.WaitForSync(ctx)
+func (s *sharedCacheEnqueueSource) WaitForSync(ctx context.Context) error {
+	if !s.cache.WaitForCacheSync(ctx) {
+		return fmt.Errorf("shared namespace cache did not sync")
+	}
+
+	return nil
+}
+
+// stop removes the enqueue handler from the shared informer.
+func (s *sharedCacheEnqueueSource) stop() {
+	if s.informer != nil && s.enqueueReg != nil {
+		_ = s.informer.RemoveEventHandler(s.enqueueReg)
+	}
+}
+
+// sharedEnqueueHandler is a k8sclientcache.ResourceEventHandler that enqueues reconcile
+// requests for a specific disruption. It is used only with shared (pool) caches.
+type sharedEnqueueHandler struct {
+	ctx            context.Context
+	queue          workqueue.TypedRateLimitingInterface[reconcile.Request]
+	namespacedName types.NamespacedName
+	labelSelector  labels.Selector
+}
+
+func (h *sharedEnqueueHandler) OnAdd(obj interface{}, _ bool) {
+	if h.ctx.Err() != nil || !h.matchesLabels(obj) {
+		return
+	}
+
+	h.queue.Add(reconcile.Request{NamespacedName: h.namespacedName})
+}
+
+func (h *sharedEnqueueHandler) OnUpdate(oldObj, newObj interface{}) {
+	if h.ctx.Err() != nil {
+		return
+	}
+
+	// Check old OR new labels: a pod relabeled OUT of the selector must still trigger
+	// reconciliation so RemoveDeadTargets can clean up chaos pods on the former target.
+	if !h.matchesLabels(oldObj) && !h.matchesLabels(newObj) {
+		return
+	}
+
+	h.queue.Add(reconcile.Request{NamespacedName: h.namespacedName})
+}
+
+func (h *sharedEnqueueHandler) OnDelete(obj interface{}) {
+	if h.ctx.Err() != nil {
+		return
+	}
+
+	// Unwrap tombstone: informers may wrap deleted objects in DeletedFinalStateUnknown
+	// when they were evicted from the delta FIFO before the delete was observed.
+	if d, ok := obj.(k8sclientcache.DeletedFinalStateUnknown); ok {
+		obj = d.Obj
+	}
+
+	if !h.matchesLabels(obj) {
+		return
+	}
+
+	h.queue.Add(reconcile.Request{NamespacedName: h.namespacedName})
+}
+
+func (h *sharedEnqueueHandler) matchesLabels(obj interface{}) bool {
+	if h.labelSelector == nil {
+		return true
+	}
+
+	o, ok := obj.(client.Object)
+	if !ok {
+		return false
+	}
+
+	return h.labelSelector.Matches(labels.Set(o.GetLabels()))
 }

--- a/watchers/watcher.go
+++ b/watchers/watcher.go
@@ -240,7 +240,18 @@ func (w *watcher) IsExpired() bool {
 }
 
 // Start starts the watcher and sets up the cache and event handlers.
-func (w *watcher) Start() error {
+func (w *watcher) Start() (retErr error) {
+	// For shared caches: release the pool reference acquired in NewWatcher if Start
+	// fails at any point. Without this, a failed watcher is never added to the manager
+	// so Clean() is never called, leaving a permanently leaked refCount.
+	if w.config.CachePool != nil {
+		defer func() {
+			if retErr != nil {
+				w.config.CachePool.Release(w.config.Namespace)
+			}
+		}()
+	}
+
 	// For shared caches the cache may already be started (by a previous watcher in the
 	// same namespace). GetInformer on a started cache blocks via WaitForCacheSync until
 	// the informer syncs — which never completes if RBAC or network is broken. Use a

--- a/watchers/watcher.go
+++ b/watchers/watcher.go
@@ -8,6 +8,7 @@ package watchers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/DataDog/chaos-controller/o11y/tags"
 	"go.uber.org/zap"
@@ -22,6 +23,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
+
+// sharedCacheInformerSyncTimeout is the maximum time watcher.Start() will wait for
+// a shared-cache informer to sync. Own-cache watchers use context.Background() because
+// the cache is started only after GetInformer registers the type (no blocking). Shared
+// caches may already be running when a second disruption in the same namespace reuses
+// them; GetInformer on a started cache calls WaitForCacheSync and would block indefinitely
+// on RBAC or network failures without this bound.
+const sharedCacheInformerSyncTimeout = 30 * time.Second
 
 type WatcherEventType string
 
@@ -232,8 +241,19 @@ func (w *watcher) IsExpired() bool {
 
 // Start starts the watcher and sets up the cache and event handlers.
 func (w *watcher) Start() error {
-	// get informer from cache
-	info, err := w.cache.GetInformer(context.Background(), w.config.ObjectType)
+	// For shared caches the cache may already be started (by a previous watcher in the
+	// same namespace). GetInformer on a started cache blocks via WaitForCacheSync until
+	// the informer syncs — which never completes if RBAC or network is broken. Use a
+	// bounded context so watcher creation fails fast with an error instead of hanging.
+	getInformerCtx := context.Background()
+	if w.config.CachePool != nil {
+		var cancel context.CancelFunc
+		getInformerCtx, cancel = context.WithTimeout(context.Background(), sharedCacheInformerSyncTimeout) //nolint:gosec // G118 - cancel called via defer
+
+		defer cancel()
+	}
+
+	info, err := w.cache.GetInformer(getInformerCtx, w.config.ObjectType)
 	if err != nil {
 		return fmt.Errorf("error getting informer from cache: %w", err)
 	}

--- a/watchers/watcher.go
+++ b/watchers/watcher.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/chaos-controller/o11y/tags"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclientcache "k8s.io/client-go/tools/cache"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -55,8 +56,20 @@ type Watcher interface {
 
 // WatcherConfig holds configuration values used to create a new Watcher instance.
 type WatcherConfig struct {
-	// CacheOptions for configuring the cache.
+	// CacheOptions for configuring the cache. Ignored when CachePool is set.
 	CacheOptions k8scontrollercache.Options
+
+	// CachePool, when set, provides a shared namespace cache instead of creating
+	// a dedicated cache for this watcher.
+	CachePool *NamespaceCachePool
+
+	// Namespace is the target namespace used as the pool key when CachePool is set.
+	// Use "" for cluster-scoped (node-level) disruptions.
+	Namespace string
+
+	// LabelSelector, when set, filters reconcile enqueue requests so that only
+	// pod/node events matching the selector trigger a reconcile for this disruption.
+	LabelSelector labels.Selector
 
 	// Handler function that will be called when an event occurs.
 	Handler k8sclientcache.ResourceEventHandler
@@ -67,7 +80,7 @@ type WatcherConfig struct {
 	// Name of the watcher instance.
 	Name string
 
-	// Namespace of the resource to watch.
+	// NamespacedName of the disruption this watcher belongs to.
 	NamespacedName types.NamespacedName
 
 	// ObjectType of the object to watch.
@@ -100,8 +113,12 @@ type watcher struct {
 	// The configuration used to create the watcher
 	config WatcherConfig
 
-	// The context tuple that contains the context and cancellation function used to cancel the watcher
+	// The context tuple that contains the per-watcher context used for lifecycle tracking.
 	ctxTuple CtxTuple
+
+	// cacheCancelFunc cancels the cache goroutine. Only set when this watcher owns its cache.
+	// Nil when using a shared cache from NamespaceCachePool.
+	cacheCancelFunc context.CancelFunc
 }
 
 // NewWatcher is a function that creates a new watcher instance based on the given configuration values.
@@ -110,9 +127,22 @@ func NewWatcher(config WatcherConfig, cacheMock k8scontrollercache.Cache, cacheC
 		config: config,
 	}
 
-	// Used by unit test to allow mocking
-	if cacheMock == nil {
-		// create cache if it hasn't been set yet
+	switch {
+	case cacheMock != nil:
+		// Unit test: use provided mock cache.
+		watcherInstance.cache = cacheMock
+
+	case config.CachePool != nil:
+		// Shared cache: get-or-create from the pool. The pool owns the cache lifecycle.
+		sharedCache, err := config.CachePool.GetOrCreate(config.Namespace, config.ObjectType)
+		if err != nil {
+			return nil, fmt.Errorf("error getting shared cache from pool: %w", err)
+		}
+
+		watcherInstance.cache = sharedCache
+
+	default:
+		// Own cache: create a dedicated cache for this watcher.
 		cache, err := k8scontrollercache.New(
 			controllerruntime.GetConfigOrDie(),
 			config.CacheOptions,
@@ -122,8 +152,6 @@ func NewWatcher(config WatcherConfig, cacheMock k8scontrollercache.Cache, cacheC
 		}
 
 		watcherInstance.cache = cache
-	} else {
-		watcherInstance.cache = cacheMock
 	}
 
 	// Used by unit test to allow mocking
@@ -135,9 +163,16 @@ func NewWatcher(config WatcherConfig, cacheMock k8scontrollercache.Cache, cacheC
 	return &watcherInstance, nil
 }
 
-// Clean is a method that cancels the context of a watcher instance.
+// Clean stops the watcher. For own-cache watchers, it cancels the cache goroutine.
+// For shared-cache watchers, it releases the reference in the pool.
 func (w *watcher) Clean() {
 	w.ctxTuple.CancelFunc()
+
+	if w.cacheCancelFunc != nil {
+		w.cacheCancelFunc()
+	} else if w.config.CachePool != nil {
+		w.config.CachePool.Release(w.config.Namespace)
+	}
 }
 
 // GetContextTuple is a method that returns a CtxTuple instance.
@@ -187,22 +222,36 @@ func (w *watcher) Start() error {
 		return fmt.Errorf("error adding event handler to the informer: %w", err)
 	}
 
-	// create context and cancel function for the watcher
-	cacheCtx, cacheCancelFunc := context.WithCancel(context.Background()) //nolint:gosec // G118 - cancel func is stored in ctxTuple and called on watcher cleanup
-	w.ctxTuple = CtxTuple{cacheCancelFunc, cacheCtx, w.config.NamespacedName}
+	// Per-watcher context used for lifecycle tracking (IsExpired, Clean).
+	// This is separate from the cache context so that cleaning a single watcher
+	// does not stop a shared cache.
+	watcherCtx, watcherCancelFunc := context.WithCancel(context.Background()) //nolint:gosec // G118 - cancel func is stored in ctxTuple and called on watcher cleanup
+	w.ctxTuple = CtxTuple{watcherCancelFunc, watcherCtx, w.config.NamespacedName}
 
-	// start the cache in a goroutine
-	go func() {
-		if err := w.cache.Start(cacheCtx); err != nil {
-			w.config.Log.Errorw("could not start the watcher", tags.ErrorKey, err)
-		}
-	}()
+	if w.config.CachePool == nil {
+		// Own cache: start it in a background goroutine.
+		cacheCtx, cacheCancelFunc := context.WithCancel(context.Background()) //nolint:gosec // G118 - cancel func stored in cacheCancelFunc and called on Clean
+		w.cacheCancelFunc = cacheCancelFunc
 
-	// create a SyncingSource for the controller
-	w.cacheSource = source.Kind(w.cache, w.config.ObjectType, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		return []reconcile.Request{
-			{NamespacedName: w.ctxTuple.NamespacedName},
+		go func() {
+			if err := w.cache.Start(cacheCtx); err != nil {
+				w.config.Log.Errorw("could not start the watcher", tags.ErrorKey, err)
+			}
+		}()
+	}
+	// Shared cache: already started by the pool.
+
+	// Build the SyncingSource. When a LabelSelector is configured, only enqueue
+	// reconcile requests for events whose object labels match — avoiding spurious
+	// reconciles for pods in the same namespace that belong to other disruptions.
+	labelSelector := w.config.LabelSelector
+
+	w.cacheSource = source.Kind(w.cache, w.config.ObjectType, handler.TypedEnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+		if labelSelector != nil && !labelSelector.Matches(labels.Set(obj.GetLabels())) {
+			return nil
 		}
+
+		return []reconcile.Request{{NamespacedName: w.ctxTuple.NamespacedName}}
 	}))
 
 	return nil

--- a/watchers/watcher.go
+++ b/watchers/watcher.go
@@ -270,6 +270,11 @@ func (w *watcher) Start() error {
 	// Shared cache: already started by the pool.
 
 	if w.config.CachePool != nil {
+		// Start the shared cache now that the informer has been registered on it.
+		// Starting before GetInformer could cause GetInformer to block indefinitely
+		// if the informer sync cannot complete (e.g. RBAC issues).
+		w.config.CachePool.StartCache(w.config.Namespace)
+
 		// Shared cache path: bypass source.Kind entirely.
 		//
 		// source.Kind discards the ResourceEventHandlerRegistration it receives from

--- a/watchers/watcher.go
+++ b/watchers/watcher.go
@@ -107,6 +107,13 @@ type watcher struct {
 	// The Kubernetes resource cache that stores watched resources
 	cache k8scontrollercache.Cache
 
+	// informer is stored so that the per-disruption event handler can be removed when the watcher
+	// is cleaned up while the shared namespace cache (pool) is still alive for other disruptions.
+	informer k8scontrollercache.Informer
+
+	// handlerReg is the registration returned by AddEventHandler. Used to remove the handler on cleanup.
+	handlerReg k8sclientcache.ResourceEventHandlerRegistration
+
 	// The source that provides the cache with Kubernetes resource updates
 	cacheSource source.SyncingSource
 
@@ -164,13 +171,20 @@ func NewWatcher(config WatcherConfig, cacheMock k8scontrollercache.Cache, cacheC
 }
 
 // Clean stops the watcher. For own-cache watchers, it cancels the cache goroutine.
-// For shared-cache watchers, it releases the reference in the pool.
+// For shared-cache watchers, it removes the per-disruption event handler from the shared
+// informer (so it stops firing for this disruption) and releases the pool reference.
 func (w *watcher) Clean() {
 	w.ctxTuple.CancelFunc()
 
 	if w.cacheCancelFunc != nil {
 		w.cacheCancelFunc()
 	} else if w.config.CachePool != nil {
+		// Remove the event handler so it stops processing events for this disruption
+		// even if the shared cache remains alive for other disruptions.
+		if w.informer != nil && w.handlerReg != nil {
+			_ = w.informer.RemoveEventHandler(w.handlerReg)
+		}
+
 		w.config.CachePool.Release(w.config.Namespace)
 	}
 }
@@ -216,11 +230,17 @@ func (w *watcher) Start() error {
 		return fmt.Errorf("error getting informer from cache: %w", err)
 	}
 
-	// add event handler to informer
-	_, err = info.AddEventHandler(w.config.Handler)
+	// Store the informer and register the per-disruption event handler.
+	// The registration is kept so it can be removed in Clean() when the watcher
+	// is torn down while the shared namespace cache (pool) stays alive.
+	w.informer = info
+
+	reg, err := info.AddEventHandler(w.config.Handler)
 	if err != nil {
 		return fmt.Errorf("error adding event handler to the informer: %w", err)
 	}
+
+	w.handlerReg = reg
 
 	// Per-watcher context used for lifecycle tracking (IsExpired, Clean).
 	// This is separate from the cache context so that cleaning a single watcher
@@ -241,13 +261,17 @@ func (w *watcher) Start() error {
 	}
 	// Shared cache: already started by the pool.
 
-	// Build the SyncingSource. When a LabelSelector is configured, only enqueue
-	// reconcile requests for events whose object labels match — avoiding spurious
-	// reconciles for pods in the same namespace that belong to other disruptions.
-	labelSelector := w.config.LabelSelector
-
+	// Build the SyncingSource.
+	// No label-selector filter is applied here intentionally:
+	//  - Own caches: the cache is already restricted to matching pods via CacheOptions,
+	//    so only matching pod events arrive — filtering would be a no-op.
+	//  - Shared namespace caches: filtering only the NEW labels would miss update events
+	//    where a pod is relabeled OUT of the selector, preventing RemoveDeadTargets from
+	//    running and leaving chaos pods on targets the user removed from the selector.
+	//    Allowing all namespace events through is correct; the reconciler handles it.
+	// The watcher context check stops enqueuing after the watcher is cleaned up.
 	w.cacheSource = source.Kind(w.cache, w.config.ObjectType, handler.TypedEnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
-		if labelSelector != nil && !labelSelector.Matches(labels.Set(obj.GetLabels())) {
+		if w.ctxTuple.Ctx.Err() != nil {
 			return nil
 		}
 

--- a/watchers/watcher.go
+++ b/watchers/watcher.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-
 type WatcherEventType string
 
 const (

--- a/watchers/watcher.go
+++ b/watchers/watcher.go
@@ -8,7 +8,6 @@ package watchers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/DataDog/chaos-controller/o11y/tags"
 	"go.uber.org/zap"
@@ -24,13 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-// sharedCacheInformerSyncTimeout is the maximum time watcher.Start() will wait for
-// a shared-cache informer to sync. Own-cache watchers use context.Background() because
-// the cache is started only after GetInformer registers the type (no blocking). Shared
-// caches may already be running when a second disruption in the same namespace reuses
-// them; GetInformer on a started cache calls WaitForCacheSync and would block indefinitely
-// on RBAC or network failures without this bound.
-const sharedCacheInformerSyncTimeout = 30 * time.Second
 
 type WatcherEventType string
 
@@ -253,18 +245,18 @@ func (w *watcher) Start() (retErr error) {
 	}
 
 	// For shared caches the cache may already be started (by a previous watcher in the
-	// same namespace). GetInformer on a started cache blocks via WaitForCacheSync until
-	// the informer syncs — which never completes if RBAC or network is broken. Use a
-	// bounded context so watcher creation fails fast with an error instead of hanging.
-	getInformerCtx := context.Background()
+	// same namespace). GetInformer on a started cache blocks via WaitForCacheSync by
+	// default. In large namespaces or on slow API servers initial sync can take longer
+	// than any hard timeout, causing watcher creation to fail and leaving the disruption
+	// without target event watches. Use BlockUntilSynced(false) so GetInformer returns
+	// immediately; the watcher starts receiving events once sync completes in the
+	// background, which is safe because the handler and enqueue logic do not require sync.
+	var getInformerOpts []k8scontrollercache.InformerGetOption
 	if w.config.CachePool != nil {
-		var cancel context.CancelFunc
-		getInformerCtx, cancel = context.WithTimeout(context.Background(), sharedCacheInformerSyncTimeout) //nolint:gosec // G118 - cancel called via defer
-
-		defer cancel()
+		getInformerOpts = append(getInformerOpts, k8scontrollercache.BlockUntilSynced(false))
 	}
 
-	info, err := w.cache.GetInformer(getInformerCtx, w.config.ObjectType)
+	info, err := w.cache.GetInformer(context.Background(), w.config.ObjectType, getInformerOpts...)
 	if err != nil {
 		return fmt.Errorf("error getting informer from cache: %w", err)
 	}

--- a/watchers/watcher.go
+++ b/watchers/watcher.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclientcache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	k8scontrollercache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -270,7 +271,7 @@ func (w *watcher) Start() error {
 	//    running and leaving chaos pods on targets the user removed from the selector.
 	//    Allowing all namespace events through is correct; the reconciler handles it.
 	// The watcher context check stops enqueuing after the watcher is cleaned up.
-	w.cacheSource = source.Kind(w.cache, w.config.ObjectType, handler.TypedEnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+	innerSource := source.Kind(w.cache, w.config.ObjectType, handler.TypedEnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
 		if w.ctxTuple.Ctx.Err() != nil {
 			return nil
 		}
@@ -278,10 +279,49 @@ func (w *watcher) Start() error {
 		return []reconcile.Request{{NamespacedName: w.ctxTuple.NamespacedName}}
 	}))
 
+	if w.config.CachePool != nil {
+		// Shared cache: wrap the source so its internal informer handler is deregistered
+		// when the watcher context is cancelled, preventing stale handlers from accumulating
+		// on the shared informer across disruption create/delete cycles.
+		w.cacheSource = &watcherBoundSource{inner: innerSource, watcherCtx: w.ctxTuple.Ctx}
+	} else {
+		w.cacheSource = innerSource
+	}
+
 	return nil
 }
 
 // GetConfig return the configuration of the Watcher instance
 func (w *watcher) GetConfig() WatcherConfig {
 	return w.config
+}
+
+// watcherBoundSource wraps a SyncingSource and ties its lifecycle to a watcher context.
+// When the watcher context is cancelled (via Clean()), a merged context is cancelled,
+// which causes the inner source to deregister its internal queue handler from the shared
+// informer — preventing stale handlers from accumulating on long-running controllers.
+type watcherBoundSource struct {
+	inner      source.SyncingSource
+	watcherCtx context.Context
+}
+
+func (s *watcherBoundSource) Start(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
+	// Merge the controller's context with the watcher's lifecycle context so the source
+	// stops (and deregisters its informer handler) when either is cancelled.
+	mergedCtx, cancel := context.WithCancel(ctx) //nolint:gosec // G118 - cancel is fired by the goroutine below
+
+	go func() {
+		defer cancel()
+
+		select {
+		case <-s.watcherCtx.Done():
+		case <-ctx.Done():
+		}
+	}()
+
+	return s.inner.Start(mergedCtx, q)
+}
+
+func (s *watcherBoundSource) WaitForSync(ctx context.Context) error {
+	return s.inner.WaitForSync(ctx)
 }


### PR DESCRIPTION
## Goal of the development

At scale, every active `Disruption` was opening two independent Watch connections to the API server — one for chaos pods, one for target pods/nodes. With many disruptions running in parallel, this caused goroutine bloat, memory pressure, and excessive load on the API server. This PR brings that from O(disruptions) down to O(namespaces).

## Development performed

**One shared handler for chaos pods** (`SharedChaosPodHandler`)

Previously each disruption maintained its own private cache watching the chaos namespace for pod events. Since they all watch the same namespace, this was pure duplication. Now a single handler is registered on the manager's existing pod informer and figures out which disruption an event belongs to by reading the pod's labels at event time.

In HA mode, standby replicas were also emitting events and metrics, producing duplicates. The handler is now gated on `mgr.Elected()` so only the leader acts.

**One cache per namespace for target pods** (`NamespaceCachePool`)

Instead of each disruption owning a private cache for its target namespace, disruptions in the same namespace now share one. A ref-counted pool (`namespace_cache_pool.go`) creates the cache on the first disruption and tears it down when the last one is cleaned up.

Because the cache is shared, each disruption's event handler filters events by its own label selector so it only processes pods that are actually its targets.

**Handler deregistration fix** (`sharedCacheEnqueueSource`)

The standard `source.Kind` mechanism discards the handler registration it receives, making it impossible to deregister when a disruption is deleted. Over time this would silently accumulate stale handlers on the shared informer. The new `sharedCacheEnqueueSource` registers directly and stores the token so `Clean()` can remove it properly.

This also fixes a relabel edge case: when a pod is removed from a disruption's selector, the old `source.Kind` path only checked the new labels, so no reconcile was triggered and `RemoveDeadTargets` never ran. The new handler checks old OR new labels.

**Manager pod cache scoped to chaos namespace only**

The manager's pod cache now only watches `ChaosNamespace`. Target pods in user namespaces are read directly from the API server (via `APIReader`) on the reconcile path — they don't need to be cached globally.

**Removed the legacy `kubeInformerFactory`**

A separate `k8s.io/client-go` informer factory was running in parallel with controller-runtime's own cache for no good reason. It's gone.

## View

| | Before | After |
|---|---|---|
| Chaos pod watching | 1 private cache per disruption | 1 shared handler on manager cache |
| Target pod/node watching | 1 private cache per disruption | 1 cache per unique namespace |
| API server Watch connections | 2 × N disruptions | 1 + number of unique namespaces |
| Manager pod cache scope | All namespaces | Chaos namespace only |

## Information for testing

- `make test` covers pool ref-counting, handler deregistration, and leader-gating.
- Local Lima cluster: create several disruptions in the same namespace and confirm Watch connections don't grow linearly (`kubectl get --raw /metrics | grep apiserver_watch`).
- HA setup: verify only the leader replica emits chaos pod failure events — the standby should stay silent.

## TODO

- [ ] Monitor Watch connection count in staging after rollout

## Best practice
- [x] My comments are updated
- [x] My branch is updated.
- [x] My code is clean without command of debuggage