### PR TITLE
[FIX][CHAOS] Fix cgroup version selection for Lima local cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ ifeq (true,$(CI))
 DD_ENV = ci
 endif
 
-LIMA_CGROUPS=v1
+LIMA_CGROUPS?=v1
 ifeq (v2,$(CGROUPS))
 LIMA_CGROUPS=v2
 endif

--- a/scripts/lima_start.sh
+++ b/scripts/lima_start.sh
@@ -3,16 +3,34 @@
 # start the lima instance with the given image and get the kube config
 limactl start --tty=false --name="${LIMA_INSTANCE}" - <"./${LIMA_CONFIG}.yaml"
 
-# for cgroups v1, reconfigure grub and restart the instance
+# detect the current cgroup version running in the instance
+CURRENT_CGROUP_FS=$(limactl shell "${LIMA_INSTANCE}" stat -fc %T /sys/fs/cgroup/)
+if [[ ${CURRENT_CGROUP_FS} == "cgroup2fs" ]]; then
+  CURRENT_CGROUPS="v2"
+else
+  CURRENT_CGROUPS="v1"
+fi
+
+echo "Detected cgroup version: ${CURRENT_CGROUPS}, desired: ${LIMA_CGROUPS}"
+
+# reconfigure grub and restart only if the current version doesn't match the desired one
 # we need to both call the reboot command and do a lima stop/start
 # for the instance to be working (it rebinds things such as ssh to the host)
-if [[ ${LIMA_CGROUPS} == "v1" ]]; then
-  echo "Reconfiguring lima instance with cgroups v1"
-  limactl shell "${LIMA_INSTANCE}" sudo sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=0"/' /etc/default/grub
+if [[ ${CURRENT_CGROUPS} != ${LIMA_CGROUPS} ]]; then
+  if [[ ${LIMA_CGROUPS} == "v1" ]]; then
+    echo "Reconfiguring lima instance with cgroups v1"
+    limactl shell "${LIMA_INSTANCE}" sudo sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 systemd.unified_cgroup_hierarchy=0"/' /etc/default/grub
+  else
+    echo "Reconfiguring lima instance with cgroups v2"
+    limactl shell "${LIMA_INSTANCE}" sudo sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 systemd.unified_cgroup_hierarchy=1"/' /etc/default/grub
+  fi
+
   limactl shell "${LIMA_INSTANCE}" sudo update-grub
   limactl shell "${LIMA_INSTANCE}" sudo reboot
   echo "Waiting for instance to reboot, it might take a while"
   sleep 10
   limactl stop "${LIMA_INSTANCE}"
   limactl start "${LIMA_INSTANCE}"
+else
+  echo "Cgroup version already matches, no reconfiguration needed"
 fi


### PR DESCRIPTION
## Motivation

The Lima local cluster was always starting with cgroups v1 even when `LIMA_CGROUPS=v2` was exported in `.envrc`. The Makefile was using a plain `=` assignment which unconditionally overrides any value from the shell environment. Additionally, `lima_start.sh` only knew how to force v1 and had no way to detect or transition to v2.

## Changes

- **Makefile**: changed `LIMA_CGROUPS=v1` to `LIMA_CGROUPS?=v1` so the environment variable from `.envrc` takes precedence. The `CGROUPS=v2` make argument override still works.
- **scripts/lima_start.sh**: the script now detects the cgroup version currently active in the running instance (`stat -fc %T /sys/fs/cgroup/`) and reconfigures grub only when the detected version differs from the desired one. Supports both v1→v2 and v2→v1 transitions without unnecessary reboots.

## QA Instructions

1. Ensure `.envrc` exports `LIMA_CGROUPS=v2` (already the case)
2. Run `make lima-stop && make lima-start`
3. Verify: `limactl shell <instance> -- stat -fc %T /sys/fs/cgroup/` → should print `cgroup2fs`

## Blast Radius

Local development only. No impact on production or CI (CI uses minikube, not Lima).

## Documentation

- [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
- [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
- [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)